### PR TITLE
feat(dh): remove "now" text from date range format

### DIFF
--- a/apps/dh/e2e-dh/src/integration/language-selection.spec.ts
+++ b/apps/dh/e2e-dh/src/integration/language-selection.spec.ts
@@ -15,6 +15,10 @@
  * limitations under the License.
  */
 import { DisplayLanguage } from '@energinet-datahub/dh/globalization/domain';
+import {
+  en as enTranslations,
+  da as daTranslations,
+} from '@energinet-datahub/dh/globalization/assets-localization';
 
 import * as appShell from '../support/app-shell.po';
 
@@ -28,14 +32,20 @@ describe('Language selection', () => {
 
   it(`Given no language is selected
     Then Danish translations are displayed`, () => {
-    appShell.getTitle().should('contain', 'Målepunkter');
+    appShell
+      .getTitle()
+      .should('have.text', daTranslations.meteringPoint.search.title);
   });
 
   it(`When English is selected
     Then English translations are displayed`, () => {
     getLanguagePicker(DisplayLanguage.English).click();
 
-    appShell.getTitle().should('contain', 'Metering Points');
+    console.log(appShell.getTitle());
+
+    appShell
+      .getTitle()
+      .should('have.text', enTranslations.meteringPoint.search.title);
   });
 
   it(`Given English is selected
@@ -45,6 +55,8 @@ describe('Language selection', () => {
 
     getLanguagePicker(DisplayLanguage.Danish).click();
 
-    appShell.getTitle().should('contain', 'Målepunkter');
+    appShell
+      .getTitle()
+      .should('have.text', daTranslations.meteringPoint.search.title);
   });
 });

--- a/apps/dh/e2e-dh/src/integration/language-selection.spec.ts
+++ b/apps/dh/e2e-dh/src/integration/language-selection.spec.ts
@@ -41,8 +41,6 @@ describe('Language selection', () => {
     Then English translations are displayed`, () => {
     getLanguagePicker(DisplayLanguage.English).click();
 
-    console.log(appShell.getTitle());
-
     appShell
       .getTitle()
       .should('have.text', enTranslations.meteringPoint.search.title);

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -55,7 +55,6 @@
           "effectivePeriod": "Gyldighedsperiode",
           "status": "Tilslutningsstatus"
         },
-        "now": "nu",
         "noChildMeteringPointsTitle": "Ingen child målepunkter",
         "noChildMeteringPointsText": "Vi fandt ingen child målepunkter til dette målepunkt"
       }

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -218,7 +218,7 @@
     "noActiveMessage": "Vi fandt ingen aktive {{title}} på dette målepunkt",
     "taxIndicator": "Afgift",
     "chargesNotFound": {
-      "title": "Vi fandt desværre ingen priser tilknyttet til dette målepunkt"
+      "title": "Vi fandt desværre ingen priser tilknyttet dette målepunkt"
     },
     "serverError": {
       "title": "Ups! Der opstod en fejl",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -55,7 +55,6 @@
           "effectivePeriod": "Validity period",
           "status": "Connection state"
         },
-        "now": "now",
         "noChildMeteringPointsTitle": "No child metering point(s)",
         "noChildMeteringPointsText": "We did not find any child metering point(s) on this metering point"
       }

--- a/libs/dh/metering-point/feature-overview/src/lib/child-metering-point-tab-content/dh-child-metering-point-tab-content.component.html
+++ b/libs/dh/metering-point/feature-overview/src/lib/child-metering-point-tab-content/dh-child-metering-point-tab-content.component.html
@@ -69,10 +69,7 @@ limitations under the License.
           class="date-icon"
         ></watt-icon>
 
-        <span class="watt-text-s">
-          {{ row.effectiveDate | dhDate }} -
-          {{ 'meteringPoint.overview.childMeteringPointsTab.now' | transloco }}
-        </span>
+        <span class="watt-text-s">{{ row.effectiveDate | dhDate }} - </span>
       </mat-cell>
     </ng-container>
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

### DataHub

- Remove "now" text from date range format

### DataHub E2E

- Fix failing tests

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/geh-metering-point/issues/601
