### PR TITLE
Update: `Charges.Clients` and `Charges.Clients.Registration` to latest v `6.0.0`

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/Controllers/ChargesControllerTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/Controllers/ChargesControllerTests.cs
@@ -14,6 +14,7 @@
 
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Energinet.DataHub.Charges.Clients.Charges;
 using Energinet.DataHub.Charges.Contracts.Charge;
@@ -28,24 +29,29 @@ namespace Energinet.DataHub.WebApi.Tests.Integration.Controllers
 {
     public class ChargesControllerTests : ControllerTestsBase<IChargesClient>
     {
-        public ChargesControllerTests(BffWebApiFixture bffWebApiFixture, WebApiFactory factory, ITestOutputHelper testOutputHelper)
+        public ChargesControllerTests(
+            BffWebApiFixture bffWebApiFixture,
+            WebApiFactory factory,
+            ITestOutputHelper testOutputHelper)
             : base(bffWebApiFixture, factory, testOutputHelper)
         {
         }
 
         [Theory]
         [InlineAutoMoqData]
-        public async Task GetChargesAsync_WhenMeteringPointIdHasChargeLinks_ReturnsOk(List<ChargeV1Dto> list)
+        public async Task SearchAsync_WhenChargesExists_ReturnsOk(
+            List<ChargeV1Dto> data,
+            ChargeSearchCriteriaV1Dto searchCriteriaV1Dto)
         {
             // Arrange
-            var requestUrl = $"/v1/Charges";
+            var requestUrl = $"/v1/Charges/SearchAsync";
 
             DomainClientMock
-                .Setup(m => m.GetChargesAsync())
-                .ReturnsAsync(list);
+                .Setup(m => m.SearchChargesAsync(It.IsAny<ChargeSearchCriteriaV1Dto>()))
+                .ReturnsAsync(data);
 
             // Act
-            var actual = await BffClient.GetAsync(requestUrl);
+            var actual = await BffClient.PostAsJsonAsync(requestUrl, searchCriteriaV1Dto);
 
             // Assert
             actual.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/ChargesController.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/ChargesController.cs
@@ -34,14 +34,6 @@ namespace Energinet.DataHub.WebApi.Controllers
             _chargesClient = chargesClient;
         }
 
-        [HttpGet]
-        public async Task<ActionResult<IList<ChargeV1Dto>>> GetAsync()
-        {
-            var result = await _chargesClient.GetChargesAsync();
-
-            return result.Any() ? Ok(result) : NotFound();
-        }
-
         [HttpPost("SearchAsync")]
         public async Task<ActionResult<IList<ChargeV1Dto>>> SearchAsync([FromBody] ChargeSearchCriteriaV1Dto searchCriteria)
         {

--- a/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -37,8 +37,8 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Wholesale.Client" Version="2.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
-    <PackageReference Include="Energinet.DataHub.Charges.Clients" Version="5.0.1" />
-    <PackageReference Include="Energinet.DataHub.Charges.Clients.Registration" Version="5.0.1" />
+    <PackageReference Include="Energinet.DataHub.Charges.Clients" Version="6.0.0" />
+    <PackageReference Include="Energinet.DataHub.Charges.Clients.Registration" Version="6.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.Common.Security" Version="7.1.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="7.1.0" />
     <PackageReference Include="Energinet.DataHub.MarketParticipant.Client" Version="2.7.3" />

--- a/libs/dh/shared/domain/src/lib/generated/v1/api/charges-http.service.ts
+++ b/libs/dh/shared/domain/src/lib/generated/v1/api/charges-http.service.ts
@@ -107,68 +107,6 @@ export class ChargesHttp {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public v1ChargesGet(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<Array<ChargeV1Dto>>;
-    public v1ChargesGet(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<Array<ChargeV1Dto>>>;
-    public v1ChargesGet(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<Array<ChargeV1Dto>>>;
-    public v1ChargesGet(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any> {
-
-        let localVarHeaders = this.defaultHeaders;
-
-        let localVarCredential: string | undefined;
-        // authentication (Bearer) required
-        localVarCredential = this.configuration.lookupCredential('Bearer');
-        if (localVarCredential) {
-            localVarHeaders = localVarHeaders.set('Authorization', 'Bearer ' + localVarCredential);
-        }
-
-        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
-        if (localVarHttpHeaderAcceptSelected === undefined) {
-            // to determine the Accept header
-            const httpHeaderAccepts: string[] = [
-                'text/plain',
-                'application/json',
-                'text/json'
-            ];
-            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
-        }
-        if (localVarHttpHeaderAcceptSelected !== undefined) {
-            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
-        }
-
-        let localVarHttpContext: HttpContext | undefined = options && options.context;
-        if (localVarHttpContext === undefined) {
-            localVarHttpContext = new HttpContext();
-        }
-
-
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
-        if (localVarHttpHeaderAcceptSelected) {
-            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
-                responseType_ = 'text';
-            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
-                responseType_ = 'json';
-            } else {
-                responseType_ = 'blob';
-            }
-        }
-
-        let localVarPath = `/v1/Charges`;
-        return this.httpClient.request<Array<ChargeV1Dto>>('get', `${this.configuration.basePath}${localVarPath}`,
-            {
-                context: localVarHttpContext,
-                responseType: <any>responseType_,
-                withCredentials: this.configuration.withCredentials,
-                headers: localVarHeaders,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
-    }
-
-    /**
-     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
-     * @param reportProgress flag to report request and response progress.
-     */
     public v1ChargesGetMarketParticipantsAsyncGet(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<Array<MarketParticipantV1Dto>>;
     public v1ChargesGetMarketParticipantsAsyncGet(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<Array<MarketParticipantV1Dto>>>;
     public v1ChargesGetMarketParticipantsAsyncGet(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<Array<MarketParticipantV1Dto>>>;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This PR bumps below packages to v. 6.0.0

* Energinet.DataHub.Charges.Clients
* Energinet.DataHub.Charges.Clients.Registration

This PR also removes the BFF's ChargeController method `GetAsync()`. Which is no longer used by frontend, nor supported by backend.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/geh-charges/issues/1799
