### PR TITLE
feat(wholesale): add non-profiled consumption per grid area step

### DIFF
--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -804,9 +804,10 @@
     },
     "processStepResults": {
       "step": "Trin {{step}}",
-      "aggregatedProductionPerGridArea": "Kvartersafregnet forbrug per netområde",
+      "aggregatedProductionPerGridArea": "Produktion per netområde",
       "aggregatedConsumptionPerEnergySupplier": "Kvartersafregnet forbrug per elleverandør",
       "nonProfiledConsumptionPerBalanceResponsible": "Kvartersafregnet forbrug per balanceansvarlig",
+      "nonProfiledConsumptionPerGridArea": "Kvartersafregnet forbrug per netområde",
       "gridArea": "Netområde",
       "energySupplier": "El-leverandør",
       "meteringPointType": "Målepunktstype",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -813,9 +813,10 @@
     },
     "processStepResults": {
       "step": "Step {{step}}",
-      "aggregatedProductionPerGridArea": "Non-profiled consumption per grid area",
+      "aggregatedProductionPerGridArea": "Production per grid area",
       "aggregatedConsumptionPerEnergySupplier": "Non-profiled consumption per Energy Supplier",
       "nonProfiledConsumptionPerBalanceResponsible": "Non-profiled consumption per Balance Responsible Party",
+      "nonProfiledConsumptionPerGridArea": "Non-profiled consumption per grid area",
       "gridArea": "Grid area",
       "energySupplier": "Energy Supplier",
       "meteringPointType": "Metering point type",

--- a/libs/dh/wholesale/feature-calculation-steps/src/lib/dh-wholesale-calculation-steps.component.html
+++ b/libs/dh/wholesale/feature-calculation-steps/src/lib/dh-wholesale-calculation-steps.component.html
@@ -128,6 +128,14 @@ limitations under the License.
           </ng-template>
         </watt-expandable-card>
       </li>
+      <li>
+        <watt-card>
+          <h4>
+            <watt-badge size="large" class="watt-space-inline-m">4</watt-badge>
+            {{ t("processStepResults.nonProfiledConsumptionPerGridArea") }}
+          </h4>
+        </watt-card>
+      </li>
     </ul>
 
     <aside class="details">


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Add non-profiled consumption per grid area step
![image](https://user-images.githubusercontent.com/86852536/222671511-2a51be29-d0ea-4cdd-90b9-160af9b78aea.png)

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#820](https://github.com/Energinet-DataHub/opengeh-wholesale/issues/820)
