### PR TITLE
ci(eo): tag Helm chart without `v` prefix

### DIFF
--- a/infrastructure/eo/chart/Chart.yaml
+++ b/infrastructure/eo/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: v0.1.1
+version: 0.1.1
 
 dependencies:
   - name: eo-base-helm-chart

--- a/infrastructure/eo/chart/values.yaml
+++ b/infrastructure/eo/chart/values.yaml
@@ -4,7 +4,7 @@ eo-base-helm-chart:
       replicaCount: 2
       image:
         repository: ghcr.io/energinet-datahub/greenforce-frontend-ett-app
-        tag: 'latest'
+        tag: 0.1.1
         pullPolicy: Always
 
   service:


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### CI
- Tag Helm chart version without `v` prefix to fix semantic version check in  #329 
<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/energy-origin/issues/313
