### PR TITLE
Add metering point controller

### DIFF
--- a/libs/api-dh-app/documents/development.md
+++ b/libs/api-dh-app/documents/development.md
@@ -21,7 +21,9 @@ This workflow verifies the ASP.NET Core Web API by building and running all test
 
 ## Setup local environment
 
-> Describe necessary setup here.
+Add appsettings.Development.json with valid settings:
+
+ApiClientSettings > MeteringPointBaseUrl
 
 ## .nxignore / .prettierignore
 

--- a/libs/api-dh-app/documents/development.md
+++ b/libs/api-dh-app/documents/development.md
@@ -19,7 +19,7 @@ It can also:
 
 This workflow verifies the ASP.NET Core Web API by building and running all tests.
 
-## Setup local envioment
+## Setup local environment
 
 > Describe necessary setup here.
 

--- a/libs/api-dh-app/source/DataHub.WebApi.Tests/Integration/Controllers/MeteringPointControllerTests.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi.Tests/Integration/Controllers/MeteringPointControllerTests.cs
@@ -50,7 +50,7 @@ namespace Energinet.DataHub.WebApi.Tests.Integration.Controllers
         private HttpClient HttpClient { get; }
 
         [Fact]
-        public async Task When_Requested_Then_StatusCodeIsOK()
+        public async Task When_MeteringPoint_Requested_And_Found_Then_StatusCode_IsOK()
         {
             // Arrange
             const string gsrn = "574591757409421563";
@@ -69,7 +69,7 @@ namespace Energinet.DataHub.WebApi.Tests.Integration.Controllers
         }
 
         [Fact]
