### PR TITLE
ci(ett): fix affected `base-branch` parameter for merge commits and PR host container image tag

### DIFF
--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -62,7 +62,7 @@ jobs:
         id: affected
         uses: ./.github/actions/affected
         with:
-          base-branch: ${{ env.base-branch }}
+          base-branch: ${{ env.is-main-branch == 'true' && 'main' || env.base-branch }}
           base-commit: ${{ env.is-main-branch == 'true' && 'HEAD~1' || 'HEAD' }}
           project: ${{ env.app-name }}
 

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      host-image-tag: ${{ github.ref == 'refs/heads/main' && 'latest' || format('pr-${0}', github.event.pull_request.number) }}
+      host-image-tag: ${{ github.ref == 'refs/heads/main' && 'latest' || format('pr-{0}', github.event.pull_request.number) }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
- The `base-branch` parameter is currently set to `undefined` on merge runs. The parameter is now correctly set.
- The host container image tag is incorrect for PR runs.

## References

- https://github.com/Energinet-DataHub/energy-track-and-trace/issues/45
