### PR TITLE
fix(wholesale): reset selected batch on search

### DIFF
--- a/libs/dh/wholesale/feature-search/src/lib/dh-wholesale-search.component.ts
+++ b/libs/dh/wholesale/feature-search/src/lib/dh-wholesale-search.component.ts
@@ -86,6 +86,8 @@ export class DhWholesaleSearchComponent implements AfterViewInit, OnDestroy {
     if (selectedBatch) {
       this.store.getBatch(selectedBatch);
       this.batchDetails.open();
+    } else {
+      this.store.setSelectedBatch(undefined);
     }
     this.changeDetectorRef.detectChanges();
   }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Reset the selected batch on search if no query param of the batch is set. 
Currently, if you select a batch ->, select grid area -> click on search batch in the menu - the table will highlight the selected batch. With this PR, it will be reset. 

![image](https://user-images.githubusercontent.com/86852536/208845525-9cc80c5d-f6ef-4089-ba25-c5373dbd45f9.png)