-        public async Task When_Requested_Then_StatusCodeIsNotFound()
+        public async Task When_MeteringPoint_Requested_And_Not_Found_Then_StatusCode_IsNotFound()
         {
             // Arrange
             const string gsrn = "non-existing-gsrn-number";

--- a/libs/api-dh-app/source/DataHub.WebApi.Tests/Integration/Controllers/MeteringPointControllerTests.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi.Tests/Integration/Controllers/MeteringPointControllerTests.cs
@@ -59,7 +59,7 @@ namespace Energinet.DataHub.WebApi.Tests.Integration.Controllers
             var meteringPointDto = Fixture.Create<MeteringPointDto>();
 
             ApiClientMock
-                .Setup(mock => mock.GetMeteringPointByGsrnAsync(gsrn, CancellationToken.None))
+                .Setup(mock => mock.GetMeteringPointByGsrnAsync(gsrn))
                 .ReturnsAsync(meteringPointDto);
 
             // Act
@@ -77,7 +77,7 @@ namespace Energinet.DataHub.WebApi.Tests.Integration.Controllers
             var requestUrl = $"/v1/meteringpoint/getbygsrn?gsrnNumber={gsrn}";
 
             ApiClientMock
-                .Setup(mock => mock.GetMeteringPointByGsrnAsync(gsrn, CancellationToken.None))
+                .Setup(mock => mock.GetMeteringPointByGsrnAsync(gsrn))
                 .Returns(Task.FromResult<MeteringPointDto?>(null));
 
             // Act

--- a/libs/api-dh-app/source/DataHub.WebApi.Tests/Integration/Controllers/MeteringPointControllerTests.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi.Tests/Integration/Controllers/MeteringPointControllerTests.cs
@@ -14,6 +14,7 @@
 
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture;
 using Energinet.DataHub.MeteringPoints.Client.Abstractions;
@@ -58,7 +59,7 @@ namespace Energinet.DataHub.WebApi.Tests.Integration.Controllers
             var meteringPointDto = Fixture.Create<MeteringPointDto>();
 
             ApiClientMock
-                .Setup(mock => mock.GetMeteringPointByGsrnAsync(gsrn))
+                .Setup(mock => mock.GetMeteringPointByGsrnAsync(gsrn, CancellationToken.None))
                 .ReturnsAsync(meteringPointDto);
 
             // Act
@@ -76,7 +77,7 @@ namespace Energinet.DataHub.WebApi.Tests.Integration.Controllers
             var requestUrl = $"/v1/meteringpoint/getbygsrn?gsrnNumber={gsrn}";
 
             ApiClientMock
-                .Setup(mock => mock.GetMeteringPointByGsrnAsync(gsrn))
+                .Setup(mock => mock.GetMeteringPointByGsrnAsync(gsrn, CancellationToken.None))
                 .Returns(Task.FromResult<MeteringPointDto?>(null));
 
             // Act

--- a/libs/api-dh-app/source/DataHub.WebApi.Tests/Integration/Controllers/MeteringPointControllerTests.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi.Tests/Integration/Controllers/MeteringPointControllerTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2021 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Threading.Tasks;
+using Energinet.DataHub.WebApi.Tests.Fixtures;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Energinet.DataHub.WebApi.Tests.Integration.Controllers
+{
+    public class MeteringPointControllerTests : WebHostTestBase
+    {
+        public MeteringPointControllerTests(WebApplicationFactory<Startup> factory)
+            : base(factory)
+        {
+        }
+
+        [Fact]
+        public async Task When_Requested_Then_StatusCodeIsOK()
+        {
+            // Arrange
+            string gsrn = "574591757409421563";
+            var requestUrl = $"/v1/MeteringPoint/GetByGsrn?gsrnNumber={gsrn}";
+
+            // Act
+            var actual = await HttpClient.GetAsync(requestUrl);
+
+            // Assert
+            actual.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task When_Requested_Then_StatusCodeIsNotFound()
+        {
+            // Arrange
+            string gsrn = "non-existing-gsrn-number";
+            var requestUrl = $"/v1/meteringpoint/getbygsrn?gsrnNumber={gsrn}";
+
+            // Act
+            var actual = await HttpClient.GetAsync(requestUrl);
+
+            // Assert
+            actual.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+    }
+}

--- a/libs/api-dh-app/source/DataHub.WebApi/ApiClientSettings.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/ApiClientSettings.cs
@@ -12,18 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-
 namespace Energinet.DataHub.WebApi
 {
-    public class BaseUrls
+    public class ApiClientSettings
     {
-        public string? MeteringPoint { get; set; }
-
-        public Uri GetMeteringPointUrl()
-        {
-            if (MeteringPoint == null) throw new ArgumentNullException(nameof(MeteringPoint));
-            return new Uri(MeteringPoint);
-        }
+        public string? MeteringPointBaseUrl { get; set; }
     }
 }

--- a/libs/api-dh-app/source/DataHub.WebApi/ApiClientSettings.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/ApiClientSettings.cs
@@ -16,6 +16,6 @@ namespace Energinet.DataHub.WebApi
 {
     public class ApiClientSettings
     {
-        public string? MeteringPointBaseUrl { get; set; }
+        public string MeteringPointBaseUrl { get; set; } = string.Empty;
     }
 }

--- a/libs/api-dh-app/source/DataHub.WebApi/BaseUrls.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/BaseUrls.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Energinet DataHub A/S
+﻿// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Net.Http;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Xunit;
+using System;
 
-namespace Energinet.DataHub.WebApi.Tests.Fixtures
+namespace Energinet.DataHub.WebApi
 {
-    public abstract class WebHostTestBase : IClassFixture<WebApplicationFactory<Startup>>
+    public class BaseUrls
     {
-        protected WebHostTestBase(WebApplicationFactory<Startup> factory)
-        {
-            HttpClient = factory.CreateClient();
-        }
+        public string? MeteringPoint { get; set; }
 
-        protected HttpClient HttpClient { get; }
+        public Uri GetMeteringPointUrl()
+        {
+            if (MeteringPoint == null) throw new ArgumentNullException(nameof(MeteringPoint));
+            return new Uri(MeteringPoint);
+        }
     }
 }

--- a/libs/api-dh-app/source/DataHub.WebApi/BaseUrls.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/BaseUrls.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+﻿// Copyright 2021 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
@@ -30,12 +30,12 @@ namespace Energinet.DataHub.WebApi.Controllers
         }
 
         /// <summary>
-        /// Get a metering point by GSRN number
+        /// Get a metering point by GSRN number.
         /// </summary>
-        /// <param name="gsrnNumber">Public identifier of a metering point</param>
-        /// <returns>A metering point if found</returns>
-        /// <response code="200">Returns a metering point if found</response>
-        /// <response code="404">Returned if not found</response>
+        /// <param name="gsrnNumber">Public identifier of a metering point.</param>
+        /// <returns>A metering point if found.</returns>
+        /// <response code="200">Returns a metering point if found.</response>
+        /// <response code="404">Returned if not found.</response>
         [HttpGet("GetByGsrn")]
         public async Task<IActionResult> GetByGsrnAsync(string gsrnNumber)
         {

--- a/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
@@ -41,9 +41,7 @@ namespace Energinet.DataHub.WebApi.Controllers
         {
             var result = await _meteringPointClient.GetMeteringPointByGsrnAsync(gsrnNumber);
 
-            if (result == null) return NotFound();
-
-            return Ok(result);
+            return result == null ? NotFound() : Ok(result);
         }
     }
 }

--- a/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
@@ -34,7 +34,7 @@ namespace Energinet.DataHub.WebApi.Controllers
         /// </summary>
         /// <param name="gsrnNumber">Public identifier of a metering point</param>
         /// <returns>A metering point if found</returns>
-        /// <response code="200">Returns a metering point is found</response>
+        /// <response code="200">Returns a metering point if found</response>
         /// <response code="404">Returned if not found</response>
         [HttpGet("GetByGsrn")]
         public async Task<IActionResult> GetAsync(string gsrnNumber)

--- a/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
@@ -37,7 +37,7 @@ namespace Energinet.DataHub.WebApi.Controllers
         /// <response code="200">Returns a metering point if found.</response>
         /// <response code="404">Returned if not found.</response>
         [HttpGet("GetByGsrn")]
-        public async Task<IActionResult> GetByGsrnAsync(string gsrnNumber)
+        public async Task<ActionResult<MeteringPointDto>> GetByGsrnAsync(string gsrnNumber)
         {
             var result = await _meteringPointClient.GetMeteringPointByGsrnAsync(gsrnNumber);
 

--- a/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.MeteringPoints.Client.Abstractions;
 using Energinet.DataHub.MeteringPoints.Client.Abstractions.Models;
@@ -35,14 +34,13 @@ namespace Energinet.DataHub.WebApi.Controllers
         /// Get a metering point by GSRN number.
         /// </summary>
         /// <param name="gsrnNumber">Public identifier of a metering point.</param>
-        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
         /// <returns>A metering point if found.</returns>
         /// <response code="200">Returns a metering point if found.</response>
         /// <response code="404">Returned if not found.</response>
         [HttpGet("GetByGsrn")]
-        public async Task<ActionResult<MeteringPointDto>> GetByGsrnAsync(string gsrnNumber, CancellationToken cancellationToken)
+        public async Task<ActionResult<MeteringPointDto>> GetByGsrnAsync(string gsrnNumber)
         {
-            var result = await _meteringPointClient.GetMeteringPointByGsrnAsync(gsrnNumber, cancellationToken);
+            var result = await _meteringPointClient.GetMeteringPointByGsrnAsync(gsrnNumber);
 
             return result == null ? NotFound() : Ok(result);
         }

--- a/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
@@ -37,7 +37,7 @@ namespace Energinet.DataHub.WebApi.Controllers
         /// <response code="200">Returns a metering point if found</response>
         /// <response code="404">Returned if not found</response>
         [HttpGet("GetByGsrn")]
-        public async Task<IActionResult> GetAsync(string gsrnNumber)
+        public async Task<IActionResult> GetByGsrnAsync(string gsrnNumber)
         {
             var result = await _meteringPointClient.GetMeteringPointByGsrnAsync(gsrnNumber);
 

--- a/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2021 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using Energinet.DataHub.MeteringPoints.Client.Abstractions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Energinet.DataHub.WebApi.Controllers
+{
+    [ApiController]
+    [Route("v1/[controller]")]
+    public class MeteringPointController : ControllerBase
+    {
+        private readonly IMeteringPointClient _meteringPointClient;
+
+        public MeteringPointController(IMeteringPointClient meteringPointClient)
+        {
+            _meteringPointClient = meteringPointClient;
+        }
+
+        /// <summary>
+        /// Get a metering point by GSRN number
+        /// </summary>
+        /// <param name="gsrnNumber">Public identifier of a metering point</param>
+        /// <returns>A metering point if found</returns>
+        /// <response code="200">Returns a metering point is found</response>
+        /// <response code="404">Returned if not found</response>
+        [HttpGet("GetByGsrn")]
+        public async Task<IActionResult> GetAsync(string gsrnNumber)
+        {
+            var result = await _meteringPointClient.GetMeteringPointByGsrnAsync(gsrnNumber);
+
+            if (result == null) return NotFound();
+
+            return Ok(result);
+        }
+    }
+}

--- a/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
@@ -14,6 +14,7 @@
 
 using System.Threading.Tasks;
 using Energinet.DataHub.MeteringPoints.Client.Abstractions;
+using Energinet.DataHub.MeteringPoints.Client.Abstractions.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Energinet.DataHub.WebApi.Controllers

--- a/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Controllers/MeteringPointController.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.MeteringPoints.Client.Abstractions;
 using Energinet.DataHub.MeteringPoints.Client.Abstractions.Models;
@@ -34,13 +35,14 @@ namespace Energinet.DataHub.WebApi.Controllers
         /// Get a metering point by GSRN number.
         /// </summary>
         /// <param name="gsrnNumber">Public identifier of a metering point.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
         /// <returns>A metering point if found.</returns>
         /// <response code="200">Returns a metering point if found.</response>
         /// <response code="404">Returned if not found.</response>
         [HttpGet("GetByGsrn")]
-        public async Task<ActionResult<MeteringPointDto>> GetByGsrnAsync(string gsrnNumber)
+        public async Task<ActionResult<MeteringPointDto>> GetByGsrnAsync(string gsrnNumber, CancellationToken cancellationToken)
         {
-            var result = await _meteringPointClient.GetMeteringPointByGsrnAsync(gsrnNumber);
+            var result = await _meteringPointClient.GetMeteringPointByGsrnAsync(gsrnNumber, cancellationToken);
 
             return result == null ? NotFound() : Ok(result);
         }

--- a/libs/api-dh-app/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/libs/api-dh-app/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -30,8 +30,8 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client" Version="0.0.3" />
-    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client.Abstractions" Version="0.0.3" />
+    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client" Version="0.0.6" />
+    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client.Abstractions" Version="0.0.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/libs/api-dh-app/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/libs/api-dh-app/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -30,8 +30,8 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client" Version="0.0.4" />
-    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client.Abstractions" Version="0.0.4" />
+    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client" Version="0.0.3" />
+    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client.Abstractions" Version="0.0.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/libs/api-dh-app/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/libs/api-dh-app/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -30,6 +30,8 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client" Version="0.0.1" />
+    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client.Abstractions" Version="0.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/libs/api-dh-app/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/libs/api-dh-app/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -30,8 +30,8 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client" Version="0.0.1" />
-    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client.Abstractions" Version="0.0.1" />
+    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client" Version="0.0.3" />
+    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client.Abstractions" Version="0.0.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/libs/api-dh-app/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/libs/api-dh-app/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -30,8 +30,8 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client" Version="0.0.3" />
-    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client.Abstractions" Version="0.0.3" />
+    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client" Version="0.0.4" />
+    <PackageReference Include="Energinet.DataHub.MeteringPoints.Client.Abstractions" Version="0.0.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
@@ -93,7 +93,7 @@ namespace Energinet.DataHub.WebApi
         {
             var apiClientSettings = Configuration.GetSection("ApiClientSettings").Get<ApiClientSettings>();
 
-            services.AddMeteringPointClient(new Uri(apiClientSettings.MeteringPointBaseUrl ?? "https://empty"));
+            services.AddMeteringPointClient(new Uri(apiClientSettings?.MeteringPointBaseUrl ?? throw new ArgumentNullException(nameof(apiClientSettings.MeteringPointBaseUrl))));
         }
     }
 }

--- a/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
@@ -15,6 +15,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using Energinet.DataHub.MeteringPoints.Client.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -31,7 +32,7 @@ namespace Energinet.DataHub.WebApi
             Configuration = configuration;
         }
 
