### PR TITLE
bump versions on watt changes

### DIFF
--- a/.github/actions/yaml-increment-version/action.yaml
+++ b/.github/actions/yaml-increment-version/action.yaml
@@ -73,3 +73,5 @@ runs:
         commitChange: true
         message: 'Bump version to ${{ steps.semvers.outputs.patch }} for ${{ inputs.yaml-file }}'
         branch: ${{ github.head_ref }}
+        commitUserName: 'github-actions[bot]'
+        commitUserEmail: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/actions/yaml-increment-version/action.yaml
+++ b/.github/actions/yaml-increment-version/action.yaml
@@ -10,10 +10,10 @@ inputs:
     description: The yaml path containing the version to compare between the head (feature) branch and the base (main) branch.
     required: true
   base-yaml-file:
-    description: "Optional: The path of the yaml version file in the base (main) branch."
+    description: 'Optional: The path of the yaml version file in the base (main) branch.'
     required: false
   base-yaml-path:
-    description: "Optional: The path of the yaml version file in the base (main) branch."
+    description: 'Optional: The path of the yaml version file in the base (main) branch.'
     required: false
 
 runs:
@@ -43,7 +43,7 @@ runs:
     - name: Get next valid semvers
       id: semvers
       if: steps.is-prev-tag-valid.outcome == 'success'
-      uses: "WyriHaximus/github-action-next-semvers@v1"
+      uses: 'WyriHaximus/github-action-next-semvers@v1'
       with:
         version: ${{ steps.previous-tag.outputs.result }}
 
@@ -69,5 +69,5 @@ runs:
       with:
         valueFile: ${{ inputs.yaml-file }}
         propertyPath: ${{ inputs.yaml-path }}
-        value: "${{ steps.semvers.outputs.major }}.${{ steps.semvers.outputs.minor }}.${{ steps.semvers.outputs.patch }}"
+        value: '${{ steps.semvers.outputs.major }}.${{ steps.semvers.outputs.minor }}.${{ steps.semvers.outputs.patch }}'
         commitChange: true

--- a/.github/actions/yaml-increment-version/action.yaml
+++ b/.github/actions/yaml-increment-version/action.yaml
@@ -1,0 +1,73 @@
+name: Yaml Increment Version
+
+description: Increments the versions (semver)
+
+inputs:
+  yaml-file:
+    description: The path of the yaml file in the head (feature) branch.
+    required: true
+  yaml-path:
+    description: The yaml path containing the version to compare between the head (feature) branch and the base (main) branch.
+    required: true
+  base-yaml-file:
+    description: "Optional: The path of the yaml version file in the base (main) branch."
+    required: false
+  base-yaml-path:
+    description: "Optional: The path of the yaml version file in the base (main) branch."
+    required: false
+
+runs:
+  using: composite
+
+  steps:
+    - name: Checkout main to get latest tag
+      uses: actions/checkout@v3
+      with:
+        ref: main
+        fetch-depth: 0
+
+    - name: Get Previous tag
+      id: previous-tag
+      uses: Energinet-DataHub/energy-origin/.github/actions/yaml-get@main
+      with:
+        yaml_file: ${{ inputs.base-yaml-file || inputs.yaml-file }}
+        yaml_path: ${{ inputs.base-yaml-path || inputs.yaml-path }}
+
+    - name: Check if previous tag is valid semver
+      id: is-prev-tag-valid
+      uses: rubenesp87/semver-validation-action@cd30707b188980006854de19df716fc9cf39f37f
+      continue-on-error: true # Accept old versions to be invalid since new versions are checked they are valid
+      with:
+        version: ${{ steps.previous-tag.outputs.result }}
+
+    - name: Get next valid semvers
+      id: semvers
+      if: steps.is-prev-tag-valid.outcome == 'success'
+      uses: "WyriHaximus/github-action-next-semvers@v1"
+      with:
+        version: ${{ steps.previous-tag.outputs.result }}
+
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.head_ref }}
+
+    - name: Get current tag
+      id: current-tag
+      uses: Energinet-DataHub/energy-origin/.github/actions/yaml-get@main
+      with:
+        yaml_file: ${{ inputs.yaml-file }}
+        yaml_path: ${{ inputs.yaml-path }}
+
+    - name: Check if current tag is valid semver
+      uses: rubenesp87/semver-validation-action@cd30707b188980006854de19df716fc9cf39f37f
+      with:
+        version: ${{ steps.current-tag.outputs.result }}
+
+    - name: Increment version
+      if: ${{ steps.is-prev-tag-valid.outcome == 'success' && steps.current-tag.outputs.result != steps.semvers.outputs.patch && steps.current-tag.outputs.result != steps.semvers.outputs.minor && steps.current-tag.outputs.result != steps.semvers.outputs.major }}
+      uses: fjogeleit/yaml-update-action@d98ee6a10a971effea75480e3f315e4dacc89a23
+      with:
+        valueFile: ${{ inputs.yaml-file }}
+        propertyPath: ${{ inputs.yaml-path }}
+        value: "${{ steps.semvers.outputs.major }}.${{ steps.semvers.outputs.minor }}.${{ steps.semvers.outputs.patch }}"
+        commitChange: true

