### PR TITLE
(EO) Refactor of pie chart component test

### DIFF
--- a/libs/eo/origin-of-energy/shell/src/lib/eo-origin-of-energy-pie-chart/eo-origin-of-energy-pie-chart.component.spec.ts
+++ b/libs/eo/origin-of-energy/shell/src/lib/eo-origin-of-energy-pie-chart/eo-origin-of-energy-pie-chart.component.spec.ts
@@ -40,7 +40,7 @@ describe(EoPieChartComponent.name, () => {
       imports: [EoPieChartScam],
     });
 
-    expect(await screen.findByTestId('pie-charts')).toBeVisible;
+    expect(await screen.findByTestId('pie-chart')).toBeVisible;
   });
 
   it('formats the labels', () => {

--- a/libs/eo/origin-of-energy/shell/src/lib/eo-origin-of-energy-pie-chart/eo-origin-of-energy-pie-chart.component.spec.ts
+++ b/libs/eo/origin-of-energy/shell/src/lib/eo-origin-of-energy-pie-chart/eo-origin-of-energy-pie-chart.component.spec.ts
@@ -15,35 +15,30 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { render, screen } from '@testing-library/angular';
+import { getByTestId } from '@testing-library/angular';
 import { Context } from 'chartjs-plugin-datalabels';
-import {
-  EoPieChartComponent,
-  EoPieChartScam,
-} from './eo-origin-of-energy-pie-chart.component';
-
-let component: EoPieChartComponent;
-let fixture: ComponentFixture<EoPieChartComponent>;
+import { NgChartsModule } from 'ng2-charts';
+import { EoPieChartComponent } from './eo-origin-of-energy-pie-chart.component';
 
 describe(EoPieChartComponent.name, () => {
-  beforeEach(async () => {
-    TestBed.configureTestingModule({
-      imports: [EoPieChartScam],
-    });
+  let component: EoPieChartComponent;
+  let fixture: ComponentFixture<EoPieChartComponent>;
 
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [EoPieChartComponent],
+      imports: [NgChartsModule],
+    });
     fixture = TestBed.createComponent(EoPieChartComponent);
     component = fixture.componentInstance;
+    fixture.detectChanges();
   });
 
-  it('renders the canvas', async () => {
-    render('<eo-pie-chart></eo-pie-chart>', {
-      imports: [EoPieChartScam],
-    });
-
-    expect(await screen.findByTestId('pie-chart')).toBeVisible;
+  it('renders the component with test id', async () => {
+    expect(getByTestId(fixture.nativeElement, 'pie-charts')).toBeTruthy();
   });
 
-  it('formats the labels', () => {
+  it('datalabels plugin formats the labels', () => {
     const value = '12';
     const label = 'this is a test label';
     const context = {

--- a/libs/eo/origin-of-energy/shell/src/lib/eo-origin-of-energy-pie-chart/eo-origin-of-energy-pie-chart.component.spec.ts
+++ b/libs/eo/origin-of-energy/shell/src/lib/eo-origin-of-energy-pie-chart/eo-origin-of-energy-pie-chart.component.spec.ts
@@ -40,7 +40,7 @@ describe(EoPieChartComponent.name, () => {
       imports: [EoPieChartScam],
     });
 
-    expect(await screen.findByTestId('pie-chart')).toBeVisible;
+    expect(await screen.findByTestId('pie-charts')).toBeVisible;
   });
 
   it('formats the labels', () => {

--- a/libs/eo/origin-of-energy/shell/src/lib/eo-origin-of-energy-pie-chart/eo-origin-of-energy-pie-chart.component.spec.ts
+++ b/libs/eo/origin-of-energy/shell/src/lib/eo-origin-of-energy-pie-chart/eo-origin-of-energy-pie-chart.component.spec.ts
@@ -35,7 +35,7 @@ describe(EoPieChartComponent.name, () => {
   });
 
   it('renders the component with test id', async () => {
-    expect(getByTestId(fixture.nativeElement, 'pie-charts')).toBeTruthy();
+    expect(getByTestId(fixture.nativeElement, 'pie-chart')).toBeTruthy();
   });
 
   it('datalabels plugin formats the labels', () => {

--- a/libs/eo/origin-of-energy/shell/src/lib/eo-origin-of-energy-pie-chart/eo-origin-of-energy-pie-chart.component.ts
+++ b/libs/eo/origin-of-energy/shell/src/lib/eo-origin-of-energy-pie-chart/eo-origin-of-energy-pie-chart.component.ts
@@ -23,7 +23,7 @@ import DatalabelsPlugin, { Context } from 'chartjs-plugin-datalabels';
   selector: 'eo-pie-chart',
   template: `<canvas
     baseChart
-    data-testid="pie-charts"
+    data-testid="pie-chart"
     [data]="pieChartData"
     [type]="pieChartType"
     [options]="pieChartOptions"

--- a/libs/eo/origin-of-energy/shell/src/lib/eo-origin-of-energy-pie-chart/eo-origin-of-energy-pie-chart.component.ts
+++ b/libs/eo/origin-of-energy/shell/src/lib/eo-origin-of-energy-pie-chart/eo-origin-of-energy-pie-chart.component.ts
@@ -23,7 +23,7 @@ import DatalabelsPlugin, { Context } from 'chartjs-plugin-datalabels';
   selector: 'eo-pie-chart',
   template: `<canvas
     baseChart
-    data-testid="pie-chart"
+    data-testid="pie-charts"
     [data]="pieChartData"
     [type]="pieChartType"
     [options]="pieChartOptions"

--- a/libs/eo/origin-of-energy/shell/tsconfig.spec.json
+++ b/libs/eo/origin-of-energy/shell/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],
-  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+  "include": ["**/*.spec.ts"]
 }


### PR DESCRIPTION
## Description

This is a refactor for the pie chart component test, so that it works more performantly. 

It was originally intended for testing that we can't merge when tests fail, but now that the test has been confirmed for this repository, this refactor does not need to go to waste.