-        public IConfiguration Configuration { get; }
+        private IConfiguration Configuration { get; }
 
         /// <summary>
         /// This method gets called by the runtime. Use this method to add services to the container.
@@ -39,6 +40,8 @@ namespace Energinet.DataHub.WebApi
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers();
+
+            AddDomainClients(services);
 
             // Register the Swagger generator, defining 1 or more Swagger documents.
             services.AddSwaggerGen(config =>
@@ -84,6 +87,13 @@ namespace Energinet.DataHub.WebApi
             {
                 endpoints.MapControllers();
             });
+        }
+
+        private void AddDomainClients(IServiceCollection services)
+        {
+            var baseUrls = Configuration.GetSection("BaseUrls").Get<BaseUrls>();
+
+            services.AddMeteringPointClient(baseUrls.GetMeteringPointUrl());
         }
     }
 }

--- a/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
@@ -91,9 +91,9 @@ namespace Energinet.DataHub.WebApi
 
         private void AddDomainClients(IServiceCollection services)
         {
-            var baseUrls = Configuration.GetSection("BaseUrls").Get<BaseUrls>();
+            var apiClientSettings = Configuration.GetSection("ApiClientSettings").Get<ApiClientSettings>();
 
-            services.AddMeteringPointClient(baseUrls.GetMeteringPointUrl());
+            services.AddMeteringPointClient(new Uri(apiClientSettings.MeteringPointBaseUrl ?? "https://empty"));
         }
     }
 }

