### PR TITLE
feat(watt): add icon button to Design System

### DIFF
--- a/libs/ui-watt/src/lib/components/button/+storybook/storybook-button-overview.component.html
+++ b/libs/ui-watt/src/lib/components/button/+storybook/storybook-button-overview.component.html
@@ -128,4 +128,21 @@ limitations under the License.
       <watt-button type="primary" size="large">Enabled</watt-button>
     </div>
   </div>
+
+  <h2>Icon</h2>
+
+  <p>
+    Icon buttons allow users to take actions and make choices with a single tap.
+  </p>
+
+  <div class="content-grid">
+    <watt-icon-button icon="plus"></watt-icon-button>
+    <span class="force-hover-state">
+      <watt-icon-button icon="plus"></watt-icon-button>
+    </span>
+    <span class="force-focus-state">
+      <watt-icon-button icon="plus"></watt-icon-button>
+    </span>
+    <watt-icon-button icon="plus" [disabled]="true"></watt-icon-button>
+  </div>
 </mat-card>

--- a/libs/ui-watt/src/lib/components/button/+storybook/storybook-button-overview.component.scss
+++ b/libs/ui-watt/src/lib/components/button/+storybook/storybook-button-overview.component.scss
@@ -42,6 +42,10 @@ storybook-button-overview {
     watt-text-button button.watt-button {
       outline: buttonVariables.$watt-button-text-focus-state;
     }
+
+    watt-icon-button button.watt-icon-button {
+      outline: 2px solid var(--watt-color-primary);
+    }
   }
 
   .force-hover-state {
@@ -55,6 +59,10 @@ storybook-button-overview {
 
     watt-text-button button.watt-button {
       color: buttonVariables.$watt-button-text-hover-color;
+    }
+
+    watt-icon-button button.watt-icon-button {
+      color: var(--watt-color-primary-dark);
     }
   }
 }

--- a/libs/ui-watt/src/lib/components/button/+storybook/storybook-button-overview.component.scss
+++ b/libs/ui-watt/src/lib/components/button/+storybook/storybook-button-overview.component.scss
@@ -44,7 +44,7 @@ storybook-button-overview {
     }
 
     watt-icon-button button.watt-icon-button {
-      color: var(--watt-color-primary-dark);
+      outline: 2px solid var(--watt-color-primary);
     }
   }
 
@@ -62,7 +62,7 @@ storybook-button-overview {
     }
 
     watt-icon-button button.watt-icon-button {
-      outline: 2px solid var(--watt-color-primary);
+      color: var(--watt-color-primary-dark);
     }
   }
 }

--- a/libs/ui-watt/src/lib/components/button/+storybook/storybook-button-overview.component.scss
+++ b/libs/ui-watt/src/lib/components/button/+storybook/storybook-button-overview.component.scss
@@ -44,7 +44,7 @@ storybook-button-overview {
     }
 
     watt-icon-button button.watt-icon-button {
-      outline: 2px solid var(--watt-color-primary);
+      color: var(--watt-color-primary-dark);
     }
   }
 
@@ -62,7 +62,7 @@ storybook-button-overview {
     }
 
     watt-icon-button button.watt-icon-button {
-      color: var(--watt-color-primary-dark);
+      outline: 2px solid var(--watt-color-primary);
     }
   }
 }

--- a/libs/ui-watt/src/lib/components/button/icon-button/watt-icon-button.component.html
+++ b/libs/ui-watt/src/lib/components/button/icon-button/watt-icon-button.component.html
@@ -1,0 +1,24 @@
+<!--
+@license
+Copyright 2021 Energinet DataHub A/S
+
+Licensed under the Apache License, Version 2.0 (the "License2");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<button
+  class="watt-icon-button"
+  mat-button
+  color="primary"
+  [disabled]="disabled"
+>
+  <watt-icon [name]="icon"></watt-icon>
+</button>

--- a/libs/ui-watt/src/lib/components/button/icon-button/watt-icon-button.component.scss
+++ b/libs/ui-watt/src/lib/components/button/icon-button/watt-icon-button.component.scss
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2021 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+watt-icon-button {
+  display: inline-block;
+
+  .watt-icon-button {
+    height: 2.75rem;
+    min-width: auto;
+
+    &:focus {
+      outline: 2px solid var(--watt-color-primary);
+
+      .mat-button-focus-overlay {
+        background-color: transparent;
+      }
+    }
+
+    &:hover {
+      color: var(--watt-color-primary-dark);
+
+      .mat-button-focus-overlay {
+        background-color: transparent;
+      }
+    }
+  }
+}

