### PR TITLE
feat(dh-e2e): add healthcheck for signup and forgot password link (b2c)

### DIFF
--- a/apps/dh/e2e-dh/src/integration/b2c.spec.ts
+++ b/apps/dh/e2e-dh/src/integration/b2c.spec.ts
@@ -47,4 +47,24 @@ environments.forEach((env) => {
     await page.waitForNavigation();
     expect(page.url()).toContain(`redirect_uri=${encodeURIComponent(env.url)}`);
   });
+
+  test(`[B2C Healthcheck] ${env.name} should have "sign up" link, and redirect to "signup" user flow`, async ({
+    page,
+  }) => {
+    await page.goto(env.url).then((resp) => expect(resp?.status()).toBe(200));
+    await page.waitForNavigation();
+    await page.locator('text=Sign up now').click();
+
+    expect(page.url()).toContain(`signup`);
+  });
+
+  test(`[B2C Healthcheck] ${env.name} should have "forgot password" link, and redirect to "reset_password" user flow`, async ({
+    page,
+  }) => {
+    await page.goto(env.url).then((resp) => expect(resp?.status()).toBe(200));
+    await page.waitForNavigation();
+    await page.locator('text=Reset password here').click();
+
+    expect(page.url()).toContain(`reset_password`);
+  });
 });


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Add health checks for signup and forgot password link (b2c)

- Checks that `sign up` and `forgot password` exist
- Checks that  `sign up` and `forgot password` redirects to correct b2c userflow 

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests, or similar that should be linked here? --->

- #705 