--- a/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Energinet.DataHub.WebApi
 {
@@ -46,7 +47,13 @@ namespace Energinet.DataHub.WebApi
             // Register the Swagger generator, defining 1 or more Swagger documents.
             services.AddSwaggerGen(config =>
             {
-                config.SwaggerDoc("v1", new OpenApiInfo { Title = "DataHub BFF", Version = "1.0.0", Description = "Backend-for-frontend for DataHub", });
+                config.SwaggerDoc("v1", new OpenApiInfo
+                {
+                    Title = "DataHub BFF",
+                    Version = "1.0.0",
+                    Description = "Backend-for-frontend for DataHub",
+                });
+
                 config.SupportNonNullableReferenceTypes();
 
                 // Set the comments path for the Swagger JSON and UI.
@@ -69,7 +76,8 @@ namespace Energinet.DataHub.WebApi
                 app.UseSwagger();
 
                 // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.)
-                app.UseSwaggerUI(options => options.SwaggerEndpoint("/swagger/v1/swagger.json", "DataHub.WebApi v1"));
+                app.UseSwaggerUI(options =>
+                    options.SwaggerEndpoint("/swagger/v1/swagger.json", "DataHub.WebApi v1"));
             }
 
             app.UseHttpsRedirection();

--- a/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
@@ -47,6 +47,7 @@ namespace Energinet.DataHub.WebApi
             services.AddSwaggerGen(config =>
             {
                 config.SwaggerDoc("v1", new OpenApiInfo { Title = "DataHub BFF", Version = "1.0.0", Description = "Backend-for-frontend for DataHub", });
+                config.SupportNonNullableReferenceTypes();
 
                 // Set the comments path for the Swagger JSON and UI.
                 var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
@@ -68,8 +69,7 @@ namespace Energinet.DataHub.WebApi
                 app.UseSwagger();
 
                 // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.)
-                app.UseSwaggerUI(options =>
-                    options.SwaggerEndpoint("/swagger/v1/swagger.json", "DataHub.WebApi v1"));
+                app.UseSwaggerUI(options => options.SwaggerEndpoint("/swagger/v1/swagger.json", "DataHub.WebApi v1"));
             }
 
             app.UseHttpsRedirection();

--- a/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
@@ -93,7 +93,10 @@ namespace Energinet.DataHub.WebApi
 
         private static void AddMeteringPointClient(IServiceCollection services, ApiClientSettings? apiClientSettings)
         {
-            Uri meteringPointBaseUrl = Uri.TryCreate(apiClientSettings?.MeteringPointBaseUrl, UriKind.Absolute, out var url) ? url : new Uri("https://empty");
+            Uri meteringPointBaseUrl = Uri.TryCreate(apiClientSettings?.MeteringPointBaseUrl, UriKind.Absolute, out var url)
+                ? url
+                : new Uri("https://empty");
+
             services.AddMeteringPointClient(meteringPointBaseUrl);
         }
     }

--- a/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
@@ -46,12 +46,7 @@ namespace Energinet.DataHub.WebApi
             // Register the Swagger generator, defining 1 or more Swagger documents.
             services.AddSwaggerGen(config =>
             {
-                config.SwaggerDoc("v1", new OpenApiInfo
-                {
-                    Title = "DataHub BFF",
-                    Version = "1.0.0",
-                    Description = "Backend-for-frontend for DataHub",
-                });
+                config.SwaggerDoc("v1", new OpenApiInfo { Title = "DataHub BFF", Version = "1.0.0", Description = "Backend-for-frontend for DataHub", });
 
                 // Set the comments path for the Swagger JSON and UI.
                 var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
@@ -93,7 +88,13 @@ namespace Energinet.DataHub.WebApi
         {
             var apiClientSettings = Configuration.GetSection("ApiClientSettings").Get<ApiClientSettings>();
 
-            services.AddMeteringPointClient(new Uri(apiClientSettings?.MeteringPointBaseUrl ?? "https://empty-url"));
+            AddMeteringPointClient(services, apiClientSettings);
+        }
+
+        private static void AddMeteringPointClient(IServiceCollection services, ApiClientSettings? apiClientSettings)
+        {
+            Uri meteringPointBaseUrl = Uri.TryCreate(apiClientSettings?.MeteringPointBaseUrl, UriKind.Absolute, out var url) ? url : new Uri("https://empty");
+            services.AddMeteringPointClient(meteringPointBaseUrl);
         }
     }
 }

--- a/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
+++ b/libs/api-dh-app/source/DataHub.WebApi/Startup.cs
@@ -93,7 +93,7 @@ namespace Energinet.DataHub.WebApi
         {
             var apiClientSettings = Configuration.GetSection("ApiClientSettings").Get<ApiClientSettings>();
 
-            services.AddMeteringPointClient(new Uri(apiClientSettings?.MeteringPointBaseUrl ?? throw new ArgumentNullException(nameof(apiClientSettings.MeteringPointBaseUrl))));
+            services.AddMeteringPointClient(new Uri(apiClientSettings?.MeteringPointBaseUrl ?? "https://empty-url"));
         }
     }
 }

