### PR TITLE
Datarange picker for consumption and production

### DIFF
--- a/apps/eo/app-eo/project.json
+++ b/apps/eo/app-eo/project.json
@@ -56,12 +56,12 @@
             {
               "type": "allScript",
               "maximumWarning": "500kb",
-              "maximumError": "1.25mb"
+              "maximumError": "1.27mb"
             },
             {
               "type": "anyScript",
               "maximumWarning": "500kb",
-              "maximumError": "1.1mb"
+              "maximumError": "1.15mb"
             },
             {
               "type": "bundle",
@@ -71,7 +71,7 @@
             {
               "type": "initial",
               "maximumWarning": "500kb",
-              "maximumError": "1.21mb"
+              "maximumError": "1.25mb"
             },
             {
               "type": "anyComponentStyle",

--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.3.18
+version: 0.3.19

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.18
+    tag: 0.3.19

--- a/libs/eo/consumption-page/shell/src/lib/eo-consumption-chart-card.component.ts
+++ b/libs/eo/consumption-page/shell/src/lib/eo-consumption-chart-card.component.ts
@@ -20,8 +20,9 @@ import { Component, NgModule } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { EoLineChartScam } from '@energinet-datahub/eo/shared/atomic-design/ui-atoms';
 import { WattSpinnerModule } from '@energinet-datahub/watt';
-import { take } from 'rxjs';
-import { EoConsumptionStore, EoMeasurementData } from './eo-consumption.store';
+import { LetModule } from '@rx-angular/template';
+import { map } from 'rxjs';
+import { EoConsumptionStore } from './eo-consumption.store';
 
 @Component({
   selector: 'eo-consumption-line-chart',
@@ -31,7 +32,7 @@ import { EoConsumptionStore, EoMeasurementData } from './eo-consumption.store';
       <div *ngIf="(loadingDone$ | async) === false" class="loadingObfuscator">
         <watt-spinner [diameter]="100"></watt-spinner>
       </div>
-      <eo-line-chart [data]="getDataInKWH()"></eo-line-chart>
+      <eo-line-chart *rxLet="dataInKWH$ as data" [data]="data"></eo-line-chart>
     </ng-container>
   </mat-card>`,
   styles: [
@@ -57,28 +58,24 @@ import { EoConsumptionStore, EoMeasurementData } from './eo-consumption.store';
 })
 export class EoConsumptionLineChartComponent {
   loadingDone$ = this.store.loadingDone$;
+  dataInKWH$ = this.store.measurements$.pipe(
+    map((all) =>
+      all.map((one) => ({ ...one, value: Number(one.value / 1000) }))
+    )
+  );
 
   constructor(private store: EoConsumptionStore) {}
-
-  getDataInKWH() {
-    const measurementList: EoMeasurementData[] = [];
-
-    this.store.measurements$.pipe(take(1)).subscribe((measurements) => {
-      measurements?.map((dataPoint) =>
-        measurementList.push({
-          ...dataPoint,
-          value: Number((dataPoint.value / 1000).toFixed(0)),
-        })
-      );
-    });
-
-    return measurementList ?? [];
-  }
 }
 
 @NgModule({
   declarations: [EoConsumptionLineChartComponent],
   exports: [EoConsumptionLineChartComponent],
-  imports: [MatCardModule, EoLineChartScam, CommonModule, WattSpinnerModule],
+  imports: [
+    LetModule,
+    MatCardModule,
+    EoLineChartScam,
+    CommonModule,
+    WattSpinnerModule,
+  ],
 })
 export class EoConsumptionLineChartScam {}

--- a/libs/eo/consumption-page/shell/src/lib/eo-consumption-page-info.component.ts
+++ b/libs/eo/consumption-page/shell/src/lib/eo-consumption-page-info.component.ts
@@ -39,9 +39,7 @@ import { EoConsumptionStore } from './eo-consumption.store';
   ],
   template: `
     <mat-card>
-      <h4 class="output watt-space-stack-s">
-        Your electricity consumption in 2021
-      </h4>
+      <h4 class="output watt-space-stack-s">Your electricity consumption</h4>
       <h1 *ngIf="loadingDone$ | async; else loading">
         {{ convertTokWh((totalMeasurement$ | async) || 0).toLocaleString() }}
         kWh

--- a/libs/eo/consumption-page/shell/src/lib/eo-consumption-page-shell.component.ts
+++ b/libs/eo/consumption-page/shell/src/lib/eo-consumption-page-shell.component.ts
@@ -15,10 +15,18 @@
  * limitations under the License.
  */
 import { ChangeDetectionStrategy, Component, NgModule } from '@angular/core';
+import { EoDatePickerScam } from '@energinet-datahub/eo/shared/atomic-design/ui-atoms';
+import {
+  AppSettingsStore,
+  CalendarDateRange,
+  EoFeatureFlagScam,
+} from '@energinet-datahub/eo/shared/services';
+import { LetModule } from '@rx-angular/template';
 import { EoConsumptionLineChartScam } from './eo-consumption-chart-card.component';
 import { EoConsumptionPageEnergyConsumptionScam } from './eo-consumption-page-energy-consumption.component';
 import { EoConsumptionPageInfoScam } from './eo-consumption-page-info.component';
 import { EoConsumptionPageTipScam } from './eo-consumption-page-tip.component';
+import { EoConsumptionStore } from './eo-consumption.store';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -37,7 +45,15 @@ import { EoConsumptionPageTipScam } from './eo-consumption-page-tip.component';
       <eo-consumption-page-info
         class="watt-space-stack-l"
       ></eo-consumption-page-info>
-      <eo-consumption-line-chart></eo-consumption-line-chart>
+      <eo-consumption-line-chart
+        class="watt-space-stack-l"
+      ></eo-consumption-line-chart>
+      <eo-date-picker
+        [onFeatureFlag]="'daterange'"
+        *rxLet="appSettingsDates$ as dates"
+        [dateRangeInput]="dates"
+        (newDates)="setNewAppDates($event)"
+      ></eo-date-picker>
     </div>
     <div>
       <eo-consumption-page-tip
@@ -47,11 +63,26 @@ import { EoConsumptionPageTipScam } from './eo-consumption-page-tip.component';
     </div>
   `,
 })
-export class EoConsumptionPageShellComponent {}
+export class EoConsumptionPageShellComponent {
+  appSettingsDates$ = this.appSettingsStore.calendarDateRange$;
+
+  constructor(
+    private appSettingsStore: AppSettingsStore,
+    private consumptionStore: EoConsumptionStore
+  ) {}
+
+  setNewAppDates(dates: CalendarDateRange) {
+    this.appSettingsStore.setCalendarDateRange(dates);
+    this.consumptionStore.loadMonthlyConsumption();
+  }
+}
 
 @NgModule({
   declarations: [EoConsumptionPageShellComponent],
   imports: [
+    LetModule,
+    EoFeatureFlagScam,
+    EoDatePickerScam,
     EoConsumptionPageTipScam,
     EoConsumptionPageInfoScam,
     EoConsumptionPageEnergyConsumptionScam,

--- a/libs/eo/consumption-page/shell/src/lib/eo-consumption.service.ts
+++ b/libs/eo/consumption-page/shell/src/lib/eo-consumption.service.ts
@@ -20,6 +20,11 @@ import {
   EoApiEnvironment,
   eoApiEnvironmentToken,
 } from '@energinet-datahub/eo/shared/environments';
+import {
+  AppSettingsStore,
+  CalendarDateRange,
+} from '@energinet-datahub/eo/shared/services';
+import { take } from 'rxjs';
 
 export interface EoMeasurement {
   dateFrom: number;
@@ -37,17 +42,24 @@ interface EoConsumptionResponse {
 export class EoConsumptionService {
   #apiBase: string;
 
-  getMonthlyConsumptionFor2021() {
+  getMonthlyConsumption() {
+    let dateRange: CalendarDateRange = {} as CalendarDateRange;
+
+    this.store.calendarDateRangeInSeconds$
+      .pipe(take(1))
+      .subscribe((datesInSeconds) => (dateRange = datesInSeconds));
+
     return this.http.get<EoConsumptionResponse>(
-      `${
-        this.#apiBase
-      }/measurements/consumption?dateFrom=1609459200&dateTo=1640995199&aggregation=Month`,
+      `${this.#apiBase}/measurements/consumption?dateFrom=${
+        dateRange.start
+      }&dateTo=${dateRange.end}&aggregation=Month`,
       { withCredentials: true }
     );
   }
 
   constructor(
     private http: HttpClient,
+    private store: AppSettingsStore,
     @Inject(eoApiEnvironmentToken) apiEnvironment: EoApiEnvironment
   ) {
     this.#apiBase = `${apiEnvironment.apiBase}`;

--- a/libs/eo/consumption-page/shell/src/lib/eo-consumption.store.ts
+++ b/libs/eo/consumption-page/shell/src/lib/eo-consumption.store.ts
@@ -73,7 +73,7 @@ export class EoConsumptionStore extends ComponentStore<EoConsumptionState> {
 
   loadMonthlyConsumption() {
     this.service
-      .getMonthlyConsumptionFor2021()
+      .getMonthlyConsumption()
       .pipe(take(1))
       .subscribe({
         next: (result) => {

--- a/libs/eo/production/shell/src/lib/eo-production-chart-card.component.ts
+++ b/libs/eo/production/shell/src/lib/eo-production-chart-card.component.ts
@@ -20,8 +20,9 @@ import { Component, NgModule } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { EoLineChartScam } from '@energinet-datahub/eo/shared/atomic-design/ui-atoms';
 import { WattSpinnerModule } from '@energinet-datahub/watt';
-import { take } from 'rxjs';
-import { EoMeasurementData, EoProductionStore } from './eo-production.store';
+import { LetModule } from '@rx-angular/template';
+import { map } from 'rxjs';
+import { EoProductionStore } from './eo-production.store';
 
 @Component({
   selector: 'eo-production-line-chart',
@@ -31,7 +32,7 @@ import { EoMeasurementData, EoProductionStore } from './eo-production.store';
       <div *ngIf="(loadingDone$ | async) === false" class="loadingObfuscator">
         <watt-spinner [diameter]="100"></watt-spinner>
       </div>
-      <eo-line-chart [data]="getDataInKWH()"></eo-line-chart>
+      <eo-line-chart *rxLet="dataInKWH$ as data" [data]="data"></eo-line-chart>
     </ng-container>
   </mat-card>`,
   styles: [
@@ -57,28 +58,24 @@ import { EoMeasurementData, EoProductionStore } from './eo-production.store';
 })
 export class EoProductionLineChartComponent {
   loadingDone$ = this.store.loadingDone$;
+  dataInKWH$ = this.store.measurements$.pipe(
+    map((all) =>
+      all.map((one) => ({ ...one, value: Number(one.value / 1000) }))
+    )
+  );
 
   constructor(private store: EoProductionStore) {}
-
-  getDataInKWH() {
-    const measurementList: EoMeasurementData[] = [];
-
-    this.store.measurements$.pipe(take(1)).subscribe((measurements) => {
-      measurements?.map((dataPoint) =>
-        measurementList.push({
-          ...dataPoint,
-          value: Number((dataPoint.value / 1000).toFixed(0)),
-        })
-      );
-    });
-
-    return measurementList ?? [];
-  }
 }
 
 @NgModule({
   declarations: [EoProductionLineChartComponent],
   exports: [EoProductionLineChartComponent],
-  imports: [MatCardModule, EoLineChartScam, CommonModule, WattSpinnerModule],
+  imports: [
+    LetModule,
+    MatCardModule,
+    EoLineChartScam,
+    CommonModule,
+    WattSpinnerModule,
+  ],
 })
 export class EoProductionLineChartScam {}

--- a/libs/eo/production/shell/src/lib/eo-production-info.component.ts
+++ b/libs/eo/production/shell/src/lib/eo-production-info.component.ts
@@ -39,9 +39,7 @@ import { EoProductionStore } from './eo-production.store';
   ],
   template: `
     <mat-card>
-      <h4 class="output watt-space-stack-s">
-        Your electricity production in 2021
-      </h4>
+      <h4 class="output watt-space-stack-s">Your electricity production</h4>
       <h1 *ngIf="loadingDone$ | async; else loading">
         {{ convertTokWh((totalMeasurement$ | async) || 0).toLocaleString() }}
         kWh

--- a/libs/eo/production/shell/src/lib/eo-production-shell.component.ts
+++ b/libs/eo/production/shell/src/lib/eo-production-shell.component.ts
@@ -15,13 +15,17 @@
  * limitations under the License.
  */
 import { ChangeDetectionStrategy, Component, NgModule } from '@angular/core';
+import { EoDatePickerScam } from '@energinet-datahub/eo/shared/atomic-design/ui-atoms';
 import {
   AppSettingsStore,
   CalendarDateRange,
+  EoFeatureFlagScam,
 } from '@energinet-datahub/eo/shared/services';
+import { LetModule } from '@rx-angular/template';
 import { EoProductionLineChartScam } from './eo-production-chart-card.component';
 import { EoProductionInfoScam } from './eo-production-info.component';
 import { EoProductionTipScam } from './eo-production-tip.component';
+import { EoProductionStore } from './eo-production.store';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -41,6 +45,12 @@ import { EoProductionTipScam } from './eo-production-tip.component';
       <eo-production-line-chart
         class="watt-space-stack-l"
       ></eo-production-line-chart>
+      <eo-date-picker
+        [onFeatureFlag]="'daterange'"
+        *rxLet="appSettingsDates$ as dates"
+        [dateRangeInput]="dates"
+        (newDates)="setNewAppDates($event)"
+      ></eo-date-picker>
     </div>
     <div>
       <eo-production-tip class="watt-space-stack-l"></eo-production-tip>
@@ -50,16 +60,23 @@ import { EoProductionTipScam } from './eo-production-tip.component';
 export class EoProductionShellComponent {
   appSettingsDates$ = this.appSettingsStore.calendarDateRange$;
 
-  constructor(private appSettingsStore: AppSettingsStore) {}
+  constructor(
+    private appSettingsStore: AppSettingsStore,
+    private productionStore: EoProductionStore
+  ) {}
 
   setNewAppDates(dates: CalendarDateRange) {
     this.appSettingsStore.setCalendarDateRange(dates);
+    this.productionStore.loadMonthlyProduction();
   }
 }
 
 @NgModule({
   declarations: [EoProductionShellComponent],
   imports: [
+    EoFeatureFlagScam,
+    LetModule,
+    EoDatePickerScam,
     EoProductionTipScam,
     EoProductionInfoScam,
     EoProductionLineChartScam,

--- a/libs/eo/production/shell/src/lib/eo-production.service.ts
+++ b/libs/eo/production/shell/src/lib/eo-production.service.ts
@@ -20,6 +20,11 @@ import {
   EoApiEnvironment,
   eoApiEnvironmentToken,
 } from '@energinet-datahub/eo/shared/environments';
+import {
+  AppSettingsStore,
+  CalendarDateRange,
+} from '@energinet-datahub/eo/shared/services';
+import { take } from 'rxjs';
 
 export interface EoMeasurement {
   dateFrom: number;
@@ -37,17 +42,24 @@ interface EoProductionResponse {
 export class EoProductionService {
   #apiBase: string;
 
-  getMonthlyProductionFor2021() {
+  getMonthlyProduction() {
+    let dateRange: CalendarDateRange = {} as CalendarDateRange;
+
+    this.store.calendarDateRangeInSeconds$
+      .pipe(take(1))
+      .subscribe((datesInSeconds) => (dateRange = datesInSeconds));
+
     return this.http.get<EoProductionResponse>(
-      `${
-        this.#apiBase
-      }/measurements/production?dateFrom=1609459200&dateTo=1640995200&aggregation=Month`,
+      `${this.#apiBase}/measurements/production?dateFrom=${
+        dateRange.start
+      }&dateTo=${dateRange.end}&aggregation=Month`,
       { withCredentials: true }
     );
   }
 
   constructor(
     private http: HttpClient,
+    private store: AppSettingsStore,
     @Inject(eoApiEnvironmentToken) apiEnvironment: EoApiEnvironment
   ) {
     this.#apiBase = `${apiEnvironment.apiBase}`;

--- a/libs/eo/production/shell/src/lib/eo-production.store.ts
+++ b/libs/eo/production/shell/src/lib/eo-production.store.ts
@@ -22,7 +22,7 @@ import { EoMeasurement, EoProductionService } from './eo-production.service';
 export interface EoMeasurementData {
   /** Name of month */
   name: string;
-  /** Value of the total production for the selected dates, in kWh */
+  /** Value of the total production for the selected dates, in watt hours */
   value: number;
 }
 
@@ -73,7 +73,7 @@ export class EoProductionStore extends ComponentStore<EoProductionState> {
 
   loadMonthlyProduction() {
     this.service
-      .getMonthlyProductionFor2021()
+      .getMonthlyProduction()
       .pipe(take(1))
       .subscribe({
         next: (result) => {

--- a/libs/eo/shared/services/src/app-settings/app-settings.store.ts
+++ b/libs/eo/shared/services/src/app-settings/app-settings.store.ts
@@ -40,6 +40,10 @@ export class AppSettingsStore extends ComponentStore<AppSettingsState> {
   }
 
   readonly calendarDateRange$ = this.select((state) => state.calendarDateRange);
+  readonly calendarDateRangeInSeconds$ = this.select((state) => ({
+    start: state.calendarDateRange.start / 1000,
+    end: state.calendarDateRange.end / 1000,
+  }));
 
   readonly setCalendarDateRange = this.updater(
     (state, calendarDateRange: CalendarDateRange): AppSettingsState => ({

--- a/libs/eo/shared/services/src/feature-flag/feature-flag.directive.ts
+++ b/libs/eo/shared/services/src/feature-flag/feature-flag.directive.ts
@@ -33,6 +33,9 @@ import {
  * This directive can be used to show/hide a component based on the feature flags that are currently enabled.
  * @example
  * <div [onFeatureFlag]="'winter'">Test</div>
+ *
+ * To Enable: Append something like this '?enableFeature=daterange' to the URL
+ * To Disable: Append something like this '?disableFeature=daterange' to the URL
  */
 export class EoFeatureFlagDirective implements AfterViewInit {
   /**

--- a/libs/eo/shared/services/src/feature-flag/feature-flag.service.spec.ts
+++ b/libs/eo/shared/services/src/feature-flag/feature-flag.service.spec.ts
@@ -32,20 +32,20 @@ describe(FeatureFlagService.name, () => {
    */
   describe('If flag name is valid', () => {
     it('it can save it', () => {
-      const winterFlag = new Set().add('winter');
+      const winterFlag = new Set().add('test');
 
-      service.enableFeatureFlag('winter');
+      service.enableFeatureFlag('test');
       expect(service.getEnabledFlags()).toEqual(winterFlag);
     });
 
     it('it can remove it', () => {
-      const winterFlag = new Set().add('winter');
+      const winterFlag = new Set().add('test');
       const noFlag = new Set();
 
-      service.enableFeatureFlag('winter');
+      service.enableFeatureFlag('test');
       expect(service.getEnabledFlags()).toEqual(winterFlag);
 
-      service.disableFeatureFlag('winter');
+      service.disableFeatureFlag('test');
       expect(service.getEnabledFlags()).toEqual(noFlag);
     });
   });

--- a/libs/eo/shared/services/src/feature-flag/feature-flag.service.ts
+++ b/libs/eo/shared/services/src/feature-flag/feature-flag.service.ts
@@ -17,9 +17,8 @@
 import { Injectable } from '@angular/core';
 
 enum FeatureFlags {
-  'spring',
-  'autumn',
-  'winter',
+  'test',
+  'daterange',
 }
 export type allowedFeatureFlags = keyof typeof FeatureFlags;
 


### PR DESCRIPTION
## Description

Date range picker is now being being soft-pushed to consumption and production pages.

They are going to be in production, but hidden behind the feature flag 'daterange' for now.

They can be seen at https://demo.energioprindelse.dk/consumption?enableFeature=daterange

![image](https://user-images.githubusercontent.com/22421190/185323330-77ade32e-2413-4ce5-a1c8-85715a1575e7.png)
