### PR TITLE
feat(watt): support placing content on the same line as action buttons

### DIFF
--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.3.81
+version: 0.3.82

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.81
+    tag: 0.3.82

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer-actions.component.scss
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer-actions.component.scss
@@ -17,6 +17,7 @@
 :host {
   display: flex;
   justify-content: flex-end;
-  margin: var(--watt-space-m) 0;
   gap: var(--watt-space-m);
+  margin-bottom: var(--watt-space-m);
+  margin-left: var(--watt-space-m);
 }

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer-topbar.component.scss
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer-topbar.component.scss
@@ -20,6 +20,7 @@
   border-bottom: 1px solid var(--watt-color-neutral-grey-300);
   display: flex;
   gap: var(--watt-space-s);
+  margin-bottom: var(--watt-space-m);
   padding-bottom: var(--watt-space-s);
   position: sticky;
   top: 0;

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.html
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.html
@@ -27,10 +27,12 @@ limitations under the License.
     <div class="watt-drawer__grid-container">
       <header>
         <ng-content select="watt-drawer-topbar"></ng-content>
-        <ng-content select="watt-drawer-actions"></ng-content>
       </header>
 
       <article class="watt-drawer__content">
+        <div class="watt-drawer__actions">
+          <ng-content select="watt-drawer-actions"></ng-content>
+        </div>
         <ng-content select="watt-drawer-content"></ng-content>
       </article>
     </div>

--- a/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.scss
+++ b/libs/ui-watt/src/lib/components/drawer/watt-drawer.component.scss
@@ -44,6 +44,17 @@
 
   &--small {
     width: 460px;
+
+    .watt-drawer__actions {
+      margin-bottom: var(--watt-space-m);
+    }
+  }
+
+  &--normal,
+  &--large {
+    .watt-drawer__actions {
+      float: right;
+    }
   }
 
   &--normal {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### Watt Design System
- allow placing content on the same line* as action buttons in drawer component

![image](https://user-images.githubusercontent.com/1096332/193766872-39386f2c-b9ac-404f-bea9-a71a7fd824b7.png)

\* only works for sizes `normal` and `large`. Size `small` will render the action buttons and content as stacked. 

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #874
