### PR TITLE
refactor(dh): adjust styling on metering point search form

### DIFF
--- a/libs/dh/metering-point/feature-search/src/lib/form/dh-metering-point-search-form.component.html
+++ b/libs/dh/metering-point/feature-search/src/lib/form/dh-metering-point-search-form.component.html
@@ -20,7 +20,7 @@ limitations under the License.
   (ngSubmit)="onSubmit()"
 >
   <watt-form-field size="large">
-    <watt-label class="watt-text-m">{{ transloco('searchLabel') }}</watt-label>
+    <watt-label>{{ transloco("searchLabel") }}</watt-label>
     <watt-icon name="search" wattPrefix></watt-icon>
     <input
       #searchInput
@@ -31,7 +31,7 @@ limitations under the License.
       inputmode="numeric"
     />
     <watt-error *ngIf="searchControl.errors?.invalidMeteringPointId">
-      {{ transloco('searchInvalidLength') }}
+      {{ transloco("searchInvalidLength") }}
     </watt-error>
     <watt-icon-button
       icon="close"
@@ -46,6 +46,6 @@ limitations under the License.
     type="submit"
     size="large"
     [loading]="loading"
-    >{{ transloco('searchButton') }}</watt-button
+    >{{ transloco("searchButton") }}</watt-button
   >
 </form>

--- a/libs/dh/metering-point/feature-search/src/lib/form/dh-metering-point-search-form.component.scss
+++ b/libs/dh/metering-point/feature-search/src/lib/form/dh-metering-point-search-form.component.scss
@@ -23,6 +23,7 @@ form {
   display: flex;
   width: 100%;
   justify-content: space-between;
+  gap: var(--watt-space-s);
   flex-wrap: wrap;
 }
 
@@ -41,10 +42,8 @@ watt-icon {
 
 watt-form-field {
   width: auto;
-  margin-right: var(--watt-space-s);
-  --label-margin-bottom: var(--watt-space-m);
 }
 
 watt-button {
-  margin-top: var(--watt-space-m);
+  margin-top: var(--watt-space-xs);
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
Adjust styling on metering point search form so the input field looks consistent with input fields in Watt.

<!--- Please leave a helpful description of the pull request here. --->
### DataHub
- remove class from label 
- adjust spacing on input element 
- adjust spacing on button element

Before

![image](https://user-images.githubusercontent.com/1096332/164187519-11de9143-af61-4472-9fba-e62cc55805cb.png)

After

![image](https://user-images.githubusercontent.com/1096332/164187568-9f03e42b-702a-4746-b92e-dc3170ce2172.png)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- N/A
