### PR TITLE
fix: Drawer closes on downloading message

### DIFF
--- a/libs/dh/charges/feature-prices/src/lib/drawer/charge-message/dh-charge-price-message.component.html
+++ b/libs/dh/charges/feature-prices/src/lib/drawer/charge-message/dh-charge-price-message.component.html
@@ -44,7 +44,7 @@ limitations under the License.
       class="download-button"
       icon="openInNew"
       variant="text"
-      (click)="downloadLog($event)"
+      (click)="downloadLog()"
     >
       {{ t("prices.Download") }}
     </watt-button>

--- a/libs/dh/charges/feature-prices/src/lib/drawer/charge-message/dh-charge-price-message.component.ts
+++ b/libs/dh/charges/feature-prices/src/lib/drawer/charge-message/dh-charge-price-message.component.ts
@@ -136,7 +136,6 @@ export class DhChargePriceMessageComponent implements OnInit, OnDestroy {
     this.dhChargesPricesDrawerService.removeMessage();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   downloadLog() {
     if (this.message == undefined) return;
     const logName = this.findLogName(this.message.blobContentUri);

--- a/libs/dh/charges/feature-prices/src/lib/drawer/charge-message/dh-charge-price-message.component.ts
+++ b/libs/dh/charges/feature-prices/src/lib/drawer/charge-message/dh-charge-price-message.component.ts
@@ -137,8 +137,7 @@ export class DhChargePriceMessageComponent implements OnInit, OnDestroy {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  downloadLog(event: any) {
-    event.stopPropagation();
+  downloadLog() {
     if (this.message == undefined) return;
     const logName = this.findLogName(this.message.blobContentUri);
     this.blobStore.downloadLogFile(logName);

--- a/libs/dh/message-archive/data-access-api/src/lib/dh-message-archive-data-access-api-blob.store.ts
+++ b/libs/dh/message-archive/data-access-api/src/lib/dh-message-archive-data-access-api-blob.store.ts
@@ -101,6 +101,9 @@ export class DhMessageArchiveDataAccessBlobApiStore extends ComponentStore<Downl
         downloadLink.href = window.URL.createObjectURL(
           new Blob(binaryData, { type: dataType })
         );
+        downloadLink.onclick = function (event) {
+          event.stopPropagation();
+        };
         if (logName) downloadLink.setAttribute('download', logName);
         document.body.appendChild(downloadLink);
         downloadLink.click();


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

When clicking on the download button in Charge Message, the drawer closes. It should stay open.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
