### PR TITLE
feat: Download icon is (only) visible (or enabled) when the batch is complete

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -35,7 +35,7 @@ limitations under the License.
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Wholesale.Client" Version="2.1.0" />
+    <PackageReference Include="Energinet.DataHub.Wholesale.Client" Version="2.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Energinet.DataHub.Charges.Clients" Version="4.1.1" />
     <PackageReference Include="Energinet.DataHub.Charges.Clients.Registration" Version="4.1.1" />

--- a/libs/dh/shared/data-access-msw/src/lib/mocks/wholesale.ts
+++ b/libs/dh/shared/data-access-msw/src/lib/mocks/wholesale.ts
@@ -41,6 +41,7 @@ function getWholesaleSearchBatch(apiBase: string) {
       executionTimeStart,
       executionTimeEnd: null,
       executionState: BatchState.Pending,
+      isBasisDataDownloadAvailable: false,
     },
     {
       batchNumber: '234',
@@ -49,6 +50,7 @@ function getWholesaleSearchBatch(apiBase: string) {
       executionTimeStart,
       executionTimeEnd: null,
       executionState: BatchState.Executing,
+      isBasisDataDownloadAvailable: false,
     },
     {
       batchNumber: '345',
@@ -57,6 +59,7 @@ function getWholesaleSearchBatch(apiBase: string) {
       executionTimeStart,
       executionTimeEnd,
       executionState: BatchState.Completed,
+      isBasisDataDownloadAvailable: true,
     },
     {
       batchNumber: '567',
@@ -65,6 +68,7 @@ function getWholesaleSearchBatch(apiBase: string) {
       executionTimeStart,
       executionTimeEnd,
       executionState: BatchState.Failed,
+      isBasisDataDownloadAvailable: false,
     },
     {
       batchNumber: '123',
@@ -73,6 +77,7 @@ function getWholesaleSearchBatch(apiBase: string) {
       executionTimeStart,
       executionTimeEnd: null,
       executionState: BatchState.Pending,
+      isBasisDataDownloadAvailable: false,
     },
     {
       batchNumber: '234',
@@ -81,6 +86,7 @@ function getWholesaleSearchBatch(apiBase: string) {
       executionTimeStart,
       executionTimeEnd: null,
       executionState: BatchState.Executing,
+      isBasisDataDownloadAvailable: false,
     },
     {
       batchNumber: '345',
@@ -89,6 +95,7 @@ function getWholesaleSearchBatch(apiBase: string) {
       executionTimeStart,
       executionTimeEnd,
       executionState: BatchState.Completed,
+      isBasisDataDownloadAvailable: true,
     },
     {
       batchNumber: '567',
@@ -97,6 +104,7 @@ function getWholesaleSearchBatch(apiBase: string) {
       executionTimeStart,
       executionTimeEnd,
       executionState: BatchState.Failed,
+      isBasisDataDownloadAvailable: false,
     },
     {
       batchNumber: '123',
@@ -105,6 +113,7 @@ function getWholesaleSearchBatch(apiBase: string) {
       executionTimeStart,
       executionTimeEnd: null,
       executionState: BatchState.Pending,
+      isBasisDataDownloadAvailable: false,
     },
     {
       batchNumber: '234',
@@ -113,6 +122,7 @@ function getWholesaleSearchBatch(apiBase: string) {
       executionTimeStart,
       executionTimeEnd: null,
       executionState: BatchState.Executing,
+      isBasisDataDownloadAvailable: false,
     },
     {
       batchNumber: '345',
@@ -121,6 +131,7 @@ function getWholesaleSearchBatch(apiBase: string) {
       executionTimeStart,
       executionTimeEnd,
       executionState: BatchState.Completed,
+      isBasisDataDownloadAvailable: true,
     },
     {
       batchNumber: '567',
@@ -129,6 +140,7 @@ function getWholesaleSearchBatch(apiBase: string) {
       executionTimeStart,
       executionTimeEnd,
       executionState: BatchState.Failed,
+      isBasisDataDownloadAvailable: false,
     },
   ];
   return rest.post(`${apiBase}/v1/WholesaleBatch/search`, (req, res, ctx) => {

--- a/libs/dh/shared/domain/src/lib/generated/v1/model/batch-dto-v2.ts
+++ b/libs/dh/shared/domain/src/lib/generated/v1/model/batch-dto-v2.ts
@@ -19,6 +19,7 @@ export interface BatchDtoV2 {
     executionTimeStart?: string | null;
     executionTimeEnd?: string | null;
     executionState: BatchState;
+    isBasisDataDownloadAvailable: boolean;
 }
 
 

--- a/libs/dh/wholesale/feature-search/src/lib/table/dh-wholesale-table.component.html
+++ b/libs/dh/wholesale/feature-search/src/lib/table/dh-wholesale-table.component.html
@@ -90,6 +90,7 @@ limitations under the License.
           title="{{ transloco('download') }}"
           icon="download"
           (click)="onDownload(batch.batchNumber)"
+          (disabled)="!batch.isBasisDataDownloadAvailable"
         >
         </watt-button>
       </mat-cell>

--- a/libs/dh/wholesale/feature-search/src/lib/table/dh-wholesale-table.component.html
+++ b/libs/dh/wholesale/feature-search/src/lib/table/dh-wholesale-table.component.html
@@ -90,7 +90,7 @@ limitations under the License.
           title="{{ transloco('download') }}"
           icon="download"
           (click)="onDownload(batch)"
-          (disabled)="(!batch.isBasisDataDownloadAvailable)"
+          [disabled]="!batch.isBasisDataDownloadAvailable"
         >
         </watt-button>
       </mat-cell>

--- a/libs/dh/wholesale/feature-search/src/lib/table/dh-wholesale-table.component.html
+++ b/libs/dh/wholesale/feature-search/src/lib/table/dh-wholesale-table.component.html
@@ -90,7 +90,7 @@ limitations under the License.
           title="{{ transloco('download') }}"
           icon="download"
           (click)="onDownload(batch.batchNumber)"
-          (disabled)="!batch.isBasisDataDownloadAvailable"
+          (disabled)="(!batch.isBasisDataDownloadAvailable)"
         >
         </watt-button>
       </mat-cell>

--- a/libs/dh/wholesale/feature-search/src/lib/table/dh-wholesale-table.component.ts
+++ b/libs/dh/wholesale/feature-search/src/lib/table/dh-wholesale-table.component.ts
@@ -43,6 +43,7 @@ type wholesaleTableData = MatTableDataSource<{
   executionTimeStart?: string | null;
   executionTimeEnd?: string | null;
   executionState: BatchState;
+  isBasisDataDownloadAvailable: boolean;
 }>;
 
 @Component({


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Disable download basis data icon when data is not available
![image](https://user-images.githubusercontent.com/39729843/198221741-f71c4cc7-0396-4f03-b925-f0569579cb59.png)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#17](https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/energinet-datahub/opengeh-wholesale/17)
