### PR TITLE
fix: set version on license-checker-rseidelsohn package

### DIFF
--- a/.github/workflows/production-dependencies-license-check.yml
+++ b/.github/workflows/production-dependencies-license-check.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run license-checker
         id: licenseChecker
         if: ${{ steps.dependencies_have_changed.outputs.dependencies-have-changed == 'true' }}
-        run: echo DEPENDENCIES=$(npx license-checker-rseidelsohn --direct --production --onlyAllow="${{ steps.allowed-licenses.outputs.FILE }}" --json --excludePrivatePackages) >> $GITHUB_OUTPUT
+        run: echo DEPENDENCIES=$(npx license-checker-rseidelsohn@3 --direct --production --onlyAllow="${{ steps.allowed-licenses.outputs.FILE }}" --json --excludePrivatePackages) >> $GITHUB_OUTPUT
       - name: Update PRODUCTION_DEPENDENCIES.md
         if: ${{ steps.dependencies_have_changed.outputs.dependencies-have-changed == 'true' }}
         uses: ./.github/actions/update-production-dependencies-list


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

`license-checker-rseidelsohn` updated to 4.0.0 which doesn't support node 16. 

This PR sets it to the latest version of 3 that is supporting node 16

https://github.com/RSeidelsohn/license-checker-rseidelsohn/releases

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- N/A
