### PR TITLE
feat(watt): add default state to special icons

### DIFF
--- a/libs/dh/metering-point/feature-identity-and-master-data/src/lib/primary-master-data/dh-metering-point-primary-master-data.component.html
+++ b/libs/dh/metering-point/feature-identity-and-master-data/src/lib/primary-master-data/dh-metering-point-primary-master-data.component.html
@@ -39,7 +39,6 @@ limitations under the License.
           <watt-icon
             [name]="isActualAddressIcon"
             [label]="isActualAddressIcon"
-            [state]="isActualAddressIconState"
             [size]="iconSizes.XSmall"
           ></watt-icon>
         </dt>

--- a/libs/dh/metering-point/feature-identity-and-master-data/src/lib/primary-master-data/dh-metering-point-primary-master-data.component.ts
+++ b/libs/dh/metering-point/feature-identity-and-master-data/src/lib/primary-master-data/dh-metering-point-primary-master-data.component.ts
@@ -33,7 +33,6 @@ import {
   WattIcon,
   WattIconModule,
   WattIconSize,
-  WattIconState,
 } from '@energinet-datahub/watt';
 import {
   DhEmDashFallbackPipeScam,
@@ -70,7 +69,6 @@ export class DhMeteringPointPrimaryMasterDataComponent implements OnChanges {
   address?: string;
   iconSizes = WattIconSize;
   isActualAddressIcon: WattIcon = 'success';
-  isActualAddressIconState?: WattIconState;
   actualAddressTranslationKey = 'actualAddress';
 
   get electricitySupplierSinceTranslationKey(): string | undefined {
@@ -94,11 +92,9 @@ export class DhMeteringPointPrimaryMasterDataComponent implements OnChanges {
       this.address = this.formatAddress(currentValue);
       if (currentValue.isActualAddress) {
         this.isActualAddressIcon = 'success';
-        this.isActualAddressIconState = WattIconState.Success;
         this.actualAddressTranslationKey = 'actualAddress';
       } else {
         this.isActualAddressIcon = 'warning';
-        this.isActualAddressIconState = WattIconState.Warning;
         this.actualAddressTranslationKey = 'notActualAddress';
       }
     }

--- a/libs/ui-watt/src/lib/foundations/icon/+storybook/storybook-icon-overview.component.html
+++ b/libs/ui-watt/src/lib/foundations/icon/+storybook/storybook-icon-overview.component.html
@@ -92,23 +92,23 @@ limitations under the License.
 <h2>States</h2>
 <section class="states">
   <figure>
-    <watt-icon name="success"></watt-icon>
+    <watt-icon name="search"></watt-icon>
     <figcaption>Default</figcaption>
   </figure>
   <figure>
-    <watt-icon name="success" [state]="iconState.Success"></watt-icon>
+    <watt-icon name="success"></watt-icon>
     <figcaption>Success</figcaption>
   </figure>
   <figure>
-    <watt-icon name="success" [state]="iconState.Danger"></watt-icon>
+    <watt-icon name="danger"></watt-icon>
     <figcaption>Danger</figcaption>
   </figure>
   <figure>
-    <watt-icon name="success" [state]="iconState.Warning"></watt-icon>
+    <watt-icon name="warning"></watt-icon>
     <figcaption>Warning</figcaption>
   </figure>
   <figure>
-    <watt-icon name="success" [state]="iconState.Info"></watt-icon>
+    <watt-icon name="info"></watt-icon>
     <figcaption>Info</figcaption>
   </figure>
 </section>

--- a/libs/ui-watt/src/lib/foundations/icon/icon.component.spec.ts
+++ b/libs/ui-watt/src/lib/foundations/icon/icon.component.spec.ts
@@ -16,6 +16,7 @@
  */
 import { render } from '@testing-library/angular';
 
+import { WattIcon } from './icons';
 import {
   WattIconComponent,
   WattIconModule,
@@ -24,10 +25,10 @@ import {
 } from './index';
 
 describe(WattIconComponent.name, () => {
-  it('has default size', async () => {
+  it('has default `size`', async () => {
     const view = await render(WattIconComponent, {
       componentProperties: {
-        name: 'success',
+        name: 'search',
       },
       imports: [WattIconModule],
     });
@@ -37,46 +38,123 @@ describe(WattIconComponent.name, () => {
     expect(component.size).toBe(WattIconSize.Medium);
   });
 
+  it('has default `state`', async () => {
+    const view = await render(WattIconComponent, {
+      componentProperties: {
+        name: 'search',
+      },
+      imports: [WattIconModule],
+    });
+
+    const component = view.fixture.componentInstance;
+
+    expect(component.state).toBe(WattIconState.Default);
+  });
+
   describe('host classes', () => {
-    it('has default `size` class', async () => {
-      const view = await render(WattIconComponent, {
-        componentProperties: {
-          name: 'success',
-        },
-        imports: [WattIconModule],
+    describe('`size` class', () => {
+      it('has default value', async () => {
+        const view = await render(WattIconComponent, {
+          componentProperties: {
+            name: 'search',
+          },
+          imports: [WattIconModule],
+        });
+
+        const actualClasses = Object.keys(view.fixture.debugElement.classes);
+
+        expect(actualClasses).toContain('icon-size-m');
       });
 
-      const actualClasses = Object.keys(view.fixture.debugElement.classes);
+      it('can be set', async () => {
+        const view = await render(WattIconComponent, {
+          componentProperties: {
+            name: 'search',
+            size: WattIconSize.Large,
+          },
+          imports: [WattIconModule],
+        });
 
-      expect(actualClasses).toContain('icon-size-m');
+        const actualClasses = Object.keys(view.fixture.debugElement.classes);
+
+        expect(actualClasses).toContain('icon-size-l');
+      });
     });
 
-    it('can set `size` class', async () => {
+    describe('`state` class', () => {
+      it('has default value', async () => {
+        const view = await render(WattIconComponent, {
+          componentProperties: {
+            name: 'search',
+          },
+          imports: [WattIconModule],
+        });
+
+        const actualClasses = Object.keys(view.fixture.debugElement.classes);
+
+        expect(actualClasses).toContain('icon-state-default');
+      });
+
+      it('can be set', async () => {
+        const view = await render(WattIconComponent, {
+          componentProperties: {
+            name: 'search',
+            state: WattIconState.Success,
+          },
+          imports: [WattIconModule],
+        });
+
+        const actualClasses = Object.keys(view.fixture.debugElement.classes);
+
+        expect(actualClasses).toContain('icon-state-success');
+      });
+    });
+  });
+
+  describe.each([
+    ['success', WattIconState.Success, 'icon-state-success'],
+    ['danger', WattIconState.Danger, 'icon-state-danger'],
+    ['warning', WattIconState.Warning, 'icon-state-warning'],
+    ['info', WattIconState.Info, 'icon-state-info'],
+  ])('%s icon', (icon, ownDefaultState, ownStateClass) => {
+    it('has own default state', async () => {
       const view = await render(WattIconComponent, {
         componentProperties: {
-          name: 'success',
-          size: WattIconSize.Large,
+          name: icon as WattIcon,
         },
         imports: [WattIconModule],
       });
 
-      const actualClasses = Object.keys(view.fixture.debugElement.classes);
+      const component = view.fixture.componentInstance;
 
-      expect(actualClasses).toContain('icon-size-l');
+      expect(component.state).toBe(ownDefaultState);
     });
 
-    it('can set `state` class', async () => {
+    it('has own default state class', async () => {
       const view = await render(WattIconComponent, {
         componentProperties: {
-          name: 'success',
-          state: WattIconState.Success,
+          name: icon as WattIcon,
         },
         imports: [WattIconModule],
       });
 
       const actualClasses = Object.keys(view.fixture.debugElement.classes);
 
-      expect(actualClasses).toContain('icon-state-success');
+      expect(actualClasses).toContain(ownStateClass);
+    });
+
+    it('cat be set to a different state', async () => {
+      const view = await render(WattIconComponent, {
+        componentProperties: {
+          name: icon as WattIcon,
+          state: WattIconState.Default,
+        },
+        imports: [WattIconModule],
+      });
+
+      const actualClasses = Object.keys(view.fixture.debugElement.classes);
+
+      expect(actualClasses).not.toContain(ownStateClass);
     });
   });
 });

--- a/libs/ui-watt/src/lib/foundations/icon/icon.component.ts
+++ b/libs/ui-watt/src/lib/foundations/icon/icon.component.ts
@@ -19,8 +19,6 @@ import {
   Component,
   HostBinding,
   Input,
-  OnChanges,
-  SimpleChanges,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -36,24 +34,22 @@ import { WattIconState } from './watt-icon-state';
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class WattIconComponent implements OnChanges {
-  @Input() name?: WattIcon;
+export class WattIconComponent {
+  @Input() set name(value: WattIcon | undefined) {
+    this.setIcon(value);
+
+    this.state = this.getDefaultState(value);
+  }
 
   /**
    * @description used for `aria-label`
    */
   @Input() label: string | null = null;
   @Input() size: WattIconSize = WattIconSize.Medium;
-  @Input() state?: WattIconState;
+  @Input() state: WattIconState = WattIconState.Default;
 
   @HostBinding('class') get _cssClass(): string[] {
-    const classesToAdd = [`icon-size-${this.size}`];
-
-    if (this.state) {
-      classesToAdd.push(`icon-state-${this.state}`);
-    }
-
-    return classesToAdd;
+    return [`icon-size-${this.size}`, `icon-state-${this.state}`];
   }
 
   /**
@@ -69,18 +65,10 @@ export class WattIconComponent implements OnChanges {
 
   /**
    * @ignore
-   * @param changes
-   */
-  ngOnChanges(changes: SimpleChanges) {
-    this.setIcon(changes.name?.currentValue);
-  }
-
-  /**
-   * @ignore
    * @param name
    * @returns
    */
-  private setIcon(name: WattIcon) {
+  private setIcon(name?: WattIcon) {
     if (!name) {
       console.warn('No icon was provided!');
       return;
@@ -91,5 +79,25 @@ export class WattIconComponent implements OnChanges {
     this.iconService.isCustomIcon(name)
       ? (this.customIcon = iconName)
       : (this.icon = iconName);
+  }
+
+  /**
+   * @ignore
+   * @param name
+   * @returns
+   */
+  private getDefaultState(name?: WattIcon): WattIconState {
+    switch (name) {
+      case 'success':
+        return WattIconState.Success;
+      case 'danger':
+        return WattIconState.Danger;
+      case 'warning':
+        return WattIconState.Warning;
+      case 'info':
+        return WattIconState.Info;
+      default:
+        return WattIconState.Default;
+    }
   }
 }

--- a/libs/ui-watt/src/lib/foundations/icon/icon.component.ts
+++ b/libs/ui-watt/src/lib/foundations/icon/icon.component.ts
@@ -38,7 +38,7 @@ export class WattIconComponent {
   @Input() set name(value: WattIcon | undefined) {
     this.setIcon(value);
 
-    this.state = this.getDefaultState(value);
+    this.state = this.getDefaultStateForIcon(value);
   }
 
   /**
@@ -86,7 +86,7 @@ export class WattIconComponent {
    * @param name
    * @returns
    */
-  private getDefaultState(name?: WattIcon): WattIconState {
+  private getDefaultStateForIcon(name?: WattIcon): WattIconState {
     switch (name) {
       case 'success':
         return WattIconState.Success;

--- a/libs/ui-watt/src/lib/foundations/icon/watt-icon-state.ts
+++ b/libs/ui-watt/src/lib/foundations/icon/watt-icon-state.ts
@@ -16,6 +16,7 @@
  */
 
 export enum WattIconState {
+  Default = 'default',
   Success = 'success',
   Danger = 'danger',
   Warning = 'warning',


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### Watt Design System
- Set default state to `success`, `danger`, `warning` and `info` icons
- Allow state on `success`, `danger`, `warning` and `info` icons to be overwritten by `state` property
- Update showcase in Storybook

![image](https://user-images.githubusercontent.com/1096332/151348208-b8b2526d-3201-42ec-b1bc-f3bbf7693dcc.png)

### DataHub
- Remove state property on icon in master data component

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/greenforce-frontend/issues/295
