### PR TITLE
ci(ett): build and publish host

### DIFF
--- a/.github/actions/affected/action.yml
+++ b/.github/actions/affected/action.yml
@@ -1,0 +1,59 @@
+# @license
+# MIT License
+#
+# Copyright (c) 2021 ngworkers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# Terms
+
+name: Affected
+description: Check whether an Nx workspace project is affected by changes.
+
+inputs:
+  base-branch:
+    description: The name of the base branch to compare affected projects to.
+    required: false
+    default: main
+  project:
+    description: The name of the project to check.
+    required: true
+outputs:
+  is-affected:
+    description: Whether or not the project is affected by changes.
+    value: ${{ steps.affected.outputs.is-affected }}
+
+runs:
+  using: composite
+  steps:
+    - run: mkdir tmp
+      shell: bash
+    - run: touch ./tmp/IS_AFFECTED
+      shell: bash
+    # we store the result in a temporary file to allow the Node.js process to
+    # fail the calling job
+    - run:
+        node ${{ github.action_path }}/affected.mjs ${{ inputs.project }} ${{ inputs.base-branch }} >>
+        ./tmp/IS_AFFECTED
+      shell: bash
+    # if we inline the Node.js execution here, the calling job will not fail in
+    # case of process errors
+    - run: echo "::set-output name=is-affected::$(cat ./tmp/IS_AFFECTED)"
+      shell: bash
+    - run: rm ./tmp/IS_AFFECTED
+      shell: bash

--- a/.github/actions/affected/action.yml
+++ b/.github/actions/affected/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: The name of the base branch to compare affected projects to.
     required: false
     default: main
+  base-commit:
+    description: The commit on the base branch to compare affected projects to.
+    required: false
+    default: HEAD
   project:
     description: The name of the project to check.
     required: true
@@ -47,9 +51,7 @@ runs:
       shell: bash
     # we store the result in a temporary file to allow the Node.js process to
     # fail the calling job
-    - run:
-        node ${{ github.action_path }}/affected.mjs ${{ inputs.project }} ${{ inputs.base-branch }} >>
-        ./tmp/IS_AFFECTED
+    - run: node ${{ github.action_path }}/affected.mjs ${{ inputs.project }} ${{ inputs.base-branch }} ${{ inputs.base-commit }} >> ./tmp/IS_AFFECTED
       shell: bash
     # if we inline the Node.js execution here, the calling job will not fail in
     # case of process errors

--- a/.github/actions/affected/affected.mjs
+++ b/.github/actions/affected/affected.mjs
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * MIT License
+ *
+ * Copyright (c) 2021 ngworkers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * Terms
+ */
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+function readAffectedApps(baseBranch) {
+  const affected = execSync(
+    `yarn nx affected:apps --plain --base=origin/${baseBranch}`,
+    {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    }
+  );
+
+  return sanitizeAffectedOutput(affected);
+}
+
+function readAffectedLibs(baseBranch) {
+  const affected = execSync(
+    `yarn nx affected:libs --plain --base=origin/${baseBranch}`,
+    {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    }
+  );
+
+  return sanitizeAffectedOutput(affected);
+}
+
+function readAffectedProjects(baseBranch) {
+  const affectedApps = readAffectedApps(baseBranch);
+  const affectedLibs = readAffectedLibs(baseBranch);
+
+  return affectedApps.concat(affectedLibs);
+}
+
+function sanitizeAffectedOutput(affectedOutput) {
+  return affectedOutput
+    .trim()
+    .split(' ')
+    .filter((project) => project !== '');
+}
+
+function validateProjectParameter(projectName) {
+  if (!projectName) {
+    console.error('No project argument passed.');
+
+    process.exit(1);
+  }
+
+  const workspacePath = path.resolve(__dirname, '../../../angular.json');
+  const workspace = JSON.parse(readFileSync(workspacePath).toString());
+  const isProjectFound = workspace.projects[projectName] !== undefined;
+
+  if (!isProjectFound) {
+    console.error(
+      `"${projectName}" is not the name of a project in this workspace.`
+    );
+
+    process.exit(1);
+  }
+}
+
+// Not available in an ES Module as of Node.js 12.x
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const project = process.argv[2];
+const baseBranch = process.argv[3];
+
+validateProjectParameter(project);
+
+const affectedProjects = readAffectedProjects(baseBranch);
+const isAffected = affectedProjects.includes(project);
+
+console.log(isAffected);

