### PR TITLE
chore: correct transform patterns for Jest Angular preset

### DIFF
--- a/apps/dh/app-dh/jest.config.js
+++ b/apps/dh/app-dh/jest.config.js
@@ -27,9 +27,9 @@ module.exports = {
   },
   coverageDirectory: '../../coverage/apps/dh/app-dh',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/apps/ett/app-ett/jest.config.js
+++ b/apps/ett/app-ett/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../coverage/apps/ett/app-ett',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/core/shell/jest.config.js
+++ b/libs/dh/core/shell/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/dh/core/shell',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/globalization/configuration-localization/jest.config.js
+++ b/libs/dh/globalization/configuration-localization/jest.config.js
@@ -27,9 +27,9 @@ module.exports = {
   coverageDirectory:
     '../../../../coverage/libs/dh/globalization/configuration-localization',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/globalization/data-access-localization/jest.config.js
+++ b/libs/dh/globalization/data-access-localization/jest.config.js
@@ -27,9 +27,9 @@ module.exports = {
   coverageDirectory:
     '../../../../coverage/libs/dh/globalization/data-access-localization',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/globalization/domain/jest.config.js
+++ b/libs/dh/globalization/domain/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/dh/globalization/domain',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/globalization/feature-language-picker/jest.config.js
+++ b/libs/dh/globalization/feature-language-picker/jest.config.js
@@ -27,9 +27,9 @@ module.exports = {
   coverageDirectory:
     '../../../../coverage/libs/dh/globalization/feature-language-picker',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/metering-point/data-access-api/jest.config.js
+++ b/libs/dh/metering-point/data-access-api/jest.config.js
@@ -27,9 +27,9 @@ module.exports = {
   coverageDirectory:
     '../../../../coverage/libs/dh/metering-point/data-access-api',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/metering-point/domain/jest.config.js
+++ b/libs/dh/metering-point/domain/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/dh/metering-point/domain',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/metering-point/feature-overview/jest.config.js
+++ b/libs/dh/metering-point/feature-overview/jest.config.js
@@ -27,9 +27,9 @@ module.exports = {
   coverageDirectory:
     '../../../../coverage/libs/dh/metering-point/feature-overview',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/metering-point/feature-search/jest.config.js
+++ b/libs/dh/metering-point/feature-search/jest.config.js
@@ -27,9 +27,9 @@ module.exports = {
   coverageDirectory:
     '../../../../coverage/libs/dh/metering-point/feature-search',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/metering-point/routing/jest.config.js
+++ b/libs/dh/metering-point/routing/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/dh/metering-point/routing',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/metering-point/shell/jest.config.js
+++ b/libs/dh/metering-point/shell/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/dh/metering-point/shell',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/shared/data-access-api/jest.config.js
+++ b/libs/dh/shared/data-access-api/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/dh/shared/data-access-api',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/shared/environments/jest.config.js
+++ b/libs/dh/shared/environments/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/dh/shared/environments',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/shared/test-util-auth/jest.config.js
+++ b/libs/dh/shared/test-util-auth/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/dh/shared/test-util-auth',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/shared/test-util-i18n/jest.config.js
+++ b/libs/dh/shared/test-util-i18n/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/dh/shared/test-util-i18n',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/dh/shared/test-util-metering-point/jest.config.js
+++ b/libs/dh/shared/test-util-metering-point/jest.config.js
@@ -27,9 +27,9 @@ module.exports = {
   coverageDirectory:
     '../../../../coverage/libs/dh/shared/test-util-metering-point',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/eo/shared/environments/jest.config.js
+++ b/libs/eo/shared/environments/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/eo/shared/environments',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/ett/auth/data-access-api/jest.config.js
+++ b/libs/ett/auth/data-access-api/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/ett/auth/data-access-api',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/ett/auth/data-access-security/jest.config.js
+++ b/libs/ett/auth/data-access-security/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/ett/auth/data-access-security',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/ett/auth/feature-login/jest.config.js
+++ b/libs/ett/auth/feature-login/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/ett/auth/feature-login',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/ett/auth/routing-security/jest.config.js
+++ b/libs/ett/auth/routing-security/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/ett/auth/routing-security',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/ett/auth/shell/jest.config.js
+++ b/libs/ett/auth/shell/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/ett/auth/shell',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/ett/core/shell/jest.config.js
+++ b/libs/ett/core/shell/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/ett/core/shell',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/ett/dashboard/routing/jest.config.js
+++ b/libs/ett/dashboard/routing/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/ett/dashboard/routing',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/ett/dashboard/shell/jest.config.js
+++ b/libs/ett/dashboard/shell/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/ett/dashboard/shell',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/ett/shared/util-browser/jest.config.js
+++ b/libs/ett/shared/util-browser/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../../coverage/libs/ett/shared/util-browser',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/gf/test-util-matchers/jest.config.js
+++ b/libs/gf/test-util-matchers/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../coverage/libs/gf/test-util-matchers',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/gf/test-util-staging/jest.config.js
+++ b/libs/gf/test-util-staging/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../coverage/libs/gf/test-util-staging',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/gf/util-browser/jest.config.js
+++ b/libs/gf/util-browser/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../../coverage/libs/gf/util-browser',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/ui-watt/jest.config.js
+++ b/libs/ui-watt/jest.config.js
@@ -26,9 +26,9 @@ module.exports = {
   },
   coverageDirectory: '../../coverage/libs/ui-watt',
   transform: {
-    '^.+.(ts|mjs|js|html)$': 'jest-preset-angular',
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
   },
-  transformIgnorePatterns: ['node_modules/(?!.*.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',


### PR DESCRIPTION
## Description
Correct the transform patterns used with `jest-preset-angular` so that the `.` character is only used to match the dot preceeding a file extension rather than *any* character.

## References
- Maintenance
