### PR TITLE
feat: run yarn install on post-merge

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,6 @@
+if git diff --name-only | grep --quiet "yarn.lock"
+then
+  echo "Yarn.lock has changed, updating local dependencies"
+  yarn install
+  exit 0
+fi

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "energinet-datahub",
+  "private": "true",
   "version": "0.0.0",
   "license": "MIT",
   "//engines-comment": "Keep this in sync with '.nvmrc', and 'volta' config at the bottom of this file.",
@@ -9,7 +10,7 @@
     "yarn": "1.22.19"
   },
   "scripts": {
-    "postinstall": "npm run postinstall:nx && npm run postinstall:ngcc",
+    "postinstall": "npm run postinstall:nx && npm run postinstall:ngcc && git config --local core.hooksPath .githooks",
     "postinstall:ngcc": "npm run ngcc",
     "jest-preview": "jest-preview",
     "postinstall:nx": "node ./decorate-angular-cli.js",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This is an experimental PR for automatically triggering a yarn install after pulling IF yarn.lock has changed.

<!--- Please leave a helpful description of the pull request here. --->