--- a/.github/actions/affected/affected.mjs
+++ b/.github/actions/affected/affected.mjs
@@ -28,9 +28,9 @@ import { readFileSync } from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
-function readAffectedApps(baseBranch) {
+function readAffectedApps(baseBranch, baseCommit) {
   const affected = execSync(
-    `yarn nx affected:apps --plain --base=origin/${baseBranch}`,
+    `yarn nx affected:apps --plain --base=origin/${baseBranch} --head=${baseCommit}`,
     {
       encoding: 'utf-8',
       stdio: 'pipe',
@@ -40,9 +40,9 @@ function readAffectedApps(baseBranch) {
   return sanitizeAffectedOutput(affected);
 }
 
-function readAffectedLibs(baseBranch) {
+function readAffectedLibs(baseBranch, baseCommit) {
   const affected = execSync(
-    `yarn nx affected:libs --plain --base=origin/${baseBranch}`,
+    `yarn nx affected:libs --plain --base=origin/${baseBranch} --head=${baseCommit}`,
     {
       encoding: 'utf-8',
       stdio: 'pipe',
@@ -52,9 +52,9 @@ function readAffectedLibs(baseBranch) {
   return sanitizeAffectedOutput(affected);
 }
 
-function readAffectedProjects(baseBranch) {
-  const affectedApps = readAffectedApps(baseBranch);
-  const affectedLibs = readAffectedLibs(baseBranch);
+function readAffectedProjects(baseBranch, baseCommit) {
+  const affectedApps = readAffectedApps(baseBranch, baseCommit);
+  const affectedLibs = readAffectedLibs(baseBranch, baseCommit);
 
   return affectedApps.concat(affectedLibs);
 }
@@ -88,12 +88,11 @@ function validateProjectParameter(projectName) {
 
 // Not available in an ES Module as of Node.js 12.x
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const project = process.argv[2];
-const baseBranch = process.argv[3];
+const [, , project, baseBranch, baseCommit] = process.argv;
 
 validateProjectParameter(project);
 
-const affectedProjects = readAffectedProjects(baseBranch);
+const affectedProjects = readAffectedProjects(baseBranch, baseCommit);
 const isAffected = affectedProjects.includes(project);
 
 console.log(isAffected);

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      host-image-path: ./infrastructure/ett/host/Dockerfile
+      host-image-tag: ${{ github.ref == 'refs/heads/main' && 'latest' || github.sha }}
 
     steps:
       - uses: actions/checkout@v2
@@ -136,25 +136,16 @@ jobs:
         with:
           string: ghcr.io/${{ github.repository }}-${{ env.app-name }}
 
-      - name: Debug image tag
-        run: echo ${{ env.is-main-branch == 'true' && 'latest' || github.sha }}
-      - name: Debug negated image tag
-        run: echo ${{ env.is-main-branch == 'true' && github.sha || 'latest' }}
-
-      - name: 'PR: Build host container image'
-        if: ${{ env.is-pull-request == 'true' }}
-        run: docker build ./ --file ${{ env.host-image-path }} --tag ${{ steps.image-name.outputs.lowercase }}:${{ github.sha }}
-      - name: 'Merge: Build host container image'
-        if: ${{ env.is-main-branch == 'true' }}
-        run: docker build ./ --file ${{ env.host-image-path }} --tag ${{ steps.image-name.outputs.lowercase }}:latest
+      - name: Build host container image
+        run: docker build ./ --file ./infrastructure/ett/host/Dockerfile --tag ${{ steps.image-name.outputs.lowercase }}:${{ env.host-image-tag }}
 
       - name: 'PR: Upload container image artifact'
         if: ${{ env.is-pull-request == 'true' }}
         uses: ishworkh/docker-image-artifact-upload@v1
         with:
-          image: ${{ steps.image-name.outputs.lowercase }}:${{ github.sha }}
+          image: ${{ steps.image-name.outputs.lowercase }}:${{ env.host-image-tag }}
       - name: 'Merge: Publish container image'
         # if: ${{ env.is-main-branch == 'true' }}
         run: |
           docker login ghcr.io --username ${{ github.actor }} --password ${{ github.token }}
-          docker push ${{ steps.image-name.outputs.lowercase }}:latest
+          docker push ${{ steps.image-name.outputs.lowercase }}:${{ env.host-image-tag }}

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -2,9 +2,10 @@ name: Energy Track and Trace
 
 env:
   app-name: ett-app
+  base-branch: ${{ github.event.pull_request.base.ref }}
   is-main-branch: ${{ github.ref == 'refs/heads/main' }}
   is-pull-request: ${{ github.event_name  == 'pull_request' }}
-  NODE_OPTIONS: --max_old_space_size=6144
+  NODE_OPTIONS: --max-old-space-size=6144
   node-version: 14.x
   NX_MAX_PARALLEL: 2
 
@@ -20,8 +21,71 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  affected:
+    name: Is affected?
+    runs-on: ubuntu-latest
+
+    outputs:
+      is-affected: ${{ steps.affected.outputs.is-affected }}
+
+    steps:
+      # needed for nx affected command
+      - name: 'PR: Check out source code with current branch Git history'
+        if: ${{ env.is-pull-request == 'true' }}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      # needed for nx affected command
+      - name: 'PR: Fetch base branch Git history'
+        if: ${{ env.is-pull-request == 'true' }}
+        run: git fetch --no-tags --depth=1 origin $BASE_BRANCH
+      - name: 'Merge: Check out source code with previous commit history'
+        if: ${{ env.is-pull-request == 'false' }}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Use Node.js ${{ env.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node-version }}
+
+      - name: Variable-Yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache Yarn cache directory
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ env.node-version }}-yarn-${{
+            hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.node-version }}
+            ${{ runner.os }}
+      - name: Install package dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: 'PR: Is affected?'
+        id: affected
+        if: ${{ env.is-pull-request }}
+        uses: ./.github/actions/affected
+        with:
+          base-branch: ${{ env.base-branch }}
+          base-commit: HEAD
+          project: ${{ env.app-name }}
+      - name: 'Merge: Is affected?'
+        id: affected
+        if: ${{ env.is-main-branch }}
+        uses: ./.github/actions/affected
+        with:
+          base-branch: ${{ env.base-branch }}
+          base-commit: HEAD~1
+          project: ${{ env.app-name }}
+
   app:
     name: Build app
+    if: ${{ needs.affected.outputs.is-affected }}  == 'true'
+    needs: affected
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -1,0 +1,99 @@
+name: Energy Track and Trace
+
+env:
+  app-name: ett-app
+  is-main-branch: ${{ github.ref == 'refs/heads/main' }}
+  is-pull-request: ${{ github.event_name  == 'pull_request' }}
+  NODE_OPTIONS: --max_old_space_size=6144
+  node-version: 14.x
+  NX_BRANCH: ${{ github.event.number }}
+  NX_MAX_PARALLEL: 2
+  NX_RUN_GROUP: ${{ github.run_id }}
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+  workflow_dispatch: {}
+
+jobs:
+  app:
+    name: Build app
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Node.js ${{ env.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node-version }}
+
+      - name: Variable-Yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache Yarn cache directory
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ env.node-version }}-yarn-${{
+            hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.node-version }}
+            ${{ runner.os }}
+      - name: Install package dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: Angular Compatibility Compiler
+        run: yarn ngcc
+
+      - name: Production build
+        run: yarn build ${{ env.app-name }} --max-parallel=$NX_MAX_PARALLEL
+
+      - name: Upload web app build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.app-name }}
+          path: ./dist/apps/${{ env.app-name }}/
+          if-no-files-found: error
+
+  container:
+    name: Container image
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.app-name }}
+          path: ./dist/apps/${{ env.app-name }}/
+
+      - name: Container image name
+        id: image-name
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ghcr.io/${{ github.repository }}-${{ env.app-name }}
+
+      - name: 'PR: Build container image'
+        if: ${{ env.is-pull-request == 'true' }}
+        run:
+          docker build ./ --file ./infrastructure/ett/host/Dockerfile --tag ${{
+          steps.image-name.outputs.lowercase }}:${{ github.sha }}
+      - name: 'Merge: Build container image'
+        if: ${{ env.is-main-branch == 'true' }}
+        run:
+          docker build ./ --file ./infrastructure/ett/host/Dockerfile --tag ${{
+          steps.image-name.outputs.lowercase }}:latest
+
+      - name: 'PR: Upload container image artifact'
+        if: ${{ env.is-pull-request == 'true' }}
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: ${{ steps.image-name.outputs.lowercase }}:${{ github.sha }}
+      - name: 'Merge: Publish container image'
+        if: ${{ env.is-main-branch == 'true' }}
+        run: |
+          docker login ghcr.io --username ${{ github.actor }} --password ${{ github.token }}
+          docker push ${{ steps.image-name.outputs.lowercase }}:latest

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -51,7 +51,7 @@ jobs:
         run: yarn ngcc --use-program-dependencies --tsconfig apps/${{ env.app-name }}/tsconfig.app.json
 
       - name: Production build
-        run: nx build ${{ env.app-name }} --max-parallel=$NX_MAX_PARALLEL
+        run: yarn nx build ${{ env.app-name }} --max-parallel=$NX_MAX_PARALLEL
 
       - name: Upload web app build artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -51,7 +51,7 @@ jobs:
         run: yarn ngcc --use-program-dependencies --tsconfig apps/${{ env.app-name }}/tsconfig.app.json
 
       - name: Production build
-        run: yarn build ${{ env.app-name }} --max-parallel=$NX_MAX_PARALLEL
+        run: nx build ${{ env.app-name }} --max-parallel=$NX_MAX_PARALLEL
 
       - name: Upload web app build artifact
         uses: actions/upload-artifact@v2
@@ -61,7 +61,7 @@ jobs:
           if-no-files-found: error
 
   container:
-    name: Host container image
+    name: Host container
     needs: app
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -62,7 +62,7 @@ jobs:
 
   container:
     name: Host container image
-    needs: build
+    needs: app
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -29,21 +29,14 @@ jobs:
       is-affected: ${{ steps.affected.outputs.is-affected }}
 
     steps:
-      # needed for nx affected command
-      - name: 'PR: Check out source code with current branch Git history'
-        if: ${{ env.is-pull-request == 'true' }}
+      - name: Check out source code with current branch Git history
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ env.is-main-branch == 'true' && 1 || 0 }}
       # needed for nx affected command
       - name: 'PR: Fetch base branch Git history'
         if: ${{ env.is-pull-request == 'true' }}
         run: git fetch --no-tags --depth=1 origin $BASE_BRANCH
