### PR TITLE
feat(dh): display validation error message when user role name exists

### DIFF
--- a/libs/dh/admin/data-access-api/src/lib/dh-admin-user-role-edit-data-access-api.store.ts
+++ b/libs/dh/admin/data-access-api/src/lib/dh-admin-user-role-edit-data-access-api.store.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import { inject, Injectable } from '@angular/core';
+import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
 import { ComponentStore, tapResponse } from '@ngrx/component-store';
 import { exhaustMap, Observable, tap } from 'rxjs';
 
@@ -82,12 +83,25 @@ export class DhAdminUserRoleEditDataAccessApiStore extends ComponentStore<DhEdit
 
                   onSuccessFn();
                 },
-                () => {
-                  this.patchState({ requestState: ErrorState.GENERAL_ERROR });
+                (error: HttpErrorResponse) => {
+                  this.handleError(error);
                 }
               )
             )
         )
       )
   );
+
+  private handleError({ status, error }: HttpErrorResponse): void {
+    let requestState = ErrorState.GENERAL_ERROR;
+
+    if (
+      status === HttpStatusCode.BadRequest &&
+      error?.code === ErrorState.VALIDATION_EXCEPTION
+    ) {
+      requestState = ErrorState.VALIDATION_EXCEPTION;
+    }
+
+    this.patchState({ requestState });
+  }
 }

--- a/libs/dh/admin/data-access-api/src/lib/dh-admin-user-role-edit-data-access-api.store.ts
+++ b/libs/dh/admin/data-access-api/src/lib/dh-admin-user-role-edit-data-access-api.store.ts
@@ -17,7 +17,7 @@
 import { inject, Injectable } from '@angular/core';
 import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
 import { ComponentStore, tapResponse } from '@ngrx/component-store';
-import { exhaustMap, Observable, tap } from 'rxjs';
+import { exhaustMap, filter, Observable, tap } from 'rxjs';
 
 import {
   ErrorState,
@@ -44,13 +44,12 @@ export class DhAdminUserRoleEditDataAccessApiStore extends ComponentStore<DhEdit
     DhAdminUserRolesManagementDataAccessApiStore
   );
 
-  isInit$ = this.select((state) => state.requestState === LoadingState.INIT);
   isLoading$ = this.select(
     (state) => state.requestState === LoadingState.LOADING
   );
-  hasGeneralError$ = this.select(
-    (state) => state.requestState === ErrorState.GENERAL_ERROR
-  );
+  hasValidationError$ = this.select(
+    (state) => state.requestState === ErrorState.VALIDATION_EXCEPTION
+  ).pipe(filter((value) => value));
 
   constructor(private httpClient: MarketParticipantUserRoleHttp) {
     super(initialState);

--- a/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
+++ b/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
@@ -29,7 +29,7 @@ limitations under the License.
               <watt-label>{{ t("tab.masterData.nameInputLabel") }}</watt-label>
               <input wattInput type="text" formControlName="name" />
               <watt-error
-                *ngIf="userRoleEditForm.get('name')?.errors?.['nameAlreadyExists']"
+                *ngIf="userRoleEditForm.controls.name?.errors?.['nameAlreadyExists']"
               >
                 {{ t("tab.masterData.errors.nameAlreadyExists") }}
               </watt-error>

--- a/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
+++ b/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
@@ -25,9 +25,14 @@ limitations under the License.
       <watt-tabs>
         <watt-tab [label]="t('tab.masterData.tabLabel')">
           <div class="form-wrapper">
-            <watt-form-field>
+            <watt-form-field class="watt-space-stack-l">
               <watt-label>{{ t("tab.masterData.nameInputLabel") }}</watt-label>
               <input wattInput type="text" formControlName="name" />
+              <watt-error
+                *ngIf="userRoleEditForm.get('name')?.errors?.['nameAlreadyExists']"
+              >
+                {{ t("tab.masterData.errors.nameAlreadyExists") }}
+              </watt-error>
             </watt-form-field>
 
             <watt-form-field>

--- a/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.ts
+++ b/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.ts
@@ -92,12 +92,12 @@ export class DhEditUserRoleModalComponent
   private destroy$ = new Subject<void>();
 
   readonly userRole$ = this.userRoleWithPermissionsStore.userRole$;
+  readonly roleName$ = this.userRole$.pipe(map((role) => role.name));
 
-  isLoading$ = this.userRoleEditStore.isLoading$;
+  readonly isLoading$ = this.userRoleEditStore.isLoading$;
+  readonly hasValidationError$ = this.userRoleEditStore.hasValidationError$;
 
-  roleName$ = this.userRole$.pipe(map((role) => role.name));
-
-  userRoleEditForm = this.formBuilder.group({
+  readonly userRoleEditForm = this.formBuilder.group({
     name: this.formBuilder.nonNullable.control('', [Validators.required]),
     description: this.formBuilder.nonNullable.control(''),
   });
@@ -112,6 +112,12 @@ export class DhEditUserRoleModalComponent
     this.userRole$.pipe(takeUntil(this.destroy$)).subscribe((userRole) => {
       formControls.name.setValue(userRole.name);
       formControls.description.setValue(userRole.description);
+    });
+
+    this.hasValidationError$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      formControls.name.setErrors({
+        nameAlreadyExists: true,
+      });
     });
   }
 

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -1031,7 +1031,7 @@
             "nameInputLabel": "Navn",
             "descriptionInputLabel": "Beskrivelse",
             "errors": {
-              "nameAlreadyExists": "Navnet er allerede i brug"
+              "nameAlreadyExists": "En bruger rolle med dette navn findes allerede"
             }
           },
           "permissions": {

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -1029,7 +1029,10 @@
           "masterData": {
             "tabLabel": "Stamdata",
             "nameInputLabel": "Navn",
-            "descriptionInputLabel": "Beskrivelse"
+            "descriptionInputLabel": "Beskrivelse",
+            "errors": {
+              "nameAlreadyExists": "Navnet er allerede i brug"
+            }
           },
           "permissions": {
             "tabLabel": "Rettigheder"

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -1026,7 +1026,10 @@
           "masterData": {
             "tabLabel": "Master data",
             "nameInputLabel": "Name",
-            "descriptionInputLabel": "Description"
+            "descriptionInputLabel": "Description",
+            "errors": {
+              "nameAlreadyExists": "The user role already exists"
+            }
           },
           "permissions": {
             "tabLabel": "Permissions"

--- a/libs/dh/shared/data-access-api/src/lib/states.ts
+++ b/libs/dh/shared/data-access-api/src/lib/states.ts
@@ -17,6 +17,7 @@
 export const enum ErrorState {
   NOT_FOUND_ERROR = 'NOT_FOUND_ERROR',
   GENERAL_ERROR = 'GENERAL_ERROR',
+  VALIDATION_EXCEPTION = 'VALIDATION_EXCEPTION',
 }
 
 export const enum LoadingState {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### DataHub

- display validation error message when user role name exists
- add new error state type

![image](https://user-images.githubusercontent.com/1096332/217463524-0d13691e-ff9f-41be-9cdf-37643c9371c5.png)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/ARCHIVED-geh-post-office/issues/891
