### PR TITLE
feat(ett): rename `return_url` query string parameter for Auth API

### DIFF
--- a/libs/ett/auth/data-access/src/lib/oidc/auth-oidc-http.service.spec.ts
+++ b/libs/ett/auth/data-access/src/lib/oidc/auth-oidc-http.service.spec.ts
@@ -51,6 +51,6 @@ describe(AuthOidcHttp.name, () => {
     );
     response.flush(fakeResponse);
 
-    expect(response.request.params.get('redirect_uri')).toBe(expectedReturnUrl);
+    expect(response.request.params.get('return_url')).toBe(expectedReturnUrl);
   });
 });

--- a/libs/ett/auth/data-access/src/lib/oidc/auth-oidc-http.service.ts
+++ b/libs/ett/auth/data-access/src/lib/oidc/auth-oidc-http.service.ts
@@ -29,12 +29,12 @@ export interface AuthOidcLoginResponse {
 export class AuthOidcHttp {
   constructor(private http: HttpClient) {}
 
-  login(redirectUri: string): Observable<AuthOidcLoginResponse> {
+  login(returnUrl: string): Observable<AuthOidcLoginResponse> {
     return this.http.get<AuthOidcLoginResponse>(
       `${environment.apiBase}/oidc/login`,
       {
         params: {
-          redirect_uri: redirectUri,
+          return_url: returnUrl,
         },
       }
     );

--- a/libs/ett/auth/feature-login/src/lib/ett-authentication-link.directive.spec.ts
+++ b/libs/ett/auth/feature-login/src/lib/ett-authentication-link.directive.spec.ts
@@ -52,7 +52,7 @@ describe(EttAuthenticationDirective.name, () => {
             MockProvider(AuthOidcHttp, {
               login: (redirectUri) =>
                 of({
-                  url: `${authenticationUrl}?redirect_uri=${redirectUri}`,
+                  url: `${authenticationUrl}?return_url=${redirectUri}`,
                 }),
             }),
           ],
@@ -75,7 +75,7 @@ describe(EttAuthenticationDirective.name, () => {
       const baseHref = TestBed.inject(APP_BASE_HREF);
       const actualUrl = new URL(link.href);
 
-      expect(actualUrl.searchParams.get('redirect_uri')).toBe(
+      expect(actualUrl.searchParams.get('return_url')).toBe(
         `${baseHref}dashboard`
       );
     });


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### Auth
- Rename `redirect_uri` query string parameter for Auth API to `return_url`

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/energy-track-and-trace/issues/83

### Dependencies
Wait for Auth API OK from @j4k0bk.