### PR TITLE
fix(watt): make sure getCellData won't fail if column is undefined (watt-table)

### DIFF
--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.3.145
+version: 0.3.146

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.145
+    tag: 0.3.146

--- a/libs/ui-watt/src/lib/components/table/watt-table.component.ts
+++ b/libs/ui-watt/src/lib/components/table/watt-table.component.ts
@@ -263,8 +263,8 @@ export class WattTableComponent<T>
   _subscription!: Subscription;
 
   /** @ignore */
-  private getCellData(row: T, column: WattTableColumn<T>) {
-    if (!column.accessor) return null;
+  private getCellData(row: T, column?: WattTableColumn<T>) {
+    if (!column?.accessor) return null;
     return typeof column.accessor === 'function'
       ? column.accessor(row)
       : row[column.accessor];


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Make sure `getCellData` won't fail if the column is undefined and breaks the sorting. 

![image](https://user-images.githubusercontent.com/86852536/208624173-b1b5f30f-5610-45df-9d67-e31a2f036cd2.png)
