### PR TITLE
feat(ui-watt): Add output changes to tabs

### DIFF
--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.3.100
+version: 0.3.101

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.100
+    tag: 0.3.101

--- a/libs/ui-watt/src/lib/components/tabs/tab/tab.component.ts
+++ b/libs/ui-watt/src/lib/components/tabs/tab/tab.component.ts
@@ -31,7 +31,7 @@ export class WattTabComponent {
   @Input() label = '';
   @ViewChild('templateRef') public templateRef: TemplateRef<unknown> | null =
     null;
-  @Output() changed = new EventEmitter();
+  @Output() changed = new EventEmitter<void>();
 
   emitChange() {
     this.changed.emit();

--- a/libs/ui-watt/src/lib/components/tabs/tab/tab.component.ts
+++ b/libs/ui-watt/src/lib/components/tabs/tab/tab.component.ts
@@ -14,7 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  TemplateRef,
+  ViewChild,
+} from '@angular/core';
 
 @Component({
   selector: 'watt-tab',
@@ -24,4 +31,9 @@ export class WattTabComponent {
   @Input() label = '';
   @ViewChild('templateRef') public templateRef: TemplateRef<unknown> | null =
     null;
+  @Output() changed = new EventEmitter();
+
+  emitChange() {
+    this.changed.emit();
+  }
 }

--- a/libs/ui-watt/src/lib/components/tabs/tabs.component.html
+++ b/libs/ui-watt/src/lib/components/tabs/tabs.component.html
@@ -14,7 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<mat-tab-group dynamicHeight>
+<mat-tab-group
+  dynamicHeight
+  (selectedIndexChange)="emitSelectedTabChange($event)"
+>
   <mat-tab [label]="tab.label" *ngFor="let tab of tabElements">
     <ng-container *ngTemplateOutlet="tab.templateRef"></ng-container>
   </mat-tab>

--- a/libs/ui-watt/src/lib/components/tabs/tabs.component.ts
+++ b/libs/ui-watt/src/lib/components/tabs/tabs.component.ts
@@ -39,4 +39,17 @@ export class WattTabsComponent {
    */
   @ContentChildren(WattTabComponent)
   public readonly tabElements: QueryList<WattTabComponent> = new QueryList<WattTabComponent>();
+  activeTabIndex = 0;
+
+  emitSelectedTabChange(selectedIndex: number) {
+    this.activeTabIndex = selectedIndex;
+    const currentTab = this.tabElements.find(
+      (tab, index) => index === selectedIndex
+    );
+    currentTab?.emitChange();
+  }
+
+  triggerChange() {
+    this.emitSelectedTabChange(this.activeTabIndex);
+  }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

This is needed for the charge drawer, which has tabs. 
We want to know whenever a tab has been selected, so we can load the data inside that tab. 
We would also like to know which tab is currently active when the drawer is open, to load the correct data.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
