### PR TITLE
feat(dh): adjustments to edit user role modal

### DIFF
--- a/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
+++ b/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
@@ -29,10 +29,10 @@ limitations under the License.
               <watt-label>{{ t("tab.masterData.nameInputLabel") }}</watt-label>
               <input wattInput type="text" formControlName="name" />
               <watt-error *ngIf="userRoleEditForm.controls.name?.errors?.['nameAlreadyExists']">
-                {{ t("tab.masterData.errors.nameAlreadyExists") }}
+                {{ t("tab.validationErrors.nameAlreadyExists") }}
               </watt-error>
               <watt-error *ngIf="userRoleEditForm.controls.name?.errors?.['required']">
-                {{ t("tab.masterData.errors.required") }}
+                {{ t("tab.validationErrors.required") }}
               </watt-error>
             </watt-form-field>
 
@@ -40,7 +40,7 @@ limitations under the License.
               <watt-label>{{ t("tab.masterData.descriptionInputLabel") }}</watt-label>
               <textarea wattInput formControlName="description"></textarea>
               <watt-error *ngIf="userRoleEditForm.controls.description?.errors?.['required']">
-                {{ t("tab.masterData.errors.required") }}
+                {{ t("tab.validationErrors.required") }}
               </watt-error>
             </watt-form-field>
           </div>

--- a/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
+++ b/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
@@ -49,17 +49,21 @@ limitations under the License.
         <watt-tab [label]="t('tab.permissions.tabLabel')">
           <p class="watt-on-light--medium-emphasis">{{ t("tab.permissions.onEditMessage") }}</p>
 
-          <h4>{{ t("tab.permissions.title") }}</h4>
+          <watt-card variant="solid">
+            <watt-card-title>
+              <h4>{{ t("tab.permissions.title") }}</h4>
+            </watt-card-title>
 
-          <dh-permissions-table
-            [permissions]="marketRolePermissions$ | push: { strategy: 'local' }"
-            [initialSelection]="initiallySelectedPermissions$ | push"
-            (selectionChanged)="onSelectionChanged($event)"
-          ></dh-permissions-table>
+            <dh-permissions-table
+              [permissions]="marketRolePermissions$ | push: { strategy: 'global' }"
+              [initialSelection]="initiallySelectedPermissions$ | push"
+              (selectionChanged)="onSelectionChanged($event)"
+            ></dh-permissions-table>
 
-          <div class="spinner-container" *ngIf="marketRolePermissionsIsLoading$ | push">
-            <watt-spinner></watt-spinner>
-          </div>
+            <div class="spinner-container" *ngIf="marketRolePermissionsIsLoading$ | push">
+              <watt-spinner></watt-spinner>
+            </div>
+          </watt-card>
         </watt-tab>
       </watt-tabs>
     </form>

--- a/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
+++ b/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
@@ -49,6 +49,13 @@ limitations under the License.
         <watt-tab [label]="t('tab.permissions.tabLabel')">
           <p class="watt-on-light--medium-emphasis">{{ t("tab.permissions.onEditMessage") }}</p>
 
+          <div
+            class="watt-space-stack-m"
+            *ngIf="userRoleEditForm.dirty && userRoleEditForm.controls.permissionIds.errors?.['required']"
+          >
+            <watt-error>{{ t("tab.validationErrors.permissionRequired") }}</watt-error>
+          </div>
+
           <watt-card variant="solid">
             <watt-card-title>
               <h4>{{ t("tab.permissions.title") }}</h4>

--- a/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
+++ b/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.html
@@ -56,6 +56,10 @@ limitations under the License.
             [initialSelection]="initiallySelectedPermissions$ | push"
             (selectionChanged)="onSelectionChanged($event)"
           ></dh-permissions-table>
+
+          <div class="spinner-container" *ngIf="marketRolePermissionsIsLoading$ | push">
+            <watt-spinner></watt-spinner>
+          </div>
         </watt-tab>
       </watt-tabs>
     </form>

--- a/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.ts
+++ b/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.ts
@@ -38,6 +38,7 @@ import { WattFormFieldModule } from '@energinet-datahub/watt/form-field';
 import { WattInputModule } from '@energinet-datahub/watt/input';
 import { WattModalComponent, WattModalModule } from '@energinet-datahub/watt/modal';
 import { WattTabsModule } from '@energinet-datahub/watt/tabs';
+import { WattSpinnerModule } from '@energinet-datahub/watt/spinner';
 import {
   DhAdminMarketRolePermissionsStore,
   DhAdminUserRoleEditDataAccessApiStore,
@@ -64,6 +65,12 @@ import { DhPermissionsTableComponent } from '@energinet-datahub/dh/admin/ui-perm
         padding-top: var(--watt-space-l);
         width: 25rem;
       }
