### PR TITLE
feat(ui-watt): watt-table accessor config

### DIFF
--- a/libs/dh/charges/feature-prices/src/lib/drawer/charge-content/message-tab/dh-charges-charge-messages-tab.component.html
+++ b/libs/dh/charges/feature-prices/src/lib/drawer/charge-content/message-tab/dh-charges-charge-messages-tab.component.html
@@ -50,6 +50,7 @@ limitations under the License.
       [columns]="columns"
       sortBy="messageDateTime"
       sortDirection="desc"
+      [resolveHeader]="translateHeader"
       [sortClear]="false"
       (rowClick)="rowClicked($event)"
       (sortChange)="sortData($event)"

--- a/libs/dh/charges/feature-prices/src/lib/drawer/charge-content/message-tab/dh-charges-charge-messages-tab.component.ts
+++ b/libs/dh/charges/feature-prices/src/lib/drawer/charge-content/message-tab/dh-charges-charge-messages-tab.component.ts
@@ -115,24 +115,18 @@ export class DhChargesChargeMessagesTabComponent
   totalCount = this.chargeMessagesStore.totalCount$;
 
   columns: WattTableColumnDef<ChargeMessageV1Dto> = {
-    messageId: {
-      header: () => this.transloco.translate('charges.prices.drawer.messageId'),
-    },
-    messageDateTime: {
-      header: () => this.transloco.translate('charges.prices.drawer.date'),
-      size: 'max-content',
-    },
-    messageType: {
-      header: () =>
-        this.transloco.translate('charges.prices.drawer.messageType'),
-      size: 'max-content',
-    },
+    messageId: { accessor: 'messageId' },
+    date: { accessor: 'messageDateTime', size: 'max-content' },
+    messageType: { accessor: 'messageType', size: 'max-content' },
   };
 
   private destroy$ = new Subject<void>();
 
   readonly dataSource: WattTableDataSource<ChargeMessageV1Dto> =
     new WattTableDataSource<ChargeMessageV1Dto>();