-      - name: 'Merge: Check out source code with previous commit history'
-        if: ${{ env.is-pull-request == 'false' }}
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
 
       - name: Use Node.js ${{ env.node-version }}
         uses: actions/setup-node@v2
@@ -121,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      host-image-tag: ${{ github.ref == 'refs/heads/main' && 'latest' || github.sha }}
+      host-image-tag: ${{ github.ref == 'refs/heads/main' && 'latest' || format('pr-${0}', github.event.pull_request.number) }}
 
     steps:
       - uses: actions/checkout@v2
@@ -139,35 +132,7 @@ jobs:
       - name: Build host container image
         run: docker build ./ --file ./infrastructure/ett/host/Dockerfile --tag ${{ steps.image-name.outputs.lowercase }}:${{ env.host-image-tag }}
 
-      - name: 'PR: Upload host container image artifact'
-        if: ${{ env.is-pull-request == 'true' }}
-        uses: ishworkh/docker-image-artifact-upload@v1
-        with:
-          image: ${{ steps.image-name.outputs.lowercase }}:${{ env.host-image-tag }}
-      - name: 'Merge: Publish host container image'
-        if: ${{ env.is-main-branch == 'true' }}
+      - name: Publish host container image
         run: |
           docker login ghcr.io --username ${{ github.actor }} --password ${{ github.token }}
           docker push ${{ steps.image-name.outputs.lowercase }}:${{ env.host-image-tag }}
