### PR TITLE
fix(ui-watt): increase drawer z-index

### DIFF
--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.3.53
+version: 0.3.54

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.53
+    tag: 0.3.54

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.scss
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.scss
@@ -25,6 +25,12 @@
   right: 0;
   top: 0;
   width: auto;
+
+  // Most material components does not have a z-index exceeding 100,
+  // except for modals which has a value of 1000. Since the drawer
+  // needs to stay on top of all content except modals, the value
+  // of 500 was chosen here which hopefully will remain stable.
+  z-index: 500;
 }
 
 .watt-drawer {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
Very simple PR, just increases the z-index of the drawer component to ensure it stays above tables with sticky headers (while still below modals).

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #845
