### PR TITLE
chore:(ui-watt): remove size option from button

### DIFF
--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.3.150
+version: 0.3.151

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.150
+    tag: 0.3.151

--- a/libs/dh/metering-point/feature-search/src/lib/form/dh-metering-point-search-form.component.html
+++ b/libs/dh/metering-point/feature-search/src/lib/form/dh-metering-point-search-form.component.html
@@ -19,7 +19,7 @@ limitations under the License.
   name="search-form"
   (ngSubmit)="onSubmit()"
 >
-  <watt-form-field size="large">
+  <watt-form-field>
     <watt-label>{{ transloco("searchLabel") }}</watt-label>
     <watt-icon name="search" wattPrefix></watt-icon>
     <input
@@ -42,11 +42,7 @@ limitations under the License.
       (click)="onSearchInputClear()"
     ></watt-button>
   </watt-form-field>
-  <watt-button
-    variant="primary"
-    type="submit"
-    size="large"
-    [loading]="loading"
-    >{{ transloco("searchButton") }}</watt-button
-  >
+  <watt-button variant="primary" type="submit" [loading]="loading">{{
+    transloco("searchButton")
+  }}</watt-button>
 </form>

--- a/libs/ui-watt/src/lib/components/button/+storybook/storybook-button-overview.component.html
+++ b/libs/ui-watt/src/lib/components/button/+storybook/storybook-button-overview.component.html
@@ -77,20 +77,6 @@ limitations under the License.
     >
   </div>
 
-  <h2>Size</h2>
-
-  <div class="content-grid">
-    <div>
-      <p>Default</p>
-      <watt-button variant="primary">Enabled</watt-button>
-    </div>
-    <div>
-      <p>Large</p>
-
-      <watt-button variant="primary" size="large">Enabled</watt-button>
-    </div>
-  </div>
-
   <h2>Icon</h2>
 
   <p>

--- a/libs/ui-watt/src/lib/components/button/watt-button.component.scss
+++ b/libs/ui-watt/src/lib/components/button/watt-button.component.scss
@@ -19,6 +19,7 @@
 @mixin primary-hover {
   background: var(--watt-color-primary-dark);
 }
+
 @mixin primary-focus {
   @include primary-hover;
   outline: 2px solid var(--watt-color-secondary);
@@ -62,14 +63,7 @@ watt-button {
 
   &.mat-button {
     min-width: 44px; // Magic UX width
-  }
-
-  &.watt-button--normal {
     height: 44px; // Magic UX normal height
-  }
-
-  &.watt-button--large {
-    height: 56px; // Magic UX large height
   }
 
   watt-spinner {

--- a/libs/ui-watt/src/lib/components/button/watt-button.component.spec.ts
+++ b/libs/ui-watt/src/lib/components/button/watt-button.component.spec.ts
@@ -20,7 +20,6 @@ import userEvent from '@testing-library/user-event';
 import { WattIcon } from '../../foundations/icon';
 import {
   WattButtonComponent,
-  WattButtonSize,
   WattButtonType,
   WattButtonTypes,
   WattButtonVariant,
@@ -33,7 +32,6 @@ interface WattButtonOptionsType {
   disabled?: boolean;
   text?: string;
   variant?: WattButtonVariant;
-  size?: WattButtonSize;
   type?: WattButtonType;
 }
 
@@ -42,7 +40,6 @@ describe(WattButtonComponent.name, () => {
     return await render(
       `<watt-button
          variant="${options.variant}"
-         size="${options.size}"
          icon="${options.icon}"
          type="${options.type}"
          [loading]="${options.loading}"
@@ -61,7 +58,6 @@ describe(WattButtonComponent.name, () => {
     });
 
     expect(screen.getByRole('button')).toHaveTextContent('Default button');
-    expect(screen.getByRole('button')).toHaveClass('watt-button--normal');
     expect(screen.getByRole('button')).toHaveClass('watt-button--primary');
     expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
     expect(screen.getByRole('button')).not.toHaveClass('mat-button-disabled');
@@ -92,12 +88,6 @@ describe(WattButtonComponent.name, () => {
       expect(screen.getByRole('button')).toHaveClass('watt-button--' + variant);
     }
   );
-
-  it('renders size as a class', async () => {
-    await renderComponent({ size: 'large' });
-
-    expect(screen.getByRole('button')).toHaveClass('watt-button--large');
-  });
 
   it('renders type', async () => {
     await renderComponent({ type: 'reset' });

--- a/libs/ui-watt/src/lib/components/button/watt-button.component.ts
+++ b/libs/ui-watt/src/lib/components/button/watt-button.component.ts
@@ -30,7 +30,6 @@ export const WattButtonTypes = [
   'icon',
 ] as const;
 export type WattButtonVariant = typeof WattButtonTypes[number];
-export type WattButtonSize = 'normal' | 'large';
 export type WattButtonType = 'button' | 'reset' | 'submit';
 
 @Component({
@@ -39,7 +38,7 @@ export type WattButtonType = 'button' | 'reset' | 'submit';
   template: `
     <button
       mat-button
-      class="watt-button--{{ variant }} watt-button--{{ size }}"
+      class="watt-button--{{ variant }}"
       [disabled]="disabled"
       [type]="type"
     >
@@ -61,7 +60,6 @@ export type WattButtonType = 'button' | 'reset' | 'submit';
 export class WattButtonComponent {
   @Input() icon?: WattIcon;
   @Input() variant: WattButtonVariant = 'primary';
-  @Input() size: WattButtonSize = 'normal';
   @Input() type: WattButtonType = 'button';
   @Input() disabled = false;
   @Input() loading = false;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

remove large version of the watt button and adjust text field on metering-point

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #1267
- #1266 (partially)