### PR TITLE
fix(dh): allow "date-fns-tz" as CommonJS dependency

### DIFF
--- a/apps/dh/app-dh/project.json
+++ b/apps/dh/app-dh/project.json
@@ -14,6 +14,7 @@
         "polyfills": "apps/dh/app-dh/src/polyfills.ts",
         "tsConfig": "apps/dh/app-dh/tsconfig.app.json",
         "inlineStyleLanguage": "scss",
+        "allowedCommonJsDependencies": ["date-fns-tz"],
         "assets": [
           {
             "glob": "favicon.ico",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
## DataHub

- Fix warning by allowing "date-fns-tz" as CommonJS dependency

![image](https://user-images.githubusercontent.com/1096332/147910885-603875f8-fdc6-4791-91f9-0a710e0a8da5.png)


## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- N/A
