### PR TITLE
ci(ett): fix affected job on merge runs

### DIFF
--- a/.github/actions/affected/action.yml
+++ b/.github/actions/affected/action.yml
@@ -26,14 +26,9 @@ name: Affected
 description: Check whether an Nx workspace project is affected by changes.
 
 inputs:
-  base-branch:
-    description: The name of the base branch to compare affected projects to.
-    required: false
-    default: main
-  base-commit:
-    description: The commit on the base branch to compare affected projects to.
-    required: false
-    default: HEAD
+  base:
+    description: The commit or branch to compare affected projects to.
+    required: true
   project:
     description: The name of the project to check.
     required: true
@@ -51,7 +46,7 @@ runs:
       shell: bash
     # we store the result in a temporary file to allow the Node.js process to
     # fail the calling job
-    - run: node ${{ github.action_path }}/affected.mjs ${{ inputs.project }} ${{ inputs.base-branch }} ${{ inputs.base-commit }} >> ./tmp/IS_AFFECTED
+    - run: node ${{ github.action_path }}/affected.mjs ${{ inputs.project }} ${{ inputs.base }} >> ./tmp/IS_AFFECTED
       shell: bash
     # if we inline the Node.js execution here, the calling job will not fail in
     # case of process errors

--- a/.github/actions/affected/affected.mjs
+++ b/.github/actions/affected/affected.mjs
@@ -28,9 +28,9 @@ import { readFileSync } from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
-function readAffectedApps(baseBranch, baseCommit) {
+function readAffectedApps(base) {
   const affected = execSync(
-    `yarn nx affected:apps --plain --base=origin/${baseBranch} --head=${baseCommit}`,
+    `yarn nx affected:apps --plain --base=origin/${base}`,
     {
       encoding: 'utf-8',
       stdio: 'pipe',
@@ -40,9 +40,9 @@ function readAffectedApps(baseBranch, baseCommit) {
   return sanitizeAffectedOutput(affected);
 }
 
-function readAffectedLibs(baseBranch, baseCommit) {
+function readAffectedLibs(base) {
   const affected = execSync(
-    `yarn nx affected:libs --plain --base=origin/${baseBranch} --head=${baseCommit}`,
+    `yarn nx affected:libs --plain --base=origin/${base}`,
     {
       encoding: 'utf-8',
       stdio: 'pipe',
@@ -52,9 +52,9 @@ function readAffectedLibs(baseBranch, baseCommit) {
   return sanitizeAffectedOutput(affected);
 }
 
-function readAffectedProjects(baseBranch, baseCommit) {
-  const affectedApps = readAffectedApps(baseBranch, baseCommit);
-  const affectedLibs = readAffectedLibs(baseBranch, baseCommit);
+function readAffectedProjects(base) {
+  const affectedApps = readAffectedApps(base);
+  const affectedLibs = readAffectedLibs(base);
 
   return affectedApps.concat(affectedLibs);
 }
@@ -88,11 +88,11 @@ function validateProjectParameter(projectName) {
 
 // Not available in an ES Module as of Node.js 12.x
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const [, , project, baseBranch, baseCommit] = process.argv;
+const [, , project, base] = process.argv;
 
 validateProjectParameter(project);
 
-const affectedProjects = readAffectedProjects(baseBranch, baseCommit);
+const affectedProjects = readAffectedProjects(base);
 const isAffected = affectedProjects.includes(project);
 
 console.log(isAffected);

--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -62,8 +62,7 @@ jobs:
         id: affected
         uses: ./.github/actions/affected
         with:
-          base-branch: ${{ env.is-main-branch == 'true' && 'main' || env.base-branch }}
-          base-commit: ${{ env.is-main-branch == 'true' && 'HEAD~1' || 'HEAD' }}
+          base: ${{ env.is-main-branch == 'true' && 'HEAD~1' || env.base-branch }}
           project: ${{ env.app-name }}
 
   app:


### PR DESCRIPTION
## Description
Replace `base-branch` and `base-commit` with single required `base` parameter to fix the affected job on merge runs.

## References

- https://github.com/Energinet-DataHub/energy-track-and-trace/issues/45
