### PR TITLE
feat(ui-watt): only allow one drawer at a time

### DIFF
--- a/libs/ui-watt/src/lib/components/drawer/+storybook/watt-drawer.stories.ts
+++ b/libs/ui-watt/src/lib/components/drawer/+storybook/watt-drawer.stories.ts
@@ -27,25 +27,18 @@ export default {
   title: 'Components/Drawer',
   component: WattDrawerComponent,
   argTypes: {
+    size: { control: false },
+    opened: { control: false },
     closed: {
-      table: {
-        category: 'Outputs',
-      },
+      table: { category: 'Outputs' },
       control: false,
     },
     close: {
-      table: {
-        category: 'Methods',
-      },
+      table: { category: 'Methods' },
       control: false,
     },
     open: {
-      table: {
-        category: 'Methods',
-      },
-      control: false,
-    },
-    size: {
+      table: { category: 'Methods' },
       control: false,
     },
   },

--- a/libs/ui-watt/src/lib/components/drawer/+storybook/watt-drawer.stories.ts
+++ b/libs/ui-watt/src/lib/components/drawer/+storybook/watt-drawer.stories.ts
@@ -121,3 +121,23 @@ Normal.args = { size: 'normal' };
 
 export const Large = Drawer.bind({});
 Large.args = { size: 'large' };
+
+export const Multiple: Story<WattDrawerComponent> = (args) => ({
+  props: args,
+  template: `
+    <watt-drawer #first (closed)="closed()">
+      <watt-drawer-content *ngIf="first.opened">
+        First drawer
+      </watt-drawer-content>
+    </watt-drawer>
+
+    <watt-drawer #second (closed)="closed()">
+      <watt-drawer-content *ngIf="second.opened">
+        Second drawer
+      </watt-drawer-content>
+    </watt-drawer>
+
+    <watt-button (click)="first.open()">Open first</watt-button><br /><br />
+    <watt-button (click)="second.open()">Open second</watt-button>
+  `,
+});

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.spec.ts
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.spec.ts
@@ -26,7 +26,7 @@ import userEvent from '@testing-library/user-event';
 import { WattDrawerComponent } from './watt-drawer.component';
 import * as drawerStories from './+storybook/watt-drawer.stories';
 
-const { Normal: Drawer } = composeStories(drawerStories);
+const { Normal: Drawer, Multiple } = composeStories(drawerStories);
 
 describe(WattDrawerComponent.name, () => {
   // Queries
@@ -197,5 +197,18 @@ describe(WattDrawerComponent.name, () => {
     userEvent.keyboard('{Escape}');
 
     expect(closedOutput).not.toHaveBeenCalled();
+  });
+
+  it('closes drawer when another drawer is opened', async () => {
+    await setup(Multiple);
+    const firstButton = screen.getByRole('button', { name: /^open first/i });
+    const secondButton = screen.getByRole('button', { name: /^open second/i });
+
+    userEvent.click(firstButton);
+    userEvent.click(secondButton);
+
+    expect(closedOutput).toHaveBeenCalled();
+    expect(screen.queryByText(/first drawer/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/second drawer/i)).toBeInTheDocument();
   });
 });

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.ts
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.ts
@@ -39,6 +39,8 @@ export type WattDrawerSize = 'small' | 'normal' | 'large';
   templateUrl: './watt-drawer.component.html',
 })
 export class WattDrawerComponent implements AfterViewInit, OnDestroy {
+  static currentDrawer?: WattDrawerComponent;
+
   /** Used to adjust drawer size to best fit the content. */
   @Input()
   size: WattDrawerSize = 'normal';
@@ -85,6 +87,8 @@ export class WattDrawerComponent implements AfterViewInit, OnDestroy {
     const isDrawerClosed = this.opened === false;
 
     if (isDrawerClosed) {
+      WattDrawerComponent.currentDrawer?.close();
+      WattDrawerComponent.currentDrawer = this;
       this.opened = true;
       this.cdr.detectChanges();
     }

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.ts
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.ts
@@ -39,7 +39,7 @@ export type WattDrawerSize = 'small' | 'normal' | 'large';
   templateUrl: './watt-drawer.component.html',
 })
 export class WattDrawerComponent implements AfterViewInit, OnDestroy {
-  static currentDrawer?: WattDrawerComponent;
+  private static currentDrawer?: WattDrawerComponent;
 
   /** Used to adjust drawer size to best fit the content. */
   @Input()
@@ -76,6 +76,10 @@ export class WattDrawerComponent implements AfterViewInit, OnDestroy {
 
   /** @ignore */
   ngOnDestroy(): void {
+    if (WattDrawerComponent.currentDrawer === this) {
+      WattDrawerComponent.currentDrawer = undefined;
+    }
+
     this.destroy$.next();
     this.destroy$.complete();
   }
@@ -84,9 +88,7 @@ export class WattDrawerComponent implements AfterViewInit, OnDestroy {
    * Opens the drawer. Subsequent calls are ignored while the drawer is opened.
    */
   open() {
-    const isDrawerClosed = this.opened === false;
-
-    if (isDrawerClosed) {
+    if (!this.opened) {
       WattDrawerComponent.currentDrawer?.close();
       WattDrawerComponent.currentDrawer = this;
       this.opened = true;
@@ -99,6 +101,7 @@ export class WattDrawerComponent implements AfterViewInit, OnDestroy {
    */
   close() {
     if (this.opened) {
+      WattDrawerComponent.currentDrawer = undefined;
       this.opened = false;
       this.closed.emit();
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
Trying to take the simplest approach here, since I agree that this is normally a non-issue if using the drawer "correctly" (as in reusing the same drawer component and then just updating the content instead of opening a new drawer).

However, in certain cases reusing the same drawer component might not be that feasible (for instance if on the same page two separate components are using a drawer to render completely different data).

I considered various solutions such as using a [Portal](https://material.angular.io/cdk/portal/overview) along with a service, but they were all too complex solutions for something that might not even be an issue. So I settled on just storing the current drawer instance in a static property, making it shared between multiple drawer instances. Then if you open a new drawer, the current drawer (if any) is automatically closed.

## References

Closes #727
