### PR TITLE
feat(watt): extend icon to support state colors

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -158,7 +158,8 @@ jobs:
             -Dsonar.projectKey=geh-frontend-app
             -Dsonar.organization=energinet-datahub
             -Dsonar.sources=apps/dh/app-dh,libs/dh,libs/ui-watt,libs/gf
-            -Dsonar.coverage.exclusions=libs/ui-watt/**/+storybook/*,libs/ui-watt/**/*.stories.ts
+            -Dsonar.exclusions=**/*.spec.ts
+            -Dsonar.coverage.exclusions=libs/ui-watt/**/+storybook/*,libs/ui-watt/**/*.stories.ts,
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/libs/dh/metering-point/feature-identity-and-master-data/src/lib/primary-master-data/dh-metering-point-primary-master-data.component.html
+++ b/libs/dh/metering-point/feature-identity-and-master-data/src/lib/primary-master-data/dh-metering-point-primary-master-data.component.html
@@ -37,9 +37,9 @@ limitations under the License.
           aria-hidden
         >
           <watt-icon
-            [ngClass]="isActualAddressIcon"
             [name]="isActualAddressIcon"
             [label]="isActualAddressIcon"
+            [state]="isActualAddressIconState"
             [size]="iconSizes.XSmall"
           ></watt-icon>
         </dt>

--- a/libs/dh/metering-point/feature-identity-and-master-data/src/lib/primary-master-data/dh-metering-point-primary-master-data.component.scss
+++ b/libs/dh/metering-point/feature-identity-and-master-data/src/lib/primary-master-data/dh-metering-point-primary-master-data.component.scss
@@ -26,14 +26,6 @@
     display: inline-block;
     color: var(--watt-color-primary-dark);
     margin-right: var(--watt-space-l);
-
-    &.success {
-      color: var(--watt-color-state-success);
-    }
-
-    &.warning {
-      color: var(--watt-color-state-warning);
-    }
   }
 }
 

