### PR TITLE
Fix a typo for origin of energy lib

### DIFF
--- a/infrastructure/eo/chart/Chart.yaml
+++ b/infrastructure/eo/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.2.16
+version: 0.2.17
 
 dependencies:
   - name: eo-base-helm-chart

--- a/infrastructure/eo/chart/values.yaml
+++ b/infrastructure/eo/chart/values.yaml
@@ -4,7 +4,7 @@ eo-base-helm-chart:
       replicaCount: 2
       image:
         repository: ghcr.io/energinet-datahub/eo-frontend-app
-        tag: 0.2.16
+        tag: 0.2.17
   service:
     deployment: app
     type: ClusterIP

--- a/libs/eo/origin-of-energy/routing/project.json
+++ b/libs/eo/origin-of-energy/routing/project.json
@@ -1,6 +1,6 @@
 {
   "projectType": "library",
-  "root": "libs/eo/origin-of-energy/routinx",
+  "root": "libs/eo/origin-of-energy/routing",
   "sourceRoot": "libs/eo/origin-of-energy/routing/src",
   "prefix": "eo",
   "targets": {


### PR DESCRIPTION
## Description

There was a typo in the routing for origin of energy from when the lib was generated. For some reason the linter didn't catch this until it was merged to main, so this bugfix will fix it

## References

https://github.com/Energinet-DataHub/energy-origin-issues/issues/431
