### PR TITLE
style(ui-watt): make textarea work with wattInput

### DIFF
--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.3.48
+version: 0.3.49

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.48
+    tag: 0.3.49

--- a/libs/ui-watt/src/lib/components/form-field/form-field.component.scss
+++ b/libs/ui-watt/src/lib/components/form-field/form-field.component.scss
@@ -46,7 +46,11 @@ watt-form-field {
     }
 
     .mat-form-field-flex {
-      height: 56px;
+      min-height: 56px;
+
+      & textarea:not([rows]) {
+        min-height: 72px; // equal to three lines
+      }
     }
 
     [wattPrefix],
@@ -71,7 +75,16 @@ watt-form-field {
     border-radius: 4px;
     background: var(--input-background);
     border: 1px solid var(--input-border-color);
-    height: 44px;
+    min-height: 44px;
+
+    & textarea {
+      margin: 12px; // material spacing
+      padding: 0;
+    }
+
+    & textarea:not([rows]) {
+      min-height: 60px; // equal to three lines
+    }
   }
 
   .mat-form-field {

--- a/libs/ui-watt/src/lib/components/input/+storybook/input.directive.stories.ts
+++ b/libs/ui-watt/src/lib/components/input/+storybook/input.directive.stories.ts
@@ -42,6 +42,7 @@ const Template: Story<StorybookInputWrapperComponent> = (args) => ({
 const overviewTemplate: Story = () => ({
   template: `<storybook-input-overview></storybook-input-overview>`,
 });
+
 export const overview = overviewTemplate.bind({});
 overview.argTypes = {
   disabled: {
@@ -90,6 +91,11 @@ overview.argTypes = {
     },
   },
   size: {
+    table: {
+      disable: true,
+    },
+  },
+  isTextArea: {
     table: {
       disable: true,
     },
@@ -217,6 +223,22 @@ exampleFormControl = new FormControl('', [
   Validators.required
 ]);
 `,
+    },
+  },
+};
+
+export const textArea = Template.bind({});
+textArea.args = {
+  isTextArea: true,
+};
+textArea.parameters = {
+  docs: {
+    source: {
+      code: `
+<watt-form-field>
+  <watt-label>label</watt-label>
+  <textarea wattInput [formControl]="exampleFormControl" />
+</watt-form-field>`,
     },
   },
 };

--- a/libs/ui-watt/src/lib/components/input/+storybook/storybook-input-wrapper.component.ts
+++ b/libs/ui-watt/src/lib/components/input/+storybook/storybook-input-wrapper.component.ts
@@ -36,6 +36,7 @@ import { FormControl } from '@angular/forms';
       label="some meaningful description"
     ></watt-icon>
     <input
+      *ngIf="!isTextArea"
       wattInput
       type="text"
       maxlength="256"
@@ -43,6 +44,13 @@ import { FormControl } from '@angular/forms';
       [placeholder]="placeholder"
       [required]="required"
     />
+    <textarea
+      *ngIf="isTextArea"
+      wattInput
+      [formControl]="exampleFormControl"
+      [placeholder]="placeholder"
+      [required]="required"
+    ></textarea>
     <watt-button
       variant="icon"
       *ngIf="hasSuffix"
@@ -71,6 +79,7 @@ export class StorybookInputWrapperComponent implements OnChanges {
   @Input() hasHint = false;
   @Input() required = false;
   @Input() hasError = false;
+  @Input() isTextArea = false;
   @Input() size: 'normal' | 'large' = 'normal';
 
   /**


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
This PR improves the styling of `<textarea>` when used with `[wattInput]`. I had to change the css `height` to `minHeight` for input fields, to allow the `<textarea>` to increase the height of the input field.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #626
