### PR TITLE
feat(shared): add global error handler for graphql logging to application insights

### DIFF
--- a/libs/dh/shared/data-access-graphql/src/lib/error-handler.ts
+++ b/libs/dh/shared/data-access-graphql/src/lib/error-handler.ts
@@ -1,11 +1,12 @@
 import { onError } from '@apollo/client/link/error';
 
-import { DhApplicationInsights } from "@energinet-datahub/dh/shared/util-application-insights";
+import { DhApplicationInsights } from '@energinet-datahub/dh/shared/util-application-insights';
 
-export const errorHandler = (logger: DhApplicationInsights) => onError(({ graphQLErrors }) => {
-  if (graphQLErrors) {
-    graphQLErrors.map(({ message }) => {
+export const errorHandler = (logger: DhApplicationInsights) =>
+  onError(({ graphQLErrors }) => {
+    if (graphQLErrors) {
+      graphQLErrors.map(({ message }) => {
         logger.trackException(new Error(message), 3);
-    });
-  }
-});
+      });
+    }
+  });

--- a/libs/dh/shared/data-access-graphql/src/lib/error-handler.ts
+++ b/libs/dh/shared/data-access-graphql/src/lib/error-handler.ts
@@ -1,3 +1,19 @@
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { onError } from '@apollo/client/link/error';
 
 import { DhApplicationInsights } from '@energinet-datahub/dh/shared/util-application-insights';

--- a/libs/dh/shared/data-access-graphql/src/lib/error-handler.ts
+++ b/libs/dh/shared/data-access-graphql/src/lib/error-handler.ts
@@ -1,0 +1,11 @@
+import { onError } from '@apollo/client/link/error';
+
+import { DhApplicationInsights } from "@energinet-datahub/dh/shared/util-application-insights";
+
+export const errorHandler = (logger: DhApplicationInsights) => onError(({ graphQLErrors }) => {
+  if (graphQLErrors) {
+    graphQLErrors.map(({ message }) => {
+        logger.trackException(new Error(message), 3);
+    });
+  }
+});


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Add global error handler for graphql logging to application insights.
Because requests made by graphQL, which returns errors, still return status 200, these are not automatically logged to application insights. 

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
