### PR TITLE
feat(wholesale): add calculation step for non-profiled consumption per balance responsible

### DIFF
--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -820,6 +820,7 @@
       "step": "Trin {{step}}",
       "aggregatedProductionPerGridArea": "Aggregeret produktion per netområde",
       "aggregatedConsumptionPerEnergySupplier": "Aggregeret timeforbrug per elleverandør",
+      "nonProfiledConsumptionPerBalanceResponsible": "Aggregeret timeforbrug per balanceansvarlig",
       "gridArea": "Netområde",
       "energySupplier": "El-leverandør",
       "loadProcessStepResultsErrorTitle": "Ups! Der opstod en fejl",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -817,6 +817,7 @@
       "step": "Step {{step}}",
       "aggregatedProductionPerGridArea": "Aggregated production per grid area",
       "aggregatedConsumptionPerEnergySupplier": "Aggregated consumption per energy supplier",
+      "nonProfiledConsumptionPerBalanceResponsible": "Aggregated consumption per balance responsible",
       "gridArea": "Grid area",
       "energySupplier": "Energy Supplier",
       "loadProcessStepResultsErrorTitle": "Oops! There was an error",

--- a/libs/dh/wholesale/feature-calculation-steps/src/lib/dh-wholesale-calculation-steps.component.html
+++ b/libs/dh/wholesale/feature-calculation-steps/src/lib/dh-wholesale-calculation-steps.component.html
@@ -138,7 +138,11 @@ limitations under the License.
                 <watt-badge size="large" class="watt-space-inline-m"
                   >3</watt-badge
                 >
-                {{ t("processStepResults.nonProfiledConsumptionPerBalanceResponsible") }}
+                {{
+                  t(
+                    "processStepResults.nonProfiledConsumptionPerBalanceResponsible"
+                  )
+                }}
               </h4>
             </watt-card>
           </li>

--- a/libs/dh/wholesale/feature-calculation-steps/src/lib/dh-wholesale-calculation-steps.component.html
+++ b/libs/dh/wholesale/feature-calculation-steps/src/lib/dh-wholesale-calculation-steps.component.html
@@ -132,6 +132,16 @@ limitations under the License.
               </ng-template>
             </watt-expandable-card>
           </li>
+          <li>
+            <watt-card>
+              <h4>
+                <watt-badge size="large" class="watt-space-inline-m"
+                  >3</watt-badge
+                >
+                {{ t("processStepResults.nonProfiledConsumptionPerBalanceResponsible") }}
+              </h4>
+            </watt-card>
+          </li>
         </ul>
 
         <aside class="details">


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Add calculation step for non-profiled consumption per balance responsible
![image](https://user-images.githubusercontent.com/86852536/220080013-5e20d7b3-bcfe-4116-bdfb-3081aa912f46.png)

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#786](https://github.com/Energinet-DataHub/opengeh-wholesale/issues/786)
