### PR TITLE
refactor(dh): move permissions table component to its own library

### DIFF
--- a/libs/dh/admin/feature-create-user-role/src/lib/tabs/create-role-permissions-tab/dh-create-userrole-permissions-tab.component.html
+++ b/libs/dh/admin/feature-create-user-role/src/lib/tabs/create-role-permissions-tab/dh-create-userrole-permissions-tab.component.html
@@ -14,9 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<ng-container
-  *transloco="let t; read: 'admin.userManagement.createrole.tabs.permissions'"
->
+<ng-container *transloco="let t; read: 'admin.userManagement.createrole.tabs.permissions'">
   <watt-card>
     <watt-card-title>
       <h4>
@@ -24,10 +22,10 @@ limitations under the License.
       </h4>
     </watt-card-title>
 
-    <dh-create-userrole-permissions-tab-table
+    <dh-permissions-table
       [permissions]="permissions"
       (selectionChanged)="onSelectionChange($event)"
-    ></dh-create-userrole-permissions-tab-table>
+    ></dh-permissions-table>
 
     <!-- Empty -->
     <div *ngIf="permissions.length === 0" class="no-content-container">

--- a/libs/dh/admin/feature-create-user-role/src/lib/tabs/create-role-permissions-tab/dh-create-userrole-permissions-tab.component.ts
+++ b/libs/dh/admin/feature-create-user-role/src/lib/tabs/create-role-permissions-tab/dh-create-userrole-permissions-tab.component.ts
@@ -14,24 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslocoModule } from '@ngneat/transloco';
 
 import { WattCardModule } from '@energinet-datahub/watt/card';
 import { WattEmptyStateModule } from '@energinet-datahub/watt/empty-state';
-import {
-  CreateUserRoleDto,
-  PermissionDetailsDto,
-} from '@energinet-datahub/dh/shared/domain';
-
-import { DhCreateRolePermissionTabTableComponent } from './dh-create-userrole-permissions-tab-table.component';
+import { CreateUserRoleDto, PermissionDetailsDto } from '@energinet-datahub/dh/shared/domain';
+import { DhPermissionsTableComponent } from '@energinet-datahub/dh/admin/ui-permissions-table';
 
 @Component({
   selector: 'dh-create-userrole-permissions-tab',
@@ -43,7 +33,7 @@ import { DhCreateRolePermissionTabTableComponent } from './dh-create-userrole-pe
     CommonModule,
     TranslocoModule,
     WattCardModule,
-    DhCreateRolePermissionTabTableComponent,
+    DhPermissionsTableComponent,
     WattEmptyStateModule,
   ],
 })

--- a/libs/dh/admin/ui-permissions-table/.eslintrc.json
+++ b/libs/dh/admin/ui-permissions-table/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "dh",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "dh",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/dh/admin/ui-permissions-table/README.md
+++ b/libs/dh/admin/ui-permissions-table/README.md
@@ -1,0 +1,1 @@
+# Permissions Table Ui

--- a/libs/dh/admin/ui-permissions-table/jest.config.ts
+++ b/libs/dh/admin/ui-permissions-table/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'dh-admin-ui-permissions-table',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+    },
+  },
+  coverageDirectory: '../../../../coverage/libs/dh/admin/ui-permissions-table',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/dh/admin/ui-permissions-table/jest.config.ts
+++ b/libs/dh/admin/ui-permissions-table/jest.config.ts
@@ -1,3 +1,19 @@
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /* eslint-disable */
 export default {
   displayName: 'dh-admin-ui-permissions-table',

--- a/libs/dh/admin/ui-permissions-table/project.json
+++ b/libs/dh/admin/ui-permissions-table/project.json
@@ -1,0 +1,27 @@
+{
+  "name": "dh-admin-ui-permissions-table",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/dh/admin/ui-permissions-table/src",
+  "prefix": "dh",
+  "targets": {
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/dh/admin/ui-permissions-table/jest.config.ts",
+        "passWithNoTests": true
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "lintFilePatterns": [
+          "libs/dh/admin/ui-permissions-table/**/*.ts",
+          "libs/dh/admin/ui-permissions-table/**/*.html"
+        ]
+      }
+    }
+  },
+  "tags": ["product:dh", "domain:admin", "type:ui"]
+}

