### PR TITLE
fix(watt): prevent emitting click events when disabled button is clicked

### DIFF
--- a/libs/ui-watt/src/lib/components/button/watt-button.component.scss
+++ b/libs/ui-watt/src/lib/components/button/watt-button.component.scss
@@ -53,6 +53,12 @@ watt-button {
     }
   }
 
+  &.watt-button-disabled {
+    // NOTE(xdzus)
+    // Prevents emitting a click event in Chrome/Edge/Safari when a disabled button is clicked
+    pointer-events: none;
+  }
+
   .content-grid {
     align-items: center;
     display: flex;

--- a/libs/ui-watt/src/lib/components/button/watt-button.component.ts
+++ b/libs/ui-watt/src/lib/components/button/watt-button.component.ts
@@ -57,6 +57,11 @@ export class WattButtonComponent {
     return this.loading;
   }
 
+  @HostBinding('class.watt-button-disabled')
+  get buttonDisabledState() {
+    return this.disabled;
+  }
+
   @Input() icon?: WattIcon;
   @Input() type: WattButtonType = 'button';
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### Watt Design System
- Prevent Chrome/Edge/Safari from firing click events when disabled button is clicked

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #348 
