### PR TITLE
feat(dh): move title for Start process page to top bar

### DIFF
--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -518,8 +518,8 @@
   },
   "wholesale": {
     "startProcess": {
+      "topBarTitle": "Start proces",
       "startLabel": "Start",
-      "header": "Start proces",
       "processDescription": "Kør en balance fiksering for 1. juli 2022 for netområde 805 & 806."
     },
     "overview": {

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -518,8 +518,8 @@
   },
   "wholesale": {
     "startProcess": {
+      "topBarTitle": "Start Process",
       "startLabel": "Start",
-      "header": "Start Process",
       "processDescription": "Start a balance fixing for July 1, 2022 for grid areas 805 & 806."
     },
     "overview": {

--- a/libs/dh/wholesale/feature-start/src/lib/dh-wholesale-start.component.html
+++ b/libs/dh/wholesale/feature-start/src/lib/dh-wholesale-start.component.html
@@ -16,7 +16,6 @@ limitations under the License.
 -->
 <ng-container *dhFeatureFlag="'start_wholesale_process_feature_flag'">
   <ng-container *transloco="let transloco; read: 'wholesale'">
-    <h1>{{ transloco("startProcess.header") }}</h1>
     <p>{{ transloco("startProcess.processDescription") }}</p>
     <watt-button (click)="createBatch()"
       >{{ transloco("startProcess.startLabel") }}

--- a/libs/dh/wholesale/shell/src/lib/dh-wholesale-shell.module.ts
+++ b/libs/dh/wholesale/shell/src/lib/dh-wholesale-shell.module.ts
@@ -31,6 +31,9 @@ const routes: Routes = [
   {
     path: 'start-process',
     component: DhWholesaleStartComponent,
+    data: {
+      titleTranslationKey: 'wholesale.startProcess.topBarTitle',
+    },
   },
   {
     path: 'overview',


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### DataHub
- move title for Start process page in top bar

#### Before

![image](https://user-images.githubusercontent.com/1096332/189135912-e3e06a04-023a-421e-bf5a-d1e65722c086.png)

#### After

![image](https://user-images.githubusercontent.com/1096332/189135995-bf362743-82d4-4e12-b3c3-e94da67a0f69.png)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #816
