### PR TITLE
fix(ui-watt): wrong path in watt component generator

### DIFF
--- a/tools/generators/watt-component/index.ts
+++ b/tools/generators/watt-component/index.ts
@@ -38,9 +38,7 @@ export default async function (host: Tree, schema: { name: string }) {
   updateJson(host, './tsconfig.base.json', (json) => {
     json.compilerOptions.paths[
       `@energinet-datahub/watt/${substitutions.fileName}`
-    ] = [
-      `libs/ui-watt/src/lib/components/${substitutions.fileName}/src/index.ts`,
-    ];
+    ] = [`libs/ui-watt/src/lib/components/${substitutions.fileName}/index.ts`];
     return json;
   });
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

The generated path in tsconfig.base.json pointed to a src folder that doesn't exist.

<!--- Please leave a helpful description of the pull request here. --->
