### PR TITLE
feat(dh): show notification on success/error

### DIFF
--- a/libs/dh/admin/data-access-api/src/lib/dh-admin-user-role-edit-data-access-api.store.ts
+++ b/libs/dh/admin/data-access-api/src/lib/dh-admin-user-role-edit-data-access-api.store.ts
@@ -61,13 +61,14 @@ export class DhAdminUserRoleEditDataAccessApiStore extends ComponentStore<DhEdit
         userRoleId: string;
         updatedUserRole: UpdateUserRoleDto;
         onSuccessFn: () => void;
+        onErrorFn: (statusCode: HttpStatusCode) => void;
       }>
     ) =>
       trigger$.pipe(
         tap(() => {
           this.patchState({ requestState: LoadingState.LOADING });
         }),
-        exhaustMap(({ userRoleId, updatedUserRole, onSuccessFn }) =>
+        exhaustMap(({ userRoleId, updatedUserRole, onSuccessFn, onErrorFn }) =>
           this.httpClient
             .v1MarketParticipantUserRoleUpdatePut(userRoleId, updatedUserRole)
             .pipe(
@@ -84,6 +85,7 @@ export class DhAdminUserRoleEditDataAccessApiStore extends ComponentStore<DhEdit
                 },
                 (error: HttpErrorResponse) => {
                   this.handleError(error);
+                  onErrorFn(error.status);
                 }
               )
             )

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -1026,6 +1026,8 @@
         }
       },
       "editUserRole": {
+        "saveSuccess": "Brugerrollen blev opdateret",
+        "saveError": "Noget gik galt. Brugerrollen blev ikke opdateret. Prøv igen",
         "tab": {
           "masterData": {
             "tabLabel": "Stamdata",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -1023,6 +1023,8 @@
         }
       },
       "editUserRole": {
+        "saveSuccess": "The user role was updated",
+        "saveError": "Something went wrong. The user role could not be updated. Please try again",
         "tab": {
           "masterData": {
             "tabLabel": "Master data",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

### DataHub
- show notification on edit user role success/error

![image](https://user-images.githubusercontent.com/1096332/217840995-f065c363-585e-4610-b3f4-33ba2551343a.png)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/ARCHIVED-geh-post-office/issues/891
