### PR TITLE
Bump: Update to latest `Energinet.DataHub.Charges.Clients` and `Energinet.DataHub.Charges.Clients.Registration`

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -36,8 +36,8 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
-    <PackageReference Include="Energinet.DataHub.Charges.Clients" Version="3.0.1" />
-    <PackageReference Include="Energinet.DataHub.Charges.Clients.Registration" Version="3.0.1" />
+    <PackageReference Include="Energinet.DataHub.Charges.Clients" Version="3.0.12" />
+    <PackageReference Include="Energinet.DataHub.Charges.Clients.Registration" Version="3.0.12" />
     <PackageReference Include="Energinet.DataHub.Core.App.Common.Security" Version="2.3.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="2.3.0" />
     <PackageReference Include="Energinet.DataHub.MarketParticipant.Client" Version="2.4.0" />


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This PR bumps 
* `Energinet.DataHub.Charges.Clients` to `3.0.12`
* `Energinet.DataHub.Charges.Clients.Registration` to `3.0.12`

In this Clients package, ChargeLinksClient calls are routed to `v1/GetChargeLinks` of the Charges.WebApi (instead of the no longer needed v2)
With this, the response will now contain a value instead of nulll for `ChargeOwner`

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

https://github.com/Energinet-DataHub/geh-charges/issues/1123