+
+      .spinner-container {
+        display: flex;
+        justify-content: center;
+        margin-top: var(--watt-space-m);
+      }
     `,
   ],
   providers: [DhAdminUserRoleEditDataAccessApiStore, DhAdminMarketRolePermissionsStore],
@@ -78,6 +85,7 @@ import { DhPermissionsTableComponent } from '@energinet-datahub/dh/admin/ui-perm
     WattFormFieldModule,
     WattInputModule,
     ReactiveFormsModule,
+    WattSpinnerModule,
     DhPermissionsTableComponent,
   ],
 })
@@ -114,6 +122,7 @@ export class DhEditUserRoleModalComponent implements OnInit, AfterViewInit, OnDe
       this.skipFirstPermissionSelectionEvent = initiallySelectedPermissions.length > 0;
     })
   );
+  readonly marketRolePermissionsIsLoading$ = this.marketRolePermissionsStore.isLoading$;
 
   readonly isLoading$ = this.userRoleEditStore.isLoading$;
   readonly hasValidationError$ = this.userRoleEditStore.hasValidationError$;

--- a/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.ts
+++ b/libs/dh/admin/feature-edit-user-role-modal/src/lib/dh-edit-user-role-modal.component.ts
@@ -39,6 +39,7 @@ import { WattInputModule } from '@energinet-datahub/watt/input';
 import { WattModalComponent, WattModalModule } from '@energinet-datahub/watt/modal';
 import { WattTabsModule } from '@energinet-datahub/watt/tabs';
 import { WattSpinnerModule } from '@energinet-datahub/watt/spinner';
+import { WattCardModule } from '@energinet-datahub/watt/card';
 import {
   DhAdminMarketRolePermissionsStore,
   DhAdminUserRoleEditDataAccessApiStore,
@@ -86,6 +87,7 @@ import { DhPermissionsTableComponent } from '@energinet-datahub/dh/admin/ui-perm
     WattInputModule,
     ReactiveFormsModule,
     WattSpinnerModule,
+    WattCardModule,
     DhPermissionsTableComponent,
   ],
 })

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -1080,7 +1080,8 @@
           },
           "validationErrors": {
             "nameAlreadyExists": "En bruger rolle med dette navn findes allerede",
-            "required": "Feltet er påkrævet"
+            "required": "Feltet er påkrævet",
+            "permissionRequired": "Vælg minimum én rettighed"
           }
         },
         "cancel": "Fortryd",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -1071,16 +1071,16 @@
           "masterData": {
             "tabLabel": "Stamdata",
             "nameInputLabel": "Navn",
-            "descriptionInputLabel": "Beskrivelse",
-            "errors": {
-              "nameAlreadyExists": "En bruger rolle med dette navn findes allerede",
-              "required": "Feltet er påkrævet"
-            }
+            "descriptionInputLabel": "Beskrivelse"
           },
           "permissions": {
             "tabLabel": "Rettigheder",
             "title": "Rettigheder",
             "onEditMessage": "Ved fjern/tilføj af rettigheder til en brugerrolle, kan det tage op til en time, før ændringer træder i kraft, efter de er gemt. Alternativt kan brugere logge ud og ind, hvis ændringer skal træde i kraft med det samme."
+          },
+          "validationErrors": {
+            "nameAlreadyExists": "En bruger rolle med dette navn findes allerede",
+            "required": "Feltet er påkrævet"
           }
         },
         "cancel": "Fortryd",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -1068,16 +1068,16 @@
           "masterData": {
             "tabLabel": "Master data",
             "nameInputLabel": "Name",
-            "descriptionInputLabel": "Description",
-            "errors": {
-              "nameAlreadyExists": "The user role already exists",
-              "required": "Field is required"
-            }
+            "descriptionInputLabel": "Description"
           },
           "permissions": {
             "tabLabel": "Permissions",
             "title": "Permissions",
             "onEditMessage": "When removing/adding rights to a user role, it can take up to an hour for changes to take effect after they have been saved. Alternatively, users can log out and log in if changes are to take effect immediately."
+          },
+          "validationErrors": {
+            "nameAlreadyExists": "The user role already exists",
+            "required": "Field is required"
           }
         },
         "cancel": "Cancel",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -1077,7 +1077,8 @@
           },
           "validationErrors": {
             "nameAlreadyExists": "The user role already exists",
-            "required": "Field is required"
+            "required": "Field is required",
+            "permissionRequired": "Select at least one permission"
           }
         },
         "cancel": "Cancel",


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### DataHub
- add spinner to permissions tab
- wrap permissions table in card
- show validation message in permissions tab

![image](https://user-images.githubusercontent.com/1096332/222166979-18df772a-5343-4352-8ea8-9688fcd064c3.png)

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/ARCHIVED-geh-post-office/issues/893
