### PR TITLE
fix(dh): increase feature flag expiration to 62 days (2 month'ish)

### DIFF
--- a/libs/dh/shared/feature-flags/README.md
+++ b/libs/dh/shared/feature-flags/README.md
@@ -4,7 +4,7 @@ You can disable functionality for specified environments: `dev, test, prod.`
 
 <mark>Notice: feature flags treat the pre-prod environment as prod.</mark>
 
-Feature flags are not supposed to live long; therefore, they have a **maximum lifetime of 14 days** (If a feature flag is older than 14 days, an automated test will fail).
+Feature flags are not supposed to live long; therefore, they have a **maximum lifetime of 62 days** (If a feature flag is older than 62 days, an automated test will fail).
 
 ## Create a feature flag
 

--- a/libs/dh/shared/feature-flags/src/lib/feature-flags.spec.ts
+++ b/libs/dh/shared/feature-flags/src/lib/feature-flags.spec.ts
@@ -21,7 +21,7 @@ import {
   dhFeatureFlagsConfig,
 } from './feature-flags';
 
-const maxAgeOfDays = 14;
+const maxAgeOfDays = 62;
 
 const featureFlagCases = Object.keys(dhFeatureFlagsConfig).map(
   (featureFlag) => {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Increase feature flag expiration to 62 days (2 month'ish)
<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #771