+
+  translateHeader = (key: string) =>
+    this.transloco.translate(`charges.prices.drawer.${key}`);
 
   ngOnInit() {
     this.chargeMessagesStore.all$

--- a/libs/dh/charges/feature-prices/src/lib/drawer/charge-content/price-tab/dh-charges-charge-prices-tab.component.html
+++ b/libs/dh/charges/feature-prices/src/lib/drawer/charge-content/price-tab/dh-charges-charge-prices-tab.component.html
@@ -56,6 +56,7 @@ limitations under the License.
         [columns]="columns"
         [displayedColumns]="displayedColumns"
         [dataSource]="dataSource"
+        [resolveHeader]="translateHeader"
         sortBy="fromDateTime"
         sortDirection="asc"
         [sortClear]="false"

--- a/libs/dh/charges/feature-prices/src/lib/drawer/charge-content/price-tab/dh-charges-charge-prices-tab.component.ts
+++ b/libs/dh/charges/feature-prices/src/lib/drawer/charge-content/price-tab/dh-charges-charge-prices-tab.component.ts
@@ -120,31 +120,21 @@ export class DhChargesChargePricesTabComponent
 
   displayedColumns = ['fromDateTime', 'time', 'price'];
   columns: WattTableColumnDef<ChargePriceV1Dto> = {
-    fromDateTime: {
-      header: () =>
-        this.transloco.translate('charges.prices.priceTab.fromDateTime'),
-      size: 'max-content',
-    },
-    time: {
-      header: () => this.transloco.translate('charges.prices.priceTab.time'),
-      sort: false,
-    },
-    toDateTime: {
-      header: () =>
-        this.transloco.translate('charges.prices.priceTab.toDateTime'),
-      sort: false,
-    },
-    price: {
-      header: () => this.transloco.translate('charges.prices.price'),
-      align: 'right',
-      size: 'max-content',
-    },
+    fromDateTime: { accessor: 'fromDateTime', size: 'max-content' },
+    time: { accessor: null },
+    toDateTime: { accessor: 'toDateTime', sort: false },
+    price: { accessor: 'price', align: 'right', size: 'max-content' },
   };
 
   private destroy$ = new Subject<void>();
 
   readonly dataSource: WattTableDataSource<ChargePriceV1Dto> =
     new WattTableDataSource<ChargePriceV1Dto>();
+
+  translateHeader = (key: string) =>
+    key === 'price'
+      ? this.transloco.translate('charges.prices.price')
+      : this.transloco.translate(`charges.prices.priceTab.${key}`);
 
   ngOnInit() {
     this.chargePricesStore.all$

--- a/libs/dh/charges/feature-prices/src/lib/search-result/dh-charges-prices-result.component.html
+++ b/libs/dh/charges/feature-prices/src/lib/search-result/dh-charges-prices-result.component.html
@@ -52,6 +52,7 @@ limitations under the License.
       [dataSource]="dataSource"
       sortBy="chargeId"
       sortDirection="asc"
+      [resolveHeader]="t"
       [sortClear]="false"
       [activeRow]="activeCharge"
       (rowClick)="rowClicked($event)"

--- a/libs/dh/charges/feature-prices/src/lib/search-result/dh-charges-prices-result.component.ts
+++ b/libs/dh/charges/feature-prices/src/lib/search-result/dh-charges-prices-result.component.ts
@@ -86,26 +86,31 @@ export class DhChargesPricesResultComponent
 
   /* eslint-disable sonarjs/no-duplicate-string */
   columns: WattTableColumnDef<ChargeV1Dto> = {
-    chargeId: { header: this.formatHeader, size: 'max-content' },
-    chargeName: { header: this.formatHeader },
-    chargeOwnerName: { header: this.formatHeader },
-    icons: { header: '-', size: 'max-content', sort: false, align: 'center' },
+    chargeId: { accessor: 'chargeId', size: 'max-content' },
+    chargeName: { accessor: 'chargeName' },
+    chargeOwnerName: { accessor: 'chargeOwnerName' },
+    icons: {
+      accessor: null,
+      header: '-',
+      size: 'max-content',
+      align: 'center',
+    },
     chargeType: {
-      header: this.formatHeader,
+      accessor: 'chargeType',
       cell: (row) =>
         this.translocoService.translate('charges.chargeType.' + row.chargeType),
       size: 'max-content',
     },
     resolution: {
-      header: this.formatHeader,
+      accessor: 'resolution',
       cell: (row) =>
         this.translocoService.translate(
           'charges.resolutionType.' + row.resolution
         ),
       size: 'max-content',
     },
-    validFromDateTime: { header: this.formatHeader, size: 'max-content' },
-    validToDateTime: { header: this.formatHeader, size: 'max-content' },
+    validFromDateTime: { accessor: 'validFromDateTime', size: 'max-content' },
+    validToDateTime: { accessor: 'validToDateTime', size: 'max-content' },
   };
 
   readonly dataSource = new WattTableDataSource<ChargeV1Dto>();

--- a/libs/ui-watt/src/lib/components/table/+storybook/watt-table.stories.ts
+++ b/libs/ui-watt/src/lib/components/table/+storybook/watt-table.stories.ts
@@ -122,9 +122,9 @@ Table.args = {
   selectable: true,
   suppressRowHoverHighlight: false,
   columns: {
-    position: { data: 'position', header: 'Position', size: 'min-content' },
-    name: { data: 'name', header: 'Name' },
-    symbol: { data: 'symbol', header: 'Symbol', sort: false },
+    position: { accessor: 'position', size: 'min-content' },
+    name: { accessor: 'name' },
+    symbol: { accessor: 'symbol', sort: false },
   } as WattTableColumnDef<PeriodicElement>,
   dataSource: new WattTableDataSource(periodicElements),
   activeRow: undefined,

--- a/libs/ui-watt/src/lib/components/table/+storybook/watt-table.stories.ts
+++ b/libs/ui-watt/src/lib/components/table/+storybook/watt-table.stories.ts
@@ -122,9 +122,9 @@ Table.args = {
   selectable: true,
   suppressRowHoverHighlight: false,
   columns: {
-    position: { header: 'Position', size: 'min-content' },
-    name: { header: 'Name' },
-    symbol: { header: 'Symbol', sort: false },
+    position: { data: 'position', header: 'Position', size: 'min-content' },
+    name: { data: 'name', header: 'Name' },
+    symbol: { data: 'symbol', header: 'Symbol', sort: false },
   } as WattTableColumnDef<PeriodicElement>,
   dataSource: new WattTableDataSource(periodicElements),
   activeRow: undefined,

--- a/libs/ui-watt/src/lib/components/table/watt-table.component.html
+++ b/libs/ui-watt/src/lib/components/table/watt-table.component.html
@@ -17,6 +17,7 @@ limitations under the License.
 <table
   mat-table
   matSort
+  role="treegrid"
   [matSortActive]="sortBy"
   [matSortDirection]="sortDirection"
   [matSortDisableClear]="!sortClear"
@@ -78,6 +79,7 @@ limitations under the License.
   <tr
     mat-row
     *matRowDef="let row; columns: _getColumns()"
+    [attr.aria-selected]="row === activeRow"
     (click)="rowClick.emit(row)"
     [ngClass]="{
       'watt-table-highlight-row': !suppressRowHoverHighlight,

--- a/libs/ui-watt/src/lib/components/table/watt-table.component.html
+++ b/libs/ui-watt/src/lib/components/table/watt-table.component.html
@@ -49,10 +49,12 @@ limitations under the License.
       *matHeaderCellDef
       mat-sort-header
       [arrowPosition]="column.value.align === 'right' ? 'before' : 'after'"
-      [disabled]="column.value.sort === false"
+      [disabled]="!column.value.accessor || column.value.sort === false"
       class="watt-table-align-{{ column.value.align ?? 'left' }}"
     >
-      <div class="watt-table-header-cell">{{ _getColumnHeader(column) }}</div>
+      <div class="watt-table-header-cell">
+        {{ _getColumnHeader(column) }}
+      </div>
     </th>
     <td
       mat-cell

--- a/libs/ui-watt/src/lib/components/table/watt-table.component.spec.ts
+++ b/libs/ui-watt/src/lib/components/table/watt-table.component.spec.ts
@@ -70,10 +70,10 @@ describe(WattTableComponent.name, () => {
   it('renders all rows and columns from dataSource', async () => {
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position' },
-      name: { header: 'Name' },
-      weight: { header: 'Weight' },
-      symbol: { header: 'Symbol' },
+      position: { accessor: 'position' },
+      name: { accessor: 'name' },
+      weight: { accessor: 'weight' },
+      symbol: { accessor: 'symbol' },
     };
 
     await setup({ dataSource, columns });
@@ -85,8 +85,8 @@ describe(WattTableComponent.name, () => {
   it('only renders columns as provided in input', async () => {
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position' },
-      name: { header: 'Name' },
+      position: { accessor: 'position' },
+      name: { accessor: 'name' },
     };
 
     await setup({ dataSource, columns });
@@ -97,8 +97,8 @@ describe(WattTableComponent.name, () => {
   it('renders headers with strings provided in columns', async () => {
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position' },
-      name: { header: 'Element' },
+      position: { accessor: 'position' },
+      name: { accessor: 'name', header: 'Element' },
     };
 
     await setup({ dataSource, columns });
@@ -107,21 +107,10 @@ describe(WattTableComponent.name, () => {
     expect(screen.getByText('Element')).toBeInTheDocument();
   });
 
-  it('renders headers using callback provided in columns', async () => {
-    const dataSource = new WattTableDataSource(data);
-    const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: (id) => id.toUpperCase() },
-    };
-
-    await setup({ dataSource, columns });
-
-    expect(screen.getByText('POSITION')).toBeInTheDocument();
-  });
-
   it('renders cells using callback provided in columns', async () => {
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position', cell: (data) => `Number #${data}` },
+      position: { accessor: 'position', cell: (data) => `Number #${data}` },
     };
 
     await setup({ dataSource, columns });
@@ -132,8 +121,8 @@ describe(WattTableComponent.name, () => {
   it('allows for sorting of column data', async () => {
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position', sort: true },
-      weight: { header: 'Weight', sort: false },
+      position: { accessor: 'position', sort: true },
+      weight: { accessor: 'weight', sort: false },
     };
 
     await setup({
@@ -154,8 +143,8 @@ describe(WattTableComponent.name, () => {
   it('renders checkbox column when selectable is true', async () => {
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position' },
-      weight: { header: 'Weight' },
+      position: { accessor: 'position' },
+      weight: { accessor: 'weight' },
     };
 
     await setup({ dataSource, columns, selectable: true });
@@ -167,8 +156,8 @@ describe(WattTableComponent.name, () => {
     const selectionChange = jest.fn();
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position' },
-      weight: { header: 'Weight' },
+      position: { accessor: 'position' },
+      weight: { accessor: 'weight' },
     };
 
     await setup({ dataSource, columns, selectable: true, selectionChange });
@@ -183,8 +172,8 @@ describe(WattTableComponent.name, () => {
     const selectionChange = jest.fn();
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position' },
-      weight: { header: 'Weight' },
+      position: { accessor: 'position' },
+      weight: { accessor: 'weight' },
     };
 
     await setup({ dataSource, columns, selectable: true, selectionChange });
@@ -200,8 +189,8 @@ describe(WattTableComponent.name, () => {
     const selectionChange = jest.fn();
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position' },
-      weight: { header: 'Weight' },
+      position: { accessor: 'position' },
+      weight: { accessor: 'weight' },
     };
 
     await setup({ dataSource, columns, selectable: true, selectionChange });
@@ -218,8 +207,8 @@ describe(WattTableComponent.name, () => {
     const selectionChange = jest.fn();
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position' },
-      weight: { header: 'Weight' },
+      position: { accessor: 'position' },
+      weight: { accessor: 'weight' },
     };
 
     await setup({ dataSource, columns, selectable: true, selectionChange });
@@ -234,8 +223,8 @@ describe(WattTableComponent.name, () => {
     const selectionChange = jest.fn();
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position' },
-      weight: { header: 'Weight' },
+      position: { accessor: 'position' },
+      weight: { accessor: 'weight' },
     };
 
     await setup({ dataSource, columns, selectable: true, selectionChange });
@@ -251,8 +240,8 @@ describe(WattTableComponent.name, () => {
     const rowClick = jest.fn();
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position' },
-      weight: { header: 'Weight' },
+      position: { accessor: 'position' },
+      weight: { accessor: 'weight' },
     };
 
     await setup({ dataSource, columns, rowClick });
@@ -266,8 +255,8 @@ describe(WattTableComponent.name, () => {
   it('renders cell content using template', async () => {
     const dataSource = new WattTableDataSource(data);
     const columns: WattTableColumnDef<PeriodicElement> = {
-      position: { header: 'Position' },
-      weight: { header: 'Weight' },
+      position: { accessor: 'position' },
+      weight: { accessor: 'weight' },
     };
 
     await setup(

--- a/libs/ui-watt/src/lib/components/table/watt-table.component.ts
+++ b/libs/ui-watt/src/lib/components/table/watt-table.component.ts
@@ -43,7 +43,7 @@ import {
   SortDirection,
 } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
-import { map, identity, type Subscription } from 'rxjs';
+import { map, type Subscription } from 'rxjs';
 import { WattCheckboxModule } from '../checkbox';
 import { WattTableDataSource } from './watt-table-data-source';
 

--- a/libs/ui-watt/src/lib/components/table/watt-table.component.ts
+++ b/libs/ui-watt/src/lib/components/table/watt-table.component.ts
@@ -50,9 +50,16 @@ import { WattTableDataSource } from './watt-table-data-source';
 
 export interface WattTableColumn<T> {
   /**
-   * Text to display in the header. Supports callback for translation etc.
+   * The data property of `T` that this column should be bound to. This is
+   * required for sorting to work out of the box. Use `null` for columns
+   * that cannot be associated with a data property.
    */
-  header: string | ((key: string) => string);
+  data: keyof T | null;
+
+  /**
+   * Text to display in the header. For translations or
+   */
+  header?: string;
 
   /**
    * Optional callback for determining cell content when not using template.
@@ -157,6 +164,12 @@ export class WattTableComponent<T>
    */
   @Input()
   description = '';
+
+  /**
+   * TODO
+   */
+  @Input()
+  formatHeader?: (key: string) => string;
 
   /**
    * Identifier for column that should be sorted initially.
@@ -299,6 +312,7 @@ export class WattTableComponent<T>
 
   /** @ignore */
   _getColumnHeader(column: KeyValue<string, WattTableColumn<T>>) {
+    if (!column.value.header) return this.formatHeader?.(column.key);
     return typeof column.value.header === 'string'
       ? column.value.header
       : column.value.header(column.key);

--- a/libs/ui-watt/src/lib/components/table/watt-table.component.ts
+++ b/libs/ui-watt/src/lib/components/table/watt-table.component.ts
@@ -64,7 +64,7 @@ export interface WattTableColumn<T> {
 
   /**
    * Callback for determining cell content when not using template. By default,
-   * cell content is determined by the `accessor` (unless it is `null`).
+   * cell content is found using the `accessor` (unless it is `null`).
    */
   cell?: (row: T) => string;
 
@@ -166,10 +166,12 @@ export class WattTableComponent<T>
   description = '';
 
   /**
-   * TODO
+   * Optional callback for determining header text for columns that
+   * do not have a static header text set in the column definition.
+   * Useful for providing translations of column headers.
    */
   @Input()
-  resolveHeader = identity<string>;
+  resolveHeader?: (key: string) => string;
 
   /**
    * Identifier for column that should be sorted initially.
@@ -317,7 +319,9 @@ export class WattTableComponent<T>
 
   /** @ignore */
   _getColumnHeader(column: KeyValue<string, WattTableColumn<T>>) {
-    return column.value.header ?? this.resolveHeader(column.key);
+    return column.value.header
+      ? column.value.header
+      : this.resolveHeader?.(column.key) ?? column.key;
   }
 
   /** @ignore */


### PR DESCRIPTION

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This is an attempt to make the table easier to use, by being explicit about the 
column -> `T` dependency. Previously, the column identifier (record key) had 
to match the property of `T`. With this change, the developer has to explicitly 
tell the table what data a column should be bound to (or an explicit null for 
unbound columns). Separating the column identifier from the data accessor also 
allows for using the same identifier as in translations file, leading to 
simpler translation implementations (hence the change to how the header texts are 
resolved). 

<!--- Please leave a helpful description of the pull request here. --->

