### PR TITLE
feat(wholesale): add grid area 351

### DIFF
--- a/libs/dh/wholesale/feature-start/src/lib/dh-wholesale-start.component.ts
+++ b/libs/dh/wholesale/feature-start/src/lib/dh-wholesale-start.component.ts
@@ -58,6 +58,7 @@ export class DhWholesaleStartComponent {
     533: '533',
     543: '543',
     584: '584',
+    351: '351',
   }).map((key) => ({
     displayValue: key,
     value: key,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
The list of grid areas in start batch screen has been extended with the `351` grid area

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [632](https://github.com/Energinet-DataHub/opengeh-wholesale/issues/632)
