### PR TITLE
fix(ui-watt): esc no longer closes both modal and drawer"

### DIFF
--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.3.52
+version: 0.3.53

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.52
+    tag: 0.3.53

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.html
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.html
@@ -21,6 +21,8 @@ limitations under the License.
     position="end"
     [opened]="opened"
     [disableClose]="true"
+    [autoFocus]="true"
+    [cdkTrapFocus]="true"
   >
     <div class="watt-drawer__grid-container">
       <header>

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.spec.ts
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.spec.ts
@@ -168,7 +168,7 @@ describe(WattDrawerComponent.name, () => {
     await setup(Drawer);
 
     userEvent.click(getOpenDrawerButton());
-    userEvent.keyboard('{Escape}');
+    userEvent.type(getDrawerContent() as Element, '{esc}');
 
     expect(closedOutput).toHaveBeenCalled();
   });
@@ -179,7 +179,7 @@ describe(WattDrawerComponent.name, () => {
     userEvent.click(getOpenDrawerButton());
 
     getDrawerTopBarContent()?.focus();
-    userEvent.keyboard('{Escape}');
+    userEvent.type(getDrawerContent() as Element, '{esc}');
 
     expect(closedOutput).toHaveBeenCalled();
   });
@@ -188,8 +188,7 @@ describe(WattDrawerComponent.name, () => {
     await setup(Drawer);
 
     userEvent.click(getOpenDrawerButton());
-    userEvent.keyboard('{Escape}');
-    userEvent.keyboard('{Escape}');
+    userEvent.type(getDrawerContent() as Element, '{esc}{esc}');
 
     expect(closedOutput).toHaveBeenCalledTimes(1);
   });

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.ts
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.ts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { CdkTrapFocus } from '@angular/cdk/a11y';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import {
   AfterViewInit,
@@ -27,6 +28,7 @@ import {
   Output,
   Input,
   ElementRef,
+  ViewChild,
 } from '@angular/core';
 import { Subject, takeUntil } from 'rxjs';
 
@@ -52,6 +54,9 @@ export class WattDrawerComponent implements AfterViewInit, OnDestroy {
 
   @Output()
   closed = new EventEmitter<void>();
+
+  @ViewChild(CdkTrapFocus)
+  cdkTrapFocus!: CdkTrapFocus;
 
   /**
    * Is the drawer opened
@@ -87,7 +92,7 @@ export class WattDrawerComponent implements AfterViewInit, OnDestroy {
   }
 
   /** @ignore */
-  @HostListener('window:keydown.escape')
+  @HostListener('keydown.escape')
   onEscKeyPressed() {
     this.close();
   }
@@ -119,6 +124,11 @@ export class WattDrawerComponent implements AfterViewInit, OnDestroy {
    * Opens the drawer. Subsequent calls are ignored while the drawer is opened.
    */
   open() {
+    // Trap focus whenever open is called. This doesn't work on the
+    // initiall call (when first opening the drawer), but this is
+    // handled by the autoFocus property on mat-drawer.
+    this.cdkTrapFocus.focusTrap.focusInitialElementWhenReady();
+
     // Disable click outside check until the current event loop is finished.
     // This might seem hackish, but the order of execution is stable here.
     this.bypassClickCheck = true;

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.ts
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.ts
@@ -125,7 +125,7 @@ export class WattDrawerComponent implements AfterViewInit, OnDestroy {
    */
   open() {
     // Trap focus whenever open is called. This doesn't work on the
-    // initiall call (when first opening the drawer), but this is
+    // initial call (when first opening the drawer), but this is
     // handled by the autoFocus property on mat-drawer.
     this.cdkTrapFocus.focusTrap.focusInitialElementWhenReady();
 

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer.module.ts
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer.module.ts
@@ -24,6 +24,7 @@ import { WattDrawerComponent } from './watt-drawer.component';
 import { WattDrawerTopbarComponent } from './watt-drawer-topbar.component';
 import { WattDrawerActionsComponent } from './watt-drawer-actions.component';
 import { WattDrawerContentComponent } from './watt-drawer-content.component';
+import { A11yModule } from '@angular/cdk/a11y';
 
 @NgModule({
   declarations: [
@@ -39,6 +40,7 @@ import { WattDrawerContentComponent } from './watt-drawer-content.component';
     WattDrawerContentComponent,
   ],
   imports: [
+    A11yModule,
     MatSidenavModule,
     WattButtonModule,
     WattSpinnerModule,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
The global keydown handler for the drawer was being triggered by pressing ESC within a modal, meaning if you were to open a modal within a drawer and then press ESC, both modal and drawer would close. This aims to solve that by making the keydown event scoped to the host element. For that to work though, the drawer must have focus, which is why I had to add a focus trap.
<!--- Please leave a helpful description of the pull request here. --->
