### PR TITLE
Add optional header input to wattTableCellDirective

### DIFF
--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.3.146
+version: 0.3.147

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.146
+    tag: 0.3.147

--- a/libs/ui-watt/src/lib/components/table/watt-table.component.ts
+++ b/libs/ui-watt/src/lib/components/table/watt-table.component.ts
@@ -56,6 +56,8 @@ export interface WattTableColumn<T> {
   accessor: keyof T | ((row: T) => unknown) | null;
 
   /**
+   * @deprecated Use `header` input with WattTableCellDirective instead.
+   *
    * Resolve the header text to a static display value. This will prevent
    * the `resolveHeader` input function from being called for this column.
    */
@@ -337,6 +339,7 @@ export class WattTableComponent<T>
 
   /** @ignore */
   _getColumnHeader(column: KeyValue<string, WattTableColumn<T>>) {
+    if (column.value.header) return column.value.header;
     const cell = this._cells.find((item) => item.column === column.value);
     return cell?.header ?? this.resolveHeader?.(column.key) ?? column.key;
   }

--- a/libs/ui-watt/src/lib/components/table/watt-table.component.ts
+++ b/libs/ui-watt/src/lib/components/table/watt-table.component.ts
@@ -338,7 +338,6 @@ export class WattTableComponent<T>
   /** @ignore */
   _getColumnHeader(column: KeyValue<string, WattTableColumn<T>>) {
     const cell = this._cells.find((item) => item.column === column.value);
-    console.log(cell);
     return cell?.header ?? this.resolveHeader?.(column.key) ?? column.key;
   }
 

--- a/libs/ui-watt/src/lib/components/table/watt-table.component.ts
+++ b/libs/ui-watt/src/lib/components/table/watt-table.component.ts
@@ -108,6 +108,7 @@ interface WattTableCellContext<T> {
 export class WattTableCellDirective<T> {
   /** The WattTableColumn this template applies to. */
   @Input('wattTableCell') column!: WattTableColumn<T>;
+  @Input('wattTableCellHeader') header?: string;
   templateRef = inject(TemplateRef<WattTableCellContext<T>>);
   static ngTemplateContextGuard<T>(
     _directive: WattTableCellDirective<T>,
@@ -169,6 +170,8 @@ export class WattTableComponent<T>
   description = '';
 
   /**
+   * @deprecated Use `header` input with WattTableCellDirective instead.
+   *
    * Optional callback for determining header text for columns that
    * do not have a static header text set in the column definition.
    * Useful for providing translations of column headers.
@@ -334,9 +337,9 @@ export class WattTableComponent<T>
 
   /** @ignore */
   _getColumnHeader(column: KeyValue<string, WattTableColumn<T>>) {
-    return column.value.header
-      ? column.value.header
-      : this.resolveHeader?.(column.key) ?? column.key;
+    const cell = this._cells.find((item) => item.column === column.value);
+    console.log(cell);
+    return cell?.header ?? this.resolveHeader?.(column.key) ?? column.key;
   }
 
   /** @ignore */


### PR DESCRIPTION
## Description
This PR makes it possible to supply the table header values directly in the template. Example:

```tsx
<ng-container *wattTableCell="columns.id; header: translate('columns.id'); let cell">
  ...
</ng-container>
```