### PR TITLE
feat(ui-watt): grid layout in shell

### DIFF
--- a/libs/ui-watt/src/lib/components/shell/shell.component.html
+++ b/libs/ui-watt/src/lib/components/shell/shell.component.html
@@ -37,7 +37,7 @@ limitations under the License.
     </div>
   </mat-sidenav>
 
-  <mat-sidenav-content>
+  <mat-sidenav-content class="watt-sidenav-content">
     <mat-toolbar class="watt-toolbar">
       <watt-button
         *ngIf="isHandset$ | async"

--- a/libs/ui-watt/src/lib/components/shell/shell.component.scss
+++ b/libs/ui-watt/src/lib/components/shell/shell.component.scss
@@ -68,7 +68,13 @@
   }
 }
 
+.watt-sidenav-content {
+  display: grid;
+  grid-template-rows: max-content max-content minmax(20rem, auto);
+}
+
 .watt-toolbar {
+  grid-row: 1;
   background-color: var(--watt-color-neutral-white);
   border-bottom: 1px solid var(--watt-color-neutral-grey-300);
   box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.08);
@@ -76,6 +82,7 @@
 }
 
 .watt-main-content {
+  grid-row: 3;
   @include watt.space-inset-m;
 
   @include watt.media(">Large") {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This PR makes the sidenav-content area use CSS grid for layout, enabling the outlet components to take up the remaining space of the viewport.

<!--- Please leave a helpful description of the pull request here. --->


<!--- Are there any issues, pull requests or similar that should be linked here? --->
