### PR TITLE
ci(eo): deploy to Production on merge to main

### DIFF
--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -197,7 +197,7 @@ jobs:
       SERVICE_NAME: eo-frontend
 
       BASE_ENV_REPO: 'Energinet-DataHub/eo-base-environment'
-      BASE_ENV_REPO_BRANCH: 'development'
+      BASE_ENV_REPO_BRANCH: 'main'
       HELM_CHART_PATH: 'yggdrasil/applications/eo/eo-frontend/eo-frontend.yaml'
       JOB_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
@@ -231,5 +231,5 @@ jobs:
 
             - Triggered by [Job][1] in [Repo][2]
 
-            [1]: ${{ env.JOB_URL }} 
+            [1]: ${{ env.JOB_URL }}
             [2]: ${{ github.server_url }}/${{ github.repository }}


### PR DESCRIPTION
## Description

Energy Origin currently only has the Production environment except for on demand feature environments, so we're merging directly to `main`.

## References

- https://github.com/Energinet-DataHub/energy-origin/issues/305
