### PR TITLE
ci(eo): remove base chart properties after rename

### DIFF
--- a/.github/workflows/eo-cd.yml
+++ b/.github/workflows/eo-cd.yml
@@ -152,8 +152,6 @@ jobs:
     needs: affected
     uses: Energinet-DataHub/.github/.github/workflows/version-increment-check.yaml@main
     with:
-      # TODO(xlgni): remove base_yaml_file argument after merging #441
-      base_yaml_file: infrastructure/eo/chart/Chart.yaml
       yaml_file: build/infrastructure/eo/chart/Chart.yaml
       yaml_path: version
 
@@ -163,8 +161,6 @@ jobs:
     needs: affected
     uses: Energinet-DataHub/.github/.github/workflows/version-increment-check.yaml@main
     with:
-      # TODO(xlgni): remove base_yaml_file argument after merging #441
-      base_yaml_file: infrastructure/eo/chart/values.yaml
       yaml_file: build/infrastructure/eo/chart/values.yaml
       yaml_path: eo-base-helm-chart.deployments.app.image.tag
 

--- a/apps/eo/app-eo/src/index.html
+++ b/apps/eo/app-eo/src/index.html
@@ -37,6 +37,5 @@ limitations under the License.
   </head>
   <body>
     <energy-origin-app></energy-origin-app>
-    <!-- EO#244 Build paths 2022-19-04 08:04 -->
   </body>
 </html>

--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.2.22
+version: 0.2.23
 
 dependencies:
   - name: eo-base-helm-chart

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -4,7 +4,7 @@ eo-base-helm-chart:
       replicaCount: 2
       image:
         repository: ghcr.io/energinet-datahub/eo-frontend-app
-        tag: 0.2.22
+        tag: 0.2.23
   service:
     deployment: app
     type: ClusterIP


### PR DESCRIPTION
## Description
- Remove base parameters for chart version files after they have been renamed

## References

- https://github.com/Energinet-DataHub/energy-origin-issues/issues/244
- Feature environment http://eo-u-244removebasew.westeurope.cloudapp.azure.com/