-
-  debug:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Debug ref
-        run: echo ${{ github.ref }}
-        # -> refs/pull/35/merge
-
-      - name: Debug head_ref
-        run: echo ${{ github.head_ref }}
-        # -> ci/publish-ett-app
-
-      - name: Debug pull_request
-        env:
-          PULL_REQUEST: ${{ toJSON(github.event.pull_request) }}
-        run: echo "$PULL_REQUEST"
-
-      - name: Debug github
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -6,8 +6,10 @@ env:
   is-pull-request: ${{ github.event_name  == 'pull_request' }}
   NODE_OPTIONS: --max_old_space_size=6144
   node-version: 14.x
-  NX_BRANCH: ${{ github.event.number }}
   NX_MAX_PARALLEL: 2
+
+  # Nx Cloud
+  NX_BRANCH: ${{ github.event.number }}
   NX_RUN_GROUP: ${{ github.run_id }}
 
 on:

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -48,7 +48,7 @@ jobs:
         run: yarn install --frozen-lockfile --non-interactive
 
       - name: Angular Compatibility Compiler
-        run: yarn ngcc
+        run: yarn ngcc --use-program-dependencies --tsconfig apps/${{ env.app-name }}/tsconfig.app.json
 
       - name: Production build
         run: yarn build ${{ env.app-name }} --max-parallel=$NX_MAX_PARALLEL