--- a/libs/api-dh-app/source/DataHub.WebApi/appsettings.json
+++ b/libs/api-dh-app/source/DataHub.WebApi/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "BaseUrls": {
+    "MeteringPoint" : "<Base url for Metering Point API>"
+  }
+}

--- a/libs/api-dh-app/source/DataHub.WebApi/appsettings.json
+++ b/libs/api-dh-app/source/DataHub.WebApi/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "ApiClientSettings": {
-    "MeteringPointBaseUrl" : "https://meteringpointbaseurl"
+    "MeteringPointBaseUrl" : "<Base url for Metering Point API>"
   }
 }

--- a/libs/api-dh-app/source/DataHub.WebApi/appsettings.json
+++ b/libs/api-dh-app/source/DataHub.WebApi/appsettings.json
@@ -7,7 +7,7 @@
     }
   },
   "AllowedHosts": "*",
-  "BaseUrls": {
-    "MeteringPoint" : "<Base url for Metering Point API>"
+  "ApiClientSettings": {
+    "MeteringPointBaseUrl" : "<Base url for Metering Point API>"
   }
 }

--- a/libs/api-dh-app/source/DataHub.WebApi/appsettings.json
+++ b/libs/api-dh-app/source/DataHub.WebApi/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "ApiClientSettings": {
-    "MeteringPointBaseUrl" : "<Base url for Metering Point API>"
+    "MeteringPointBaseUrl" : "https://meteringpointbaseurl"
   }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Metering Point Controller added to BFF. It makes it possible to make a search for a single metering point based on _GSRN number_.

Note that ApiClientSettings:MeteringPointBaseUrl must be applied in appsettings.json (Environment variable?) when IaC for deployment is added.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
