### PR TITLE
feat(watt): improvements to time-range component

### DIFF
--- a/infrastructure/eo/chart/Chart.yaml
+++ b/infrastructure/eo/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.2.19
+version: 0.2.20
 
 dependencies:
   - name: eo-base-helm-chart

--- a/infrastructure/eo/chart/values.yaml
+++ b/infrastructure/eo/chart/values.yaml
@@ -4,7 +4,7 @@ eo-base-helm-chart:
       replicaCount: 2
       image:
         repository: ghcr.io/energinet-datahub/eo-frontend-app
-        tag: 0.2.19
+        tag: 0.2.20
   service:
     deployment: app
     type: ClusterIP

--- a/libs/ui-watt/src/lib/components/time-range-input/watt-time-range-input.component.ts
+++ b/libs/ui-watt/src/lib/components/time-range-input/watt-time-range-input.component.ts
@@ -138,6 +138,9 @@ export class WattTimeRangeInputComponent
       'input'
     ).pipe(
       tap(() => this.setInputColor(startTimeInputElement, startTimeInputMask)),
+      tap((event) =>
+        this.jumpToEndTime(event, startTimeInputMask, endTimeInputElement)
+      ),
       map((event) => (event.target as HTMLInputElement).value)
     );
 
@@ -251,6 +254,23 @@ export class WattTimeRangeInputComponent
     }).mask(element);
 
     return inputmask;
+  }
+
+  /**
+   * @ignore
+   */
+  private jumpToEndTime(
+    event: InputEvent,
+    inputmask: Inputmask.Instance,
+    endInputElement: HTMLInputElement
+  ) {
+    if (
+      inputmask.isComplete() &&
+      (event.target as HTMLInputElement).value.length ===
+        inputmask.getemptymask().length
+    ) {
+      endInputElement.focus();
+    }
   }
 
   /**

--- a/libs/ui-watt/src/lib/components/time-range-input/watt-time-range-input.component.ts
+++ b/libs/ui-watt/src/lib/components/time-range-input/watt-time-range-input.component.ts
@@ -163,11 +163,29 @@ export class WattTimeRangeInputComponent
     );
 
     combineLatest([startTimeOnComplete$, endTimeOnComplete$])
-      .pipe(distinctUntilChanged(), takeUntil(this.destroy$))
+      .pipe(
+        // Note: A custom comparator function is necessary
+        // because RxJS' built-in comparator function checks
+        // the current and previous values for strict equality.
+        // In our case this will always return `false` since RxJS
+        // emits arrays and arrays are strictly equal only by reference.
+        distinctUntilChanged(this.customComparator),
+        takeUntil(this.destroy$)
+      )
       .subscribe(([startTime, endTime]) => {
         this.markParentControlAsTouched();
         this.changeParentValue({ start: startTime, end: endTime });
       });
+  }
+
+  /**
+   * @ignore
+   */
+  customComparator(
+    [prevStartTime, prevEndTime]: [string, string],
+    [currStartTime, currEndTime]: [string, string]
+  ): boolean {
+    return prevStartTime === currStartTime && prevEndTime === currEndTime;
   }
 
   /**

--- a/libs/ui-watt/src/lib/components/time-range-input/watt-time-range-input.component.ts
+++ b/libs/ui-watt/src/lib/components/time-range-input/watt-time-range-input.component.ts
@@ -149,17 +149,17 @@ export class WattTimeRangeInputComponent
       map((event) => (event.target as HTMLInputElement).value)
     );
 
-    const startDateOnComplete$ = startTimeOnInput$.pipe(
+    const startTimeOnComplete$ = startTimeOnInput$.pipe(
       startWith(this.initialValue?.start ?? ''),
       map((value) => (startTimeInputMask.isComplete() ? value : ''))
     );
 
-    const endDateOnComplete$ = endTimeOnInput$.pipe(
+    const endTimeOnComplete$ = endTimeOnInput$.pipe(
       startWith(this.initialValue?.end ?? ''),
       map((value) => (endTimeInputMask.isComplete() ? value : ''))
     );
 
-    combineLatest([startDateOnComplete$, endDateOnComplete$])
+    combineLatest([startTimeOnComplete$, endTimeOnComplete$])
       .pipe(distinctUntilChanged(), takeUntil(this.destroy$))
       .subscribe(([startTime, endTime]) => {
         this.markParentControlAsTouched();


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### Watt Design System
- automatically jump to "end" field when the value in "start" field is complete
- provide custom comparator to `distinctUntilChanged` operator

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #418 
