### PR TITLE
feat(eo): rename app to EnergyOrigin

### DIFF
--- a/.github/workflows/ett.yml
+++ b/.github/workflows/ett.yml
@@ -1,4 +1,4 @@
-name: Energy Track and Trace
+name: EnergyOrigin
 
 env:
   app-name: app-ett

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ Energinet-DataHub/greenforce-frontend
 |  |  ├── api-dh            # - BFF for DataHub
 |  |  ├── app-dh            # - Frontend for DataHub
 |  |  └── e2e-dh            # - E2E tests for DataHub
-|  └── ett                  # Energy Track and Trace (product)
-|     ├── app-ett           # - Frontend for Energy Track and Trace
-|     └── e2e-ett           # - E2E tests for Energy Track and Trace
+|  └── ett                  # EnergyOrigin (product)
+|     ├── app-ett           # - Frontend for EnergyOrigin
+|     └── e2e-ett           # - E2E tests for EnergyOrigin
 ├── build                   # Contains infrastructure for DataHub and the design system
 ├── dist                    # Contains output files when building artifacts (for distribution)
 |  ├── apps                 #
 |  └── libs                 #
 ├── docs                    # Contains general documentation
-├── infrastructure          # Contains infrastructure for Energy Track and Trace
+├── infrastructure          # Contains infrastructure for EnergyOrigin
 ├── libs                    # Contains source code for libraries. See "Folder Structure - library" section for more information
 └── tools                   # Contains various tools
    ├── executors            # - Executors perform actions on your code. This can include building, linting, testing, serving.
@@ -167,7 +167,7 @@ The frontend apps are built with Angular in an Nx Workspace. They are located un
 
 - `dh/app-dh` - "DataHub" app
 - `dh/e2e-dh` - End-to-end tests for `app-dh`
-- `ett/app-ett` - "Energy Track and Trace" app.
+- `ett/app-ett` - "EnergyOrigin" app.
 - `ett/e2e-ett` - End-to-end tests for `app-ett`
 
 Besides the `apps` folder, there's also a `libs` folder that contains features used by the apps. This is where most of the code lives.
@@ -193,7 +193,7 @@ the BFF. This is required for both local development and tests.
 Located under `.github/workflows`. There are:
 
 - `api-dh-ci.yml` - Used by the BFF for `app-dh`.
-- `ett.yml` - Used by "Energy Track and Trace" app
+- `ett.yml` - Used by "EnergyOrigin" app
 - `license-check-ci.yml` - Used for adding license to files
 - `frontend-ci.yml` - Used to build, test, format and lint all frontend apps
 

--- a/apps/ett/app-ett/src/index.html
+++ b/apps/ett/app-ett/src/index.html
@@ -18,7 +18,7 @@ limitations under the License.
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Energy Track and Trace</title>
+    <title>EnergyOrigin</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />

--- a/apps/ett/e2e-ett/src/integration/app.spec.ts
+++ b/apps/ett/e2e-ett/src/integration/app.spec.ts
@@ -16,10 +16,10 @@
  */
 import { getTitle } from '../support/app.po';
 
-describe('Energy Track and Trace app', () => {
+describe('EnergyOrigin app', () => {
   beforeEach(() => cy.visit('/'));
 
   it('displays a title', () => {
-    getTitle().contains('Energy Track and Trace');
+    getTitle().contains('EnergyOrigin');
   });
 });

--- a/libs/ett/auth/data-access-security/README.md
+++ b/libs/ett/auth/data-access-security/README.md
@@ -1,1 +1,1 @@
-# Energy Track and Trace security data access
+# EnergyOrigin security data access

--- a/libs/ett/auth/feature-login/README.md
+++ b/libs/ett/auth/feature-login/README.md
@@ -1,1 +1,1 @@
-# Energy Track and Trace login feature
+# EnergyOrigin login feature

--- a/libs/ett/auth/routing-security/README.md
+++ b/libs/ett/auth/routing-security/README.md
@@ -1,1 +1,1 @@
-# Energy Track and Trace security routing
+# EnergyOrigin security routing

--- a/libs/ett/auth/shell/README.md
+++ b/libs/ett/auth/shell/README.md
@@ -1,1 +1,1 @@
-# Energy Track and Trace auth shell
+# EnergyOrigin auth shell

--- a/libs/ett/auth/shell/src/lib/ett-auth-shell.component.ts
+++ b/libs/ett/auth/shell/src/lib/ett-auth-shell.component.ts
@@ -44,7 +44,7 @@ const selector = 'ett-auth-shell';
   template: `
     <mat-card role="region">
       <mat-card-title>
-        <h1>Energy Track and Trace</h1>
+        <h1>EnergyOrigin</h1>
       </mat-card-title>
       <mat-card-content>
         <p style="color: red">{{ errorMessage }}</p>

--- a/libs/ett/core/shell/README.md
+++ b/libs/ett/core/shell/README.md
@@ -1,1 +1,1 @@
-# Energy Track and Trace shell
+# EnergyOrigin shell

--- a/libs/ett/core/shell/src/lib/ett-shell.component.ts
+++ b/libs/ett/core/shell/src/lib/ett-shell.component.ts
@@ -45,7 +45,7 @@ const selector = 'ett-shell';
       </ng-container>
 
       <ng-container watt-shell-toolbar>
-        <h1>Energy Track and Trace</h1>
+        <h1>EnergyOrigin</h1>
       </ng-container>
 
       <router-outlet></router-outlet>


### PR DESCRIPTION
## Description
Change title of _Energy Track and Trace_ app to _EnergyOrigin_.

## References
- https://github.com/Energinet-DataHub/energy-origin/issues/305
