### PR TITLE
ci(ett): fix affected `base-commit` on merge

### DIFF
--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -63,7 +63,7 @@ jobs:
         uses: ./.github/actions/affected
         with:
           base-branch: ${{ env.base-branch }}
-          base-commit: ${{ env.is-pull-request && 'HEAD' || 'HEAD~1' }}
+          base-commit: ${{ env.is-main-branch == 'true' && 'HEAD~1' || 'HEAD' }}
           project: ${{ env.app-name }}
 
   app:


### PR DESCRIPTION
## Description
The `base-branch` parameter is currently set to `undefined` on merge commits. This is an attemtp to fix that by setting it to `HEAD~1`.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/energy-track-and-trace/issues/45