--- a/libs/ui-watt/src/lib/components/button/icon-button/watt-icon-button.component.ts
+++ b/libs/ui-watt/src/lib/components/button/icon-button/watt-icon-button.component.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2021 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  ViewEncapsulation,
+} from '@angular/core';
+
+import { WattIcon } from '../../../foundations/icon';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'wattIconButton',
+  selector: 'watt-icon-button',
+  styleUrls: ['./watt-icon-button.component.scss'],
+  templateUrl: './watt-icon-button.component.html',
+})
+export class WattIconButtonComponent {
+  @Input() icon?: WattIcon;
+
+  @Input() disabled = false;
+}

--- a/libs/ui-watt/src/lib/components/button/icon-button/watt-icon-button.module.ts
+++ b/libs/ui-watt/src/lib/components/button/icon-button/watt-icon-button.module.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2021 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+
+import { WattIconModule } from '../../../foundations/icon';
+import { WattIconButtonComponent } from './watt-icon-button.component';
+
+@NgModule({
+  declarations: [WattIconButtonComponent],
+  exports: [WattIconButtonComponent],
+  imports: [MatButtonModule, WattIconModule],
+})
+export class WattIconButtonModule {}

--- a/libs/ui-watt/src/lib/components/button/watt-button.component.scss
+++ b/libs/ui-watt/src/lib/components/button/watt-button.component.scss
@@ -109,11 +109,3 @@ watt-button {
     }
   }
 }
-
-/**
- * In context of Watt Form Field
- */
-watt-form-field watt-button.watt-button-normal button.watt-button {
-  min-width: auto;
-  padding: 0;
-}

--- a/libs/ui-watt/src/lib/components/button/watt-button.module.ts
+++ b/libs/ui-watt/src/lib/components/button/watt-button.module.ts
@@ -23,10 +23,11 @@ import { WattPrimaryButtonModule } from './primary-button/watt-primary-button.mo
 import { WattSecondaryButtonModule } from './secondary-button/watt-secondary-button.module';
 import { WattTextButtonModule } from './text-button/watt-text-button.module';
 import { WattSpinnerModule } from '../spinner';