@@ -61,9 +61,12 @@ jobs:
           if-no-files-found: error
 
   container:
-    name: Container image
+    name: Host container image
     needs: build
     runs-on: ubuntu-latest
+
+    env:
+      host-image-path: ./infrastructure/ett/host/Dockerfile
 
     steps:
       - uses: actions/checkout@v2
@@ -78,16 +81,12 @@ jobs:
         with:
           string: ghcr.io/${{ github.repository }}-${{ env.app-name }}
 
-      - name: 'PR: Build container image'
+      - name: 'PR: Build host container image'
         if: ${{ env.is-pull-request == 'true' }}
-        run:
-          docker build ./ --file ./infrastructure/ett/host/Dockerfile --tag ${{
-          steps.image-name.outputs.lowercase }}:${{ github.sha }}
-      - name: 'Merge: Build container image'
+        run: docker build ./ --file ${{ env.host-image-path }} --tag ${{ steps.image-name.outputs.lowercase }}:${{ github.sha }}
+      - name: 'Merge: Build host container image'
         if: ${{ env.is-main-branch == 'true' }}
-        run:
-          docker build ./ --file ./infrastructure/ett/host/Dockerfile --tag ${{
-          steps.image-name.outputs.lowercase }}:latest
+        run: docker build ./ --file ${{ env.host-image-path }} --tag ${{ steps.image-name.outputs.lowercase }}:latest
 
       - name: 'PR: Upload container image artifact'
         if: ${{ env.is-pull-request == 'true' }}

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -139,13 +139,35 @@ jobs:
       - name: Build host container image
         run: docker build ./ --file ./infrastructure/ett/host/Dockerfile --tag ${{ steps.image-name.outputs.lowercase }}:${{ env.host-image-tag }}
 
-      - name: 'PR: Upload container image artifact'
+      - name: 'PR: Upload host container image artifact'
         if: ${{ env.is-pull-request == 'true' }}
         uses: ishworkh/docker-image-artifact-upload@v1
         with:
           image: ${{ steps.image-name.outputs.lowercase }}:${{ env.host-image-tag }}
-      - name: 'Merge: Publish container image'
-        # if: ${{ env.is-main-branch == 'true' }}
+      - name: 'Merge: Publish host container image'
+        if: ${{ env.is-main-branch == 'true' }}
         run: |
           docker login ghcr.io --username ${{ github.actor }} --password ${{ github.token }}
           docker push ${{ steps.image-name.outputs.lowercase }}:${{ env.host-image-tag }}
+
+  debug:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Debug ref
+        run: echo ${{ github.ref }}
+        # -> refs/pull/35/merge
+
+      - name: Debug head_ref
+        run: echo ${{ github.head_ref }}
+        # -> ci/publish-ett-app
+
+      - name: Debug pull_request
+        env:
+          PULL_REQUEST: ${{ toJSON(github.event.pull_request) }}
+        run: echo "$PULL_REQUEST"
+
+      - name: Debug github
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -136,6 +136,11 @@ jobs:
         with:
           string: ghcr.io/${{ github.repository }}-${{ env.app-name }}
 
+      - name: Debug image tag
+        run: echo ${{ env.is-main-branch == 'true' && 'latest' || github.sha }}
+      - name: Debug negated image tag
+        run: echo ${{ env.is-main-branch == 'true' && github.sha || 'latest' }}
+
       - name: 'PR: Build host container image'
         if: ${{ env.is-pull-request == 'true' }}
         run: docker build ./ --file ${{ env.host-image-path }} --tag ${{ steps.image-name.outputs.lowercase }}:${{ github.sha }}