--- a/libs/dh/admin/ui-permissions-table/src/index.ts
+++ b/libs/dh/admin/ui-permissions-table/src/index.ts
@@ -1,1 +1,17 @@
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 export * from './lib/dh-permissions-table.component';

--- a/libs/dh/admin/ui-permissions-table/src/index.ts
+++ b/libs/dh/admin/ui-permissions-table/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/dh-permissions-table.component';

--- a/libs/dh/admin/ui-permissions-table/src/lib/dh-permissions-table.component.html
+++ b/libs/dh/admin/ui-permissions-table/src/lib/dh-permissions-table.component.html
@@ -14,17 +14,25 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<ng-container>
+<ng-container *transloco="let t; read: 'admin.userManagement.permissionsTable'">
   <watt-table
     #permissionTable
     description="permissions"
     [dataSource]="dataSource"
     [columns]="columns"
-    [resolveHeader]="translateHeader"
     sortBy="name"
     [selectable]="permissions.length > 0"
     sortDirection="asc"
     (selectionChange)="onSelectionChange($event)"
   >
+    <ng-container *wattTableCell="columns['name']; header: t('columns.name'); let element">
+      {{ element.name }}
+    </ng-container>
+
+    <ng-container
+      *wattTableCell="columns['description']; header: t('columns.description'); let element"
+    >
+      {{ element.description }}
+    </ng-container>
   </watt-table>
 </ng-container>

--- a/libs/dh/admin/ui-permissions-table/src/lib/dh-permissions-table.component.ts
+++ b/libs/dh/admin/ui-permissions-table/src/lib/dh-permissions-table.component.ts
@@ -23,7 +23,7 @@ import {
   OnChanges,
   ViewChild,
 } from '@angular/core';
