### PR TITLE
ci(ett): remove trigger filters

### DIFF
--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -18,15 +18,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - apps/dh/api-dh/**
-      - .github/workflows/api-dh-app-*.yml
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - apps/dh/api-dh/**
-      - .github/workflows/api-dh-app-*.yml
+  pull_request: {}
   workflow_dispatch: {}
 
 jobs:

--- a/libs/ett/core/shell/src/lib/ett-core-shell.module.ts
+++ b/libs/ett/core/shell/src/lib/ett-core-shell.module.ts
@@ -16,11 +16,11 @@
  */
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { ettDashboardRoutePath } from '@energinet-datahub/ett/dashboard/routing';
 import {
   EttAuthenticationGuard,
   ettAuthRoutePath,
 } from '@energinet-datahub/ett/auth/routing-security';
+import { ettDashboardRoutePath } from '@energinet-datahub/ett/dashboard/routing';
 import { GfBrowserConfigurationModule } from '@energinet-datahub/gf/util-browser';
 
 import { EttHttpModule } from './ett-http.module';


### PR DESCRIPTION
## Description

Revert trigger filters that broke the ETT CD workflow when introduced.

## References

*N/A*

## PLEASE NOTE

Before merging a frontend pull request, be sure that all checks have passed. Currently, jobs done by a Git-bot (like formatting and adding licenses) don't trigger a re-run of all the other checks. The "merge button" can therefore give you a false positive signal.
