### PR TITLE
feat(dh): move page title to top bar

### DIFF
--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -265,7 +265,7 @@
   "messageArchive": {
     "unknowenError": "Ukendt fejl",
     "search": {
-      "title": "Fremsøg forretningsbesked",
+      "topBarTitle": "Fremsøg forretningsbesked",
       "documenttype": "Dokumenttype",
       "senderId": "Afsender Id",
       "messageId": "Besked Id",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -265,7 +265,7 @@
   "messageArchive": {
     "unknowenError": "Unknowen error",
     "search": {
-      "title": "Search in request and response messages",
+      "topBarTitle": "Search in request and response messages",
       "documenttype": "Document type",
       "senderId": "Sender Id",
       "messageId": "Message Id",

--- a/libs/dh/message-archive/feature-log-search/src/lib/dh-message-archive-log-search.component.html
+++ b/libs/dh/message-archive/feature-log-search/src/lib/dh-message-archive-log-search.component.html
@@ -15,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <ng-container *transloco="let transloco; read: 'messageArchive.search'">
-  <h1>{{ transloco("title") }}</h1>
   <ng-container *rxLet="searching$ as searching">
     <ng-container *rxLet="continuationToken$ as continuationToken">
       <form #searchForm name="log-search-form" (ngSubmit)="onSubmit(searching)">

--- a/libs/dh/message-archive/shell/src/lib/dh-message-archive-shell.module.ts
+++ b/libs/dh/message-archive/shell/src/lib/dh-message-archive-shell.module.ts
@@ -23,7 +23,13 @@ import {
 } from '@energinet-datahub/dh/message-archive/feature-log-search';
 
 const routes: Routes = [
-  { path: '', component: DhMessageArchiveLogSearchComponent },
+  {
+    path: '',
+    component: DhMessageArchiveLogSearchComponent,
+    data: {
+      titleTranslationKey: 'messageArchive.search.topBarTitle',
+    },
+  },
   {
     path: ':logname',
     component: DhMessageArchiveLogSearchBlobContentComponent,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### DataHub
- move page title to top bar on "message-archive" page

#### Before 

![image](https://user-images.githubusercontent.com/1096332/189106153-c3159a00-2871-46e9-ab86-f8ebf1d3a1f0.png)

#### After

![image](https://user-images.githubusercontent.com/1096332/189106308-e0523cc7-0529-4ea8-817c-ee9c5162797f.png)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #816 
