### PR TITLE
ci(ett): correct Nginx configuration path

### DIFF
--- a/infrastructure/eo/host/Dockerfile
+++ b/infrastructure/eo/host/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:stable-alpine
 COPY ./dist/apps/ett/app-ett/ /usr/share/nginx/html/
-COPY ./infrastructure/ett/host/nginx.conf /etc/nginx/conf.d/default.conf
+COPY ./infrastructure/eo/host/nginx.conf /etc/nginx/conf.d/default.conf
 # HTTP and HTTPS (managed by API gateway)
 EXPOSE 80


### PR DESCRIPTION
## Description
Update host Nginx configuration path after #164 renamed a folder without updating the host Dockerfile.

## References
- #164
- #168
