### PR TITLE
Bump `Energinet.DataHub.Charges.Clients` to 1.0.22

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -35,7 +35,7 @@ limitations under the License.
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Charges.Clients" Version="1.0.21" />
+    <PackageReference Include="Energinet.DataHub.Charges.Clients" Version="1.0.22" />
     <PackageReference Include="Energinet.DataHub.Charges.Clients.Registration" Version="0.1.3" />
     <PackageReference Include="Energinet.DataHub.MeteringPoints.Client" Version="1.0.4" />
     <PackageReference Include="Energinet.DataHub.MeteringPoints.Client.Abstractions" Version="1.0.4" />


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This PR bumps `Energinet.DataHub.Charges.Clients` to 1.0.22 which copes with enum (ChargeType) being passed from Charges Web API as string.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

https://github.com/Energinet-DataHub/geh-charges/issues/827
