### PR TITLE
fix(wholesale): default sorting of settlement reports

### DIFF
--- a/libs/dh/wholesale/feature-settlement-reports/src/lib/table/dh-wholesale-table.component.html
+++ b/libs/dh/wholesale/feature-settlement-reports/src/lib/table/dh-wholesale-table.component.html
@@ -21,7 +21,7 @@ limitations under the License.
     [columns]="columns"
     [resolveHeader]="translateHeader"
     description="batches"
-    sortBy="executionTime"
+    sortBy="executionTimeStart"
     sortDirection="desc"
     (rowClick)="selectedRow.emit($event)"
   >


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Fix default sorting of settlement reports

![image](https://user-images.githubusercontent.com/86852536/220033464-196d4498-c4f7-4d8a-99d5-98e17b387020.png)

