### PR TITLE
fix(wholesale): remove redundant usage of query params in mocks

### DIFF
--- a/libs/dh/shared/data-access-msw/src/lib/mocks/wholesale.ts
+++ b/libs/dh/shared/data-access-msw/src/lib/mocks/wholesale.ts
@@ -194,7 +194,7 @@ function getWholesaleSearchBatch(apiBase: string) {
 
 function downloadBasisData(apiBase: string) {
   return rest.get(
-    `${apiBase}/v1/WholesaleBatch/ZippedBasisDataStream?batchId=123`,
+    `${apiBase}/v1/WholesaleBatch/ZippedBasisDataStream`,
     async (req, res, ctx) => {
       return res(ctx.status(500));
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Adjust wholesale mocks to get rid of following warning in the console:
`[MSW] Found a redundant usage of query parameters in the request handler URL for "GET https://localhost:5001/v1/WholesaleBatch/ZippedBasisDataStream?batchId=123". Please match against a path instead and access query parameters in the response resolver function using "req.url.searchParams".`
![image](https://user-images.githubusercontent.com/86852536/208612136-c8076a4a-b279-49f5-bc47-8bf99e69d9a9.png)

<!--- Please leave a helpful description of the pull request here. --->

