### PR TITLE
feat(wholesale): add new grid areas

### DIFF
--- a/libs/dh/wholesale/feature-start/src/lib/dh-wholesale-start.component.ts
+++ b/libs/dh/wholesale/feature-start/src/lib/dh-wholesale-start.component.ts
@@ -54,6 +54,10 @@ export class DhWholesaleStartComponent {
   optionsGridAreas: WattDropdownOption[] = Object.keys({
     805: '805',
     806: '806',
+    512: '512',
+    533: '533',
+    543: '543',
+    584: '584',
   }).map((key) => ({
     displayValue: key,
     value: key,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

The list of grid areas in start batch screen has been extended with the following 4 grid areas: 512, 533, 543, 584

![image](https://user-images.githubusercontent.com/86852536/208057088-334860ee-daa4-4a6b-b76c-88907c125306.png)


<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [632](https://github.com/Energinet-DataHub/opengeh-wholesale/issues/632)
