### PR TITLE
fix(dh): adjust styling of heading (reset password)

### DIFF
--- a/libs/dh/shared/assets/src/assets/reset-password-page/self-asserted.html
+++ b/libs/dh/shared/assets/src/assets/reset-password-page/self-asserted.html
@@ -122,7 +122,7 @@ limitations under the License.
         display: none !important;
       }
 
-      h2 {
+      h1 {
         font-family: "Open Sans", sans-serif;
         font-style: normal;
         font-weight: 600;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Change selector from `h2` -> `h1` since `h1` is used for reset password flow and not `h2`.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