+import { WattIconButtonModule } from './icon-button/watt-icon-button.module';
 
 @NgModule({
   declarations: [WattButtonComponent],
-  exports: [WattButtonComponent],
+  exports: [WattButtonComponent, WattIconButtonModule],
   imports: [
     CommonModule,
     WattIconModule,

--- a/libs/ui-watt/src/lib/components/button/watt-button.stories.ts
+++ b/libs/ui-watt/src/lib/components/button/watt-button.stories.ts
@@ -60,23 +60,28 @@ Overview.parameters = {
 };
 
 //👇 We create a “template” of how args map to rendering
-const ButtonTemplate: Story<WattButtonComponent> = (args) => ({
+const ButtonStory: Story<WattButtonComponent> = (args) => ({
   props: args,
   template: `<watt-button>Button</watt-button>`,
 });
 
-export const Button = ButtonTemplate.bind({});
+export const Button = ButtonStory.bind({});
 Button.args = {
   type: 'text',
 };
 
-const IconButtonTemplate: Story<WattIconButtonComponent> = (args) => ({
+const iconButtonTemplate = (args: Partial<WattIconButtonComponent>) =>
+  `<watt-icon-button icon="${args.icon}" [disabled]="${args.disabled}"></watt-icon-button>`;
+
+const IconButton: Story<WattIconButtonComponent> = (args) => ({
   props: args,
-  template: `<watt-icon-button icon="${args.icon}" [disabled]="${args.disabled}"></watt-icon-button>`,
+  template: iconButtonTemplate(args),
 });
 
-export const IconButton = IconButtonTemplate.bind({});
-IconButton.argTypes = {
+export const IconButtonStory = IconButton.bind({});
+
+IconButtonStory.storyName = 'Icon Button';
+IconButtonStory.argTypes = {
   type: {
     control: false,
   },
@@ -87,6 +92,14 @@ IconButton.argTypes = {
     control: false,
   },
 };
-IconButton.args = {
+IconButtonStory.args = {
   icon: 'search',
+  disabled: false,
+};
+IconButtonStory.parameters = {
+  docs: {
+    source: {
+      code: iconButtonTemplate(IconButtonStory.args),
+    },
+  },
 };

--- a/libs/ui-watt/src/lib/components/button/watt-button.stories.ts
+++ b/libs/ui-watt/src/lib/components/button/watt-button.stories.ts
@@ -17,12 +17,14 @@
 import { moduleMetadata, Story, Meta } from '@storybook/angular';
 
 import { StorybookButtonOverviewModule } from './+storybook/storybook-button-overview.module';
+import { WattIconButtonComponent } from './icon-button/watt-icon-button.component';
 import { WattButtonComponent } from './watt-button.component';
 import { WattButtonModule } from './watt-button.module';
 
 export default {
   title: 'Components/Button',
   component: WattButtonComponent,
+  subcomponents: { WattIconButtonComponent },
   decorators: [
     moduleMetadata({
       imports: [WattButtonModule],
@@ -34,7 +36,7 @@ const howToUseGuide = `
 1. Import ${WattButtonModule.name} in a module
 import { ${WattButtonModule.name} } from '@energinet-datahub/watt';
 
-2a. Use <watt-button>Button</watt-button> in the component's HTML template
+2a. Use <watt-button>Button</watt-button>
 
 OR
 
@@ -66,4 +68,25 @@ const ButtonTemplate: Story<WattButtonComponent> = (args) => ({
 export const Button = ButtonTemplate.bind({});
 Button.args = {
   type: 'text',
+};
+
+const IconButtonTemplate: Story<WattIconButtonComponent> = (args) => ({
+  props: args,
+  template: `<watt-icon-button icon="${args.icon}" [disabled]="${args.disabled}"></watt-icon-button>`,
+});
+
+export const IconButton = IconButtonTemplate.bind({});
+IconButton.argTypes = {
+  type: {
+    control: false,
+  },
+  size: {
+    control: false,
+  },
+  loading: {
+    control: false,
+  },
+};
+IconButton.args = {
+  icon: 'search',
 };

--- a/libs/ui-watt/src/lib/components/button/watt-button.stories.ts
+++ b/libs/ui-watt/src/lib/components/button/watt-button.stories.ts
@@ -34,7 +34,11 @@ const howToUseGuide = `
 1. Import ${WattButtonModule.name} in a module
 import { ${WattButtonModule.name} } from '@energinet-datahub/watt';
 
-2. Use <watt-button>Button</watt-button> in the component's HTML template
+2a. Use <watt-button>Button</watt-button> in the component's HTML template
+
+OR
+
+2b. Use <watt-icon-button icon="<icon-name>"></watt-icon-button> in the component's HTML template
 `;
 
 export const Overview = () => ({

--- a/libs/ui-watt/src/lib/components/empty-state/+storybook/storybook-empty-state-overview.component.html
+++ b/libs/ui-watt/src/lib/components/empty-state/+storybook/storybook-empty-state-overview.component.html
@@ -33,7 +33,7 @@ limitations under the License.
       icon="power"
       title="An unexpected error occured"
       message="Try again or contact your system administrator if you keep getting this error."
-      size="Small"
+      size="small"
     >
       <watt-button type="primary" size="normal">Go Back</watt-button>
     </watt-empty-state>
@@ -49,7 +49,7 @@ limitations under the License.
       icon="search"
       title="No results for ‘test’"
       message="Try adjusting your search or filter to find what you are looking for."
-      size="Small"
+      size="small"
     >
     </watt-empty-state>
   </div>
@@ -62,7 +62,7 @@ limitations under the License.
     <watt-empty-state
       title="No results for ‘test’"
       message="Try adjusting your search or filter to find what you are looking for."
-      size="Small"
+      size="small"
     >
     </watt-empty-state>
   </div>

--- a/libs/ui-watt/src/lib/components/input/+storybook/storybook-input-wrapper.component.ts
+++ b/libs/ui-watt/src/lib/components/input/+storybook/storybook-input-wrapper.component.ts
@@ -43,13 +43,14 @@ import { FormControl } from '@angular/forms';
       [placeholder]="placeholder"
       [required]="required"
     />
-    <watt-button
+    <watt-icon-button
       *ngIf="hasSuffix"
       wattSuffix
-      type="text"
       icon="close"
       aria-label="some meaningful description"
-    ></watt-button>
+    >
+    </watt-icon-button>
+
     <watt-error *ngIf="exampleFormControl.hasError('required')">
       This field is required
     </watt-error>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### Design System

- Add separate `<watt-icon-button>` component
- Expose the component from `WattButtonModule`
- Adjust Storybook to use the new component
- Fix property values in Storybook overview page

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/MightyDucks/issues/215

## PLEASE NOTE

Before merging a frontend pull request, be sure that all checks have passed. Currently, jobs done by a Git-bot (like formatting and adding licenses) don't trigger a re-run of all the other checks. The "merge button" can therefore give you a false positive signal.