--- a/.github/actions/yaml-increment-version/action.yaml
+++ b/.github/actions/yaml-increment-version/action.yaml
@@ -72,4 +72,4 @@ runs:
         value: ${{ steps.semvers.outputs.patch }}
         commitChange: true
         message: 'Bump version to ${{ steps.semvers.outputs.patch }} for ${{ inputs.yaml-file }}'
-        branch: ${{ github.ref }}
+        branch: ${{ github.head_ref }}

--- a/.github/actions/yaml-increment-version/action.yaml
+++ b/.github/actions/yaml-increment-version/action.yaml
@@ -72,4 +72,4 @@ runs:
         value: ${{ steps.semvers.outputs.patch }}
         commitChange: true
         message: 'Bump version to ${{ steps.semvers.outputs.patch }} for ${{ inputs.yaml-file }}'
-        branch: ${{ github.event.pull_request }}
+        branch: ${{ github.ref }}

--- a/.github/actions/yaml-increment-version/action.yaml
+++ b/.github/actions/yaml-increment-version/action.yaml
@@ -69,5 +69,7 @@ runs:
       with:
         valueFile: ${{ inputs.yaml-file }}
         propertyPath: ${{ inputs.yaml-path }}
-        value: '${{ steps.semvers.outputs.major }}.${{ steps.semvers.outputs.minor }}.${{ steps.semvers.outputs.patch }}'
+        value: ${{ steps.semvers.outputs.patch }}
         commitChange: true
+        message: 'Bump version to ${{ steps.semvers.outputs.patch }} for ${{ inputs.yaml-file }}'
+        branch: ${{ github.event.pull_request.base.ref }}

--- a/.github/actions/yaml-increment-version/action.yaml
+++ b/.github/actions/yaml-increment-version/action.yaml
@@ -72,4 +72,4 @@ runs:
         value: ${{ steps.semvers.outputs.patch }}
         commitChange: true
         message: 'Bump version to ${{ steps.semvers.outputs.patch }} for ${{ inputs.yaml-file }}'
-        branch: ${{ github.event.pull_request.base.ref }}
+        branch: ${{ github.event.pull_request }}

--- a/.github/workflows/eo-cd.yml
+++ b/.github/workflows/eo-cd.yml
@@ -172,7 +172,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.EO_SONAR_TOKEN }}
 
-  helm_chart_version_increment_check:
+  bump_helm_chart_version:
     runs-on: ubuntu-latest
     name: Helm chart check version
     if: ${{ github.event_name == 'pull_request' && needs.affected.outputs.is-affected == 'true' }}
@@ -180,12 +180,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: Energinet-DataHub/energy-origin/.github/actions/yaml-check-incremented-version@main
+      - uses: ./.github/actions/yaml-increment-version
         with:
           yaml-file: build/infrastructure/eo/chart/Chart.yaml
           yaml-path: version
 
-  app_version_increment_check:
+  bump_app_version:
     runs-on: ubuntu-latest
     name: App check version
     if: ${{ github.event_name == 'pull_request' && needs.affected.outputs.is-affected == 'true' }}
@@ -193,7 +193,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: Energinet-DataHub/energy-origin/.github/actions/yaml-check-incremented-version@main
+      - uses: ./.github/actions/yaml-increment-version
         with:
           yaml-file: build/infrastructure/eo/chart/values.yaml
           yaml-path: app.image.tag

--- a/.github/workflows/eo-cd.yml
+++ b/.github/workflows/eo-cd.yml
@@ -174,7 +174,7 @@ jobs:
 
   bump_helm_chart_version:
     runs-on: ubuntu-latest
-    name: Helm chart check version
+    name: Bump Helm chart version
     if: ${{ github.event_name == 'pull_request' && needs.affected.outputs.is-affected == 'true' }}
     needs: affected
     steps:
@@ -187,7 +187,7 @@ jobs:
 
   bump_app_version:
     runs-on: ubuntu-latest
-    name: App check version
+    name: Bump App version
     if: ${{ github.event_name == 'pull_request' && needs.affected.outputs.is-affected == 'true' }}
     needs: affected
     steps:

--- a/libs/ui-watt/src/lib/components/card/watt-card.stories.ts
+++ b/libs/ui-watt/src/lib/components/card/watt-card.stories.ts
@@ -69,5 +69,5 @@ export const cardWithVariant: Story<WattCardComponent> = (args) => ({
 });
 
 cardWithVariant.args = {
-  variant: 'elevation',
+  variant: 'solid',
 };

--- a/libs/ui-watt/src/lib/components/card/watt-card.stories.ts
+++ b/libs/ui-watt/src/lib/components/card/watt-card.stories.ts
@@ -69,5 +69,5 @@ export const cardWithVariant: Story<WattCardComponent> = (args) => ({
 });
 
 cardWithVariant.args = {
-  variant: 'solid',
+  variant: 'elevation',
 };


### PR DESCRIPTION
This PR enables versions of helm chart and values files to me automagically bumped when changes to watt happens

See this PR to see it work https://github.com/Energinet-DataHub/greenforce-frontend/pull/1446