@@ -149,7 +154,7 @@ jobs:
         with:
           image: ${{ steps.image-name.outputs.lowercase }}:${{ github.sha }}
       - name: 'Merge: Publish container image'
-        if: ${{ env.is-main-branch == 'true' }}
+        # if: ${{ env.is-main-branch == 'true' }}
         run: |
           docker login ghcr.io --username ${{ github.actor }} --password ${{ github.token }}
           docker push ${{ steps.image-name.outputs.lowercase }}:latest

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -65,21 +65,12 @@ jobs:
       - name: Install package dependencies
         run: yarn install --frozen-lockfile --non-interactive
 
-      - name: 'PR: Is affected?'
+      - name: Is affected?
         id: affected
-        if: ${{ env.is-pull-request }}
         uses: ./.github/actions/affected
         with:
           base-branch: ${{ env.base-branch }}
-          base-commit: HEAD
-          project: ${{ env.app-name }}
-      - name: 'Merge: Is affected?'
-        id: affected
-        if: ${{ env.is-main-branch }}
-        uses: ./.github/actions/affected
-        with:
-          base-branch: ${{ env.base-branch }}
-          base-commit: HEAD~1
+          base-commit: ${{ env.is-pull-request && 'HEAD' || 'HEAD~1' }}
           project: ${{ env.app-name }}
 
   app:

--- a/apps/ui-watt-e2e/src/integration/app.spec.ts
+++ b/apps/ui-watt-e2e/src/integration/app.spec.ts
@@ -1,7 +1,0 @@
-describe('Watt app', () => {
-  beforeEach(() => cy.visit('/'));
-
-  it('verifies that true is true', () => {
-    expect(true).to.be.true;
-  });
-});

--- a/apps/ui-watt-e2e/src/integration/app.spec.ts
+++ b/apps/ui-watt-e2e/src/integration/app.spec.ts
@@ -1,0 +1,7 @@
+describe('Watt app', () => {
+  beforeEach(() => cy.visit('/'));
+
+  it('verifies that true is true', () => {
+    expect(true).to.be.true;
+  });
+});

--- a/infrastructure/ett/host/Dockerfile
+++ b/infrastructure/ett/host/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:stable-alpine
+COPY ./dist/apps/ett-app/ /usr/share/nginx/html/
+COPY ./infrastructure/ett/host/nginx.conf /etc/nginx/conf.d/default.conf
+# HTTP and HTTPS (managed by API gateway)
+EXPOSE 80

--- a/infrastructure/ett/host/nginx.conf
+++ b/infrastructure/ett/host/nginx.conf
@@ -1,0 +1,41 @@
+# HTTP and HTTPS (managed by API gateway)
+server {
+  listen 80 default_server; # IPv4
+
+  server_name _; # serve all hostnames
+  server_tokens off; # disable header "Server nginx"
+
+  # gzip compression
+  gzip on;
+  gzip_comp_level 6;
+  gzip_min_length 1100;
+  gzip_buffers 16 8k;
+  gzip_proxied any;
+  gzip_types
+    application/javascript
+    application/json
+    application/rss+xml
+    application/x-javascript
+    application/xml
+    image/svg+xml
+    text/css
+    text/javascript
+    text/js
+    text/plain
+    text/xml;
+
+  # directory to serve
+  root /usr/share/nginx/html;
+
+  # Single-Page Application
+  location / {
+    add_header Cache-Control "no-store"; # disable cache
+    try_files $uri $uri/ /index.html =404; # redirect to index.html; 404 if index.html doesn't exist
+  }
+
+  # files
+	location ~ \.(?!html) {
+		add_header Cache-Control "public, max-age=2678400"; # cache for one month
+		try_files $uri =404; # 404 if file doesn't exist
+	}
+}


### PR DESCRIPTION
## Description
Energy Track and Trace app workflow:
- Build the app when the app is affected by a PR or merge
- Build, tag, and publish the host container image to GitHub Container Registry when the app is affected by a PR or merge
- Host container image is tagged as `pr-<pull-request-number>` or `latest` for PRs and merge runs, respectively

Energy Track and Trace host:
 - Nginx server with port 80 exposed
 - Gzip compression
 - SPA routing

Affected action:
- Licensed by ngworkers
- Determines whether a project is affected by changes in a pull request or merge commit

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/energy-track-and-trace/issues/45