-import { translate } from '@ngneat/transloco';
+import { TranslocoModule } from '@ngneat/transloco';
 
 import {
   WattTableDataSource,
@@ -34,9 +34,9 @@ import {
 import { PermissionDetailsDto } from '@energinet-datahub/dh/shared/domain';
 
 @Component({
-  selector: 'dh-create-userrole-permissions-tab-table',
+  selector: 'dh-permissions-table',
   standalone: true,
-  templateUrl: './dh-create-userrole-permissions-tab-table.component.html',
+  templateUrl: './dh-permissions-table.component.html',
   styles: [
     `
       :host {
@@ -46,9 +46,9 @@ import { PermissionDetailsDto } from '@energinet-datahub/dh/shared/domain';
   ],
   // Using `OnPush` causes issues with table's header row translations
   changeDetection: ChangeDetectionStrategy.Default,
-  imports: [WATT_TABLE],
+  imports: [TranslocoModule, WATT_TABLE],
 })
-export class DhCreateRolePermissionTabTableComponent implements OnChanges {
+export class DhPermissionsTableComponent implements OnChanges {
   @Output() selectionChanged = new EventEmitter<PermissionDetailsDto[]>();
   @Input() permissions: PermissionDetailsDto[] = [];
 
@@ -62,11 +62,6 @@ export class DhCreateRolePermissionTabTableComponent implements OnChanges {
     name: { accessor: 'name' },
     description: { accessor: 'description' },
   };
-
-  translateHeader = (key: string) =>
-    translate(
-      `admin.userManagement.createrole.tabs.permissions.table.columns.${key}`
-    );
 
   ngOnChanges() {
     this.dataSource.data = this.permissions;

--- a/libs/dh/admin/ui-permissions-table/src/test-setup.ts
+++ b/libs/dh/admin/ui-permissions-table/src/test-setup.ts
@@ -1,0 +1,5 @@
+import 'jest-preset-angular/setup-jest';
+
+import { setUpTestbed } from '@energinet-datahub/gf/test-util-staging';
+
+setUpTestbed();

--- a/libs/dh/admin/ui-permissions-table/src/test-setup.ts
+++ b/libs/dh/admin/ui-permissions-table/src/test-setup.ts
@@ -1,3 +1,19 @@
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import 'jest-preset-angular/setup-jest';
 
 import { setUpTestbed } from '@energinet-datahub/gf/test-util-staging';

--- a/libs/dh/admin/ui-permissions-table/tsconfig.json
+++ b/libs/dh/admin/ui-permissions-table/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "target": "es2020",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/dh/admin/ui-permissions-table/tsconfig.lib.json
+++ b/libs/dh/admin/ui-permissions-table/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/test-setup.ts",
+    "**/*.spec.ts",
+    "jest.config.ts",
+    "**/*.test.ts"
+  ],
+  "include": ["**/*.ts"]
+}

--- a/libs/dh/admin/ui-permissions-table/tsconfig.spec.json
+++ b/libs/dh/admin/ui-permissions-table/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -1046,13 +1046,7 @@
           "permissions": {
             "tabLabel": "Rettigheder",
             "title": "Rettigheder",
-            "noPermissions": "Ingen rettigheder fundet til den valgte markedsrolle",
-            "table": {
-              "columns": {
-                "name": "Navn",
-                "description": "Beskrivelse"
-              }
-            }
+            "noPermissions": "Ingen rettigheder fundet til den valgte markedsrolle"
           }
         }
       },
@@ -1084,6 +1078,12 @@
         },
         "cancel": "Fortryd",
         "save": "Gem"
+      },
+      "permissionsTable": {
+        "columns": {
+          "name": "Navn",
+          "description": "Beskrivelse"
+        }
       }
     }
   }

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -1043,13 +1043,7 @@
           "permissions": {
             "tabLabel": "Permissions",
             "title": "Permissions",
-            "noPermissions": "No permissions found for the selected market role",
-            "table": {
-              "columns": {
-                "name": "Name",
-                "description": "Description"
-              }
-            }
+            "noPermissions": "No permissions found for the selected market role"
           }
         }
       },
@@ -1081,6 +1075,12 @@
         },
         "cancel": "Cancel",
         "save": "Save"
+      },
+      "permissionsTable": {
+        "columns": {
+          "name": "Name",
+          "description": "Description"
+        }
       }
     }
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -43,6 +43,9 @@
         "libs/dh/admin/routing/src/index.ts"
       ],
       "@energinet-datahub/dh/admin/shell": ["libs/dh/admin/shell/src/index.ts"],
+      "@energinet-datahub/dh/admin/ui-permissions-table": [
+        "libs/dh/admin/ui-permissions-table/src/index.ts"
+      ],
       "@energinet-datahub/dh/auth/msal": [
         "libs/dh/auth/feature-msal/src/index.ts"
       ],

--- a/workspace.json
+++ b/workspace.json
@@ -12,6 +12,7 @@
     "dh-admin-feature-user-roles": "libs/dh/admin/feature-user-roles",
     "dh-admin-routing": "libs/dh/admin/routing",
     "dh-admin-shell": "libs/dh/admin/shell",
+    "dh-admin-ui-permissions-table": "libs/dh/admin/ui-permissions-table",
     "dh-auth-feature-msal": "libs/dh/auth/feature-msal",
     "dh-charges-data-access-api": "libs/dh/charges/data-access-api",
     "dh-charges-domain": "libs/dh/charges/domain",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

### DataHub
- move permissions table component to its own library - `ui-permissions-table`. The idea is that the component is going to be used in "edit user role" soon.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/ARCHIVED-geh-post-office/issues/893