--- a/libs/dh/metering-point/feature-identity-and-master-data/src/lib/primary-master-data/dh-metering-point-primary-master-data.component.ts
+++ b/libs/dh/metering-point/feature-identity-and-master-data/src/lib/primary-master-data/dh-metering-point-primary-master-data.component.ts
@@ -33,6 +33,7 @@ import {
   WattIcon,
   WattIconModule,
   WattIconSize,
+  WattIconState,
 } from '@energinet-datahub/watt';
 import {
   DhEmDashFallbackPipeScam,
@@ -69,6 +70,7 @@ export class DhMeteringPointPrimaryMasterDataComponent implements OnChanges {
   address?: string;
   iconSizes = WattIconSize;
   isActualAddressIcon: WattIcon = 'success';
+  isActualAddressIconState?: WattIconState;
   actualAddressTranslationKey = 'actualAddress';
 
   get electricitySupplierSinceTranslationKey(): string | undefined {
@@ -92,9 +94,11 @@ export class DhMeteringPointPrimaryMasterDataComponent implements OnChanges {
       this.address = this.formatAddress(currentValue);
       if (currentValue.isActualAddress) {
         this.isActualAddressIcon = 'success';
+        this.isActualAddressIconState = WattIconState.Success;
         this.actualAddressTranslationKey = 'actualAddress';
       } else {
         this.isActualAddressIcon = 'warning';
+        this.isActualAddressIconState = WattIconState.Warning;
         this.actualAddressTranslationKey = 'notActualAddress';
       }
     }

--- a/libs/ui-watt/src/lib/foundations/icon/+storybook/storybook-icon-overview.component.html
+++ b/libs/ui-watt/src/lib/foundations/icon/+storybook/storybook-icon-overview.component.html
@@ -88,3 +88,27 @@ limitations under the License.
     <figcaption>XXLarge (128px)</figcaption>
   </figure>
 </section>
+
+<h2>States</h2>
+<section class="states">
+  <figure>
+    <watt-icon name="success"></watt-icon>
+    <figcaption>Default</figcaption>
+  </figure>
+  <figure>
+    <watt-icon name="success" [state]="iconState.Success"></watt-icon>
+    <figcaption>Success</figcaption>
+  </figure>
+  <figure>
+    <watt-icon name="success" [state]="iconState.Danger"></watt-icon>
+    <figcaption>Danger</figcaption>
+  </figure>
+  <figure>
+    <watt-icon name="success" [state]="iconState.Warning"></watt-icon>
+    <figcaption>Warning</figcaption>
+  </figure>
+  <figure>
+    <watt-icon name="success" [state]="iconState.Info"></watt-icon>
+    <figcaption>Info</figcaption>
+  </figure>
+</section>

--- a/libs/ui-watt/src/lib/foundations/icon/+storybook/storybook-icon-overview.component.scss
+++ b/libs/ui-watt/src/lib/foundations/icon/+storybook/storybook-icon-overview.component.scss
@@ -50,7 +50,8 @@ watt-icon {
   margin-right: 10px;
 }
 
-.sizes {
+.sizes,
+.states {
   display: flex;
   flex-wrap: wrap;
   align-items: end;

--- a/libs/ui-watt/src/lib/foundations/icon/+storybook/storybook-icon-overview.component.ts
+++ b/libs/ui-watt/src/lib/foundations/icon/+storybook/storybook-icon-overview.component.ts
@@ -18,6 +18,7 @@ import { Component } from '@angular/core';
 
 import { WattIcon } from '../icons';
 import { WattIconSize } from '../watt-icon-size';
+import { WattIconState } from '../watt-icon-state';
 
 interface Icon {
   name: string;
@@ -40,6 +41,10 @@ export class StorybookIconOverviewComponent {
    * @ignore
    */
   iconSize = WattIconSize;
+  /**
+   * @ignore
+   */
+  iconState = WattIconState;
 
   /**
    * @ignore

--- a/libs/ui-watt/src/lib/foundations/icon/icon.component.scss
+++ b/libs/ui-watt/src/lib/foundations/icon/icon.component.scss
@@ -35,19 +35,19 @@ watt-icon {
     }
   }
 
-  &.icon-state-success {
+  &.icon-state-success .mat-icon {
     color: var(--watt-color-state-success);
   }
 
-  &.icon-state-danger {
+  &.icon-state-danger .mat-icon {
     color: var(--watt-color-state-danger);
   }
 
-  &.icon-state-warning {
+  &.icon-state-warning .mat-icon {
     color: var(--watt-color-state-warning);
   }
 
-  &.icon-state-info {
+  &.icon-state-info .mat-icon {
     color: var(--watt-color-state-info);
   }
 }

--- a/libs/ui-watt/src/lib/foundations/icon/icon.component.scss
+++ b/libs/ui-watt/src/lib/foundations/icon/icon.component.scss
@@ -34,4 +34,20 @@ watt-icon {
       @include icon-size($size);
     }
   }
+
+  &.icon-state-success {
+    color: var(--watt-color-state-success);
+  }
+
+  &.icon-state-danger {
+    color: var(--watt-color-state-danger);
+  }
+
+  &.icon-state-warning {
+    color: var(--watt-color-state-warning);
+  }
+
+  &.icon-state-info {
+    color: var(--watt-color-state-info);
+  }
 }

--- a/libs/ui-watt/src/lib/foundations/icon/icon.component.spec.ts
+++ b/libs/ui-watt/src/lib/foundations/icon/icon.component.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render } from '@testing-library/angular';
+
+import {
+  WattIconComponent,
+  WattIconModule,
+  WattIconSize,
+  WattIconState,
+} from './index';
+
+describe(WattIconComponent.name, () => {
+  it('has default size', async () => {
+    const view = await render(WattIconComponent, {
+      componentProperties: {
+        name: 'success',
+      },
+      imports: [WattIconModule],
+    });
+
+    const component = view.fixture.componentInstance;
+
+    expect(component.size).toBe(WattIconSize.Medium);
+  });
+
+  describe('host classes', () => {
+    it('has default `size` class', async () => {
+      const view = await render(WattIconComponent, {
+        componentProperties: {
+          name: 'success',
+        },
+        imports: [WattIconModule],
+      });
+
+      const actualClasses = Object.keys(view.fixture.debugElement.classes);
+
+      expect(actualClasses).toContain('icon-size-m');
+    });
+
+    it('can set `size` class', async () => {
+      const view = await render(WattIconComponent, {
+        componentProperties: {
+          name: 'success',
+          size: WattIconSize.Large,
+        },
+        imports: [WattIconModule],
+      });
+
+      const actualClasses = Object.keys(view.fixture.debugElement.classes);
+
+      expect(actualClasses).toContain('icon-size-l');
+    });
+
+    it('can set `state` class', async () => {
+      const view = await render(WattIconComponent, {
+        componentProperties: {
+          name: 'success',
+          state: WattIconState.Success,
+        },
+        imports: [WattIconModule],
+      });
+
+      const actualClasses = Object.keys(view.fixture.debugElement.classes);
+
+      expect(actualClasses).toContain('icon-state-success');
+    });
+  });
+});

--- a/libs/ui-watt/src/lib/foundations/icon/icon.component.ts
+++ b/libs/ui-watt/src/lib/foundations/icon/icon.component.ts
@@ -27,6 +27,7 @@ import {
 import { WattIconService } from './icon.service';
 import { WattIcon } from './icons';
 import { WattIconSize } from './watt-icon-size';
+import { WattIconState } from './watt-icon-state';
 
 @Component({
   selector: 'watt-icon',
@@ -43,9 +44,16 @@ export class WattIconComponent implements OnChanges {
    */
   @Input() label: string | null = null;
   @Input() size: WattIconSize = WattIconSize.Medium;
+  @Input() state?: WattIconState;
 
-  @HostBinding('class') get currentSize(): string[] {
-    return [`icon-size-${this.size}`];
+  @HostBinding('class') get _cssClass(): string[] {
+    const classesToAdd = [`icon-size-${this.size}`];
+
+    if (this.state) {
+      classesToAdd.push(`icon-state-${this.state}`);
+    }
+
+    return classesToAdd;
   }
 
   /**

--- a/libs/ui-watt/src/lib/foundations/icon/watt-icon-state.ts
+++ b/libs/ui-watt/src/lib/foundations/icon/watt-icon-state.ts
@@ -14,9 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { WattIcon } from './icons';
-export { WattIconModule } from './icon.module';
-export { WattIconComponent } from './icon.component';
-export { WattIconSize } from './watt-icon-size';
-export { WattIconState } from './watt-icon-state';
-export { WattIconService } from './icon.service';
+
+export enum WattIconState {
+  Success = 'success',
+  Danger = 'danger',
+  Warning = 'warning',
+  Info = 'info',
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

### Watt Design System
- Extend icon to support state colors
- Update Storybook to showcase examples

![image](https://user-images.githubusercontent.com/1096332/150971516-b584f091-7a68-4ec4-971c-c09d8ce83417.png)

### DataHub
- Refactor component to use state property on icon component

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/greenforce-frontend/issues/295
