### PR TITLE
Remove unneeded links

### DIFF
--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-frontend
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.3.175
+version: 0.3.176

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.175
+    tag: 0.3.176

--- a/libs/eo/core/shell/src/lib/eo-primary-navigation.component.ts
+++ b/libs/eo/core/shell/src/lib/eo-primary-navigation.component.ts
@@ -43,15 +43,6 @@ import {
       <watt-nav-list-item link="{{ routes.dashboard }}">
         Dashboard
       </watt-nav-list-item>
-      <watt-nav-list-item link="{{ routes.originOfEnergy }}">
-        Renewable Share
-      </watt-nav-list-item>
-      <watt-nav-list-item link="{{ routes.emissions }}">
-        Emissions
-      </watt-nav-list-item>
-      <watt-nav-list-item link="{{ routes.consumption }}">
-        Consumption
-      </watt-nav-list-item>
       <watt-nav-list-item link="{{ routes.production }}">
         Production
       </watt-nav-list-item>

--- a/libs/eo/dashboard/shell/src/lib/eo-dashboard-get-data.component.ts
+++ b/libs/eo/dashboard/shell/src/lib/eo-dashboard-get-data.component.ts
@@ -18,7 +18,6 @@
 import { Component } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { RouterModule } from '@angular/router';
-import { eoEmissionsRoutePath } from '@energinet-datahub/eo/shared/utilities';
 
 @Component({
   standalone: true,
@@ -34,11 +33,6 @@ import { eoEmissionsRoutePath } from '@energinet-datahub/eo/shared/utilities';
     <p class="watt-space-stack-m">
       You can get the data, that you need to fill out your CSR-report,
       especially the ones concerning energy use and emissions.
-    </p>
-    <p>
-      See
-      <a class="link" routerLink="/${eoEmissionsRoutePath}"> Emissions</a> for
-      further details
     </p>
   </mat-card>`,
   styles: [


### PR DESCRIPTION
## Description

This removes the following links from navigation:

- Renewable share
- Consumption
- Emission

As well as removes the link to the emissions page from dashboard