### PR TITLE
Reverted charge owner title back to "Ejer" for danish translation

### DIFF
--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -240,7 +240,7 @@
       "D02": "Gebyr",
       "D03": "Tarif"
     },
-    "chargeOwner": "Tarif ejer",
+    "chargeOwner": "Ejer",
     "startDate": "Dato",
     "transparentInvoicing": "Viderefakturering",
     "quantity": "Antal",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

In search metering point page the charge owner title has been erroneously changed to "Tarif ejer" for all charge tables. This PR reverts this change back to "Ejer" for the Danish translation.
