### PR TITLE
feat(dh): only import DhSharedUtilApplicationInsightsModule in production

### DIFF
--- a/libs/dh/core/shell/src/lib/dh-core-shell.module.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.module.ts
@@ -39,7 +39,7 @@ import {
   MSALInterceptorConfigFactory,
 } from '@energinet-datahub/dh/auth/msal';
 import { DhApiModule } from '@energinet-datahub/dh/shared/data-access-api';
-import { dhB2CEnvironmentToken } from '@energinet-datahub/dh/shared/environments';
+import { dhB2CEnvironmentToken, environment } from '@energinet-datahub/dh/shared/environments';
 import { dhMarketParticipantPath } from '@energinet-datahub/dh/market-participant/routing';
 import { dhMeteringPointPath } from '@energinet-datahub/dh/metering-point/routing';
 import { dhChargesPath } from '@energinet-datahub/dh/charges/routing';
@@ -125,7 +125,7 @@ const routes: Routes = [
     MsalModule,
     DhConfigurationLocalizationModule.forRoot(),
     WattDanishDatetimeModule.forRoot(),
-    DhSharedUtilApplicationInsightsModule.forRoot(),
+    environment.production ? DhSharedUtilApplicationInsightsModule.forRoot() : [],
     RouterModule.forRoot(routes, {
       anchorScrolling: 'enabled',
       // Don't perform initial navigation in iframes or popups

--- a/libs/dh/core/shell/src/lib/dh-core-shell.module.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.module.ts
@@ -39,7 +39,10 @@ import {
   MSALInterceptorConfigFactory,
 } from '@energinet-datahub/dh/auth/msal';
 import { DhApiModule } from '@energinet-datahub/dh/shared/data-access-api';
-import { dhB2CEnvironmentToken, environment } from '@energinet-datahub/dh/shared/environments';
+import {
+  dhB2CEnvironmentToken,
+  environment,
+} from '@energinet-datahub/dh/shared/environments';
 import { dhMarketParticipantPath } from '@energinet-datahub/dh/market-participant/routing';
 import { dhMeteringPointPath } from '@energinet-datahub/dh/metering-point/routing';
 import { dhChargesPath } from '@energinet-datahub/dh/charges/routing';
@@ -125,7 +128,9 @@ const routes: Routes = [
     MsalModule,
     DhConfigurationLocalizationModule.forRoot(),
     WattDanishDatetimeModule.forRoot(),
-    environment.production ? DhSharedUtilApplicationInsightsModule.forRoot() : [],
+    environment.production
+      ? DhSharedUtilApplicationInsightsModule.forRoot()
+      : [],
     RouterModule.forRoot(routes, {
       anchorScrolling: 'enabled',
       // Don't perform initial navigation in iframes or popups


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Only import `DhSharedUtilApplicationInsightsModule` in production to eliminate console noise and ensure application insights aren't hijacking any error messages in the `mock` or `development` environment. 

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #944 
