### PR TITLE
fix(ui-watt): disable slider toggle when input is disabled

### DIFF
--- a/libs/ui-watt/src/lib/components/input/timepicker/watt-timepicker.component.html
+++ b/libs/ui-watt/src/lib/components/input/timepicker/watt-timepicker.component.html
@@ -57,6 +57,7 @@ limitations under the License.
     mat-icon-button
     class="watt-timepicker-slider-toggle"
     type="button"
+    [disabled]="disabled"
     [attr.aria-pressed]="sliderOpen"
     (click)="toggleSlider()"
     (focusin)="onFocusIn()"


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
Forgot to account for disabled state. This just makes sure the slider cannot
be toggled while the input is disabled.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
