### PR TITLE
fix(dh): set import path explicitly

### DIFF
--- a/tools/generators/dh-library-generator/index.ts
+++ b/tools/generators/dh-library-generator/index.ts
@@ -115,6 +115,7 @@ export default async function (tree: Tree, schema: DhLibrarySchema) {
     // https://github.com/nrwl/nx/pull/10167#issuecomment-1126146451
     await angularMoveGenerator(tree, {
       updateImportPath: true,
+      importPath: `@energinet-datahub/dh/${libDomain}/routing`,
       projectName: `dh-${libDomain}-routing-tmpl`,
       destination: `dh/${libDomain}/routing`,
     });


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
When using the `dh-library-generator` to make routing libs, the import paths in `tsconfig.base.json` was incorrectly being generated with dashes (`-`) as separators instead of slashes (`/`).

Before it would generate something like this:
```json
"@energinet-datahub/dh-charges-routing"
```

Now it correctly generates:
```json
"@energinet-datahub/dh/charges/routing"
```
