### PR TITLE
Show Organizations/GridAreas in B002.

### DIFF
--- a/libs/dh/shared/feature-flags/src/lib/feature-flags.ts
+++ b/libs/dh/shared/feature-flags/src/lib/feature-flags.ts
@@ -61,7 +61,6 @@ export const dhFeatureFlagsConfig = makeFeatureFlags({
     created: '21-10-2022',
     disabledEnvironments: [
       DhAppEnvironment.experimental,
-      DhAppEnvironment.prod,
     ],
   },
 });


### PR DESCRIPTION
Organizations/GridAreas should now be visible in B002.
