### PR TITLE
feat(dh): make description field in edit user role required

### DIFF
--- a/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
+++ b/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
@@ -33,6 +33,11 @@ limitations under the License.
               >
                 {{ t("tab.masterData.errors.nameAlreadyExists") }}
               </watt-error>
+              <watt-error
+                *ngIf="userRoleEditForm.controls.name?.errors?.['required']"
+              >
+                {{ t("tab.masterData.errors.required") }}
+              </watt-error>
             </watt-form-field>
 
             <watt-form-field>

--- a/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
+++ b/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
@@ -45,6 +45,11 @@ limitations under the License.
                 t("tab.masterData.descriptionInputLabel")
               }}</watt-label>
               <textarea wattInput formControlName="description"></textarea>
+              <watt-error
+                *ngIf="userRoleEditForm.controls.description?.errors?.['required']"
+              >
+                {{ t("tab.masterData.errors.required") }}
+              </watt-error>
             </watt-form-field>
           </div>
         </watt-tab>

--- a/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.ts
+++ b/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.ts
@@ -99,7 +99,9 @@ export class DhEditUserRoleModalComponent
 
   readonly userRoleEditForm = this.formBuilder.group({
     name: this.formBuilder.nonNullable.control('', [Validators.required]),
-    description: this.formBuilder.nonNullable.control(''),
+    description: this.formBuilder.nonNullable.control('', [
+      Validators.required,
+    ]),
   });
 
   @ViewChild(WattModalComponent) editUserRoleModal!: WattModalComponent;

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -1032,7 +1032,8 @@
             "nameInputLabel": "Navn",
             "descriptionInputLabel": "Beskrivelse",
             "errors": {
-              "nameAlreadyExists": "En bruger rolle med dette navn findes allerede"
+              "nameAlreadyExists": "En bruger rolle med dette navn findes allerede",
+              "required": "Feltet er påkrævet"
             }
           },
           "permissions": {

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -1029,7 +1029,8 @@
             "nameInputLabel": "Name",
             "descriptionInputLabel": "Description",
             "errors": {
-              "nameAlreadyExists": "The user role already exists"
+              "nameAlreadyExists": "The user role already exists",
+              "required": "Field is required"
             }
           },
           "permissions": {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### DataHub
- make description field in edit user role required
- display required error on name field

![image](https://user-images.githubusercontent.com/1096332/217513776-172e0c48-3f29-4ad5-9a3e-0f7d540fd7ce.png)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/ARCHIVED-geh-post-office/issues/891
