### PR TITLE
feat(dh): refresh data when permission edit is successful

### DIFF
--- a/libs/dh/admin/feature-permissions/src/lib/details/dh-admin-permission-detail.component.html
+++ b/libs/dh/admin/feature-permissions/src/lib/details/dh-admin-permission-detail.component.html
@@ -58,5 +58,5 @@ limitations under the License.
 <dh-edit-permission-modal
   *ngIf="isEditPermissionModalVisible && selectedPermission"
   [permission]="selectedPermission"
-  (closed)="modalOnClose()"
+  (closed)="modalOnClose($event)"
 ></dh-edit-permission-modal>

--- a/libs/dh/admin/feature-permissions/src/lib/details/dh-admin-permission-detail.component.ts
+++ b/libs/dh/admin/feature-permissions/src/lib/details/dh-admin-permission-detail.component.ts
@@ -58,6 +58,7 @@ export class DhAdminPermissionDetailComponent {
   isEditPermissionModalVisible = false;
 
   @Output() closed = new EventEmitter<void>();
+  @Output() refreshData = new EventEmitter<void>();
 
   onClose(): void {
     this.drawer.close();
@@ -70,7 +71,11 @@ export class DhAdminPermissionDetailComponent {
     this.drawer.open();
   }
 
-  modalOnClose(): void {
+  modalOnClose({ saveSuccess }: { saveSuccess: boolean }): void {
     this.isEditPermissionModalVisible = false;
+
+    if (saveSuccess) {
+      this.refreshData.emit();
+    }
   }
 }

--- a/libs/dh/admin/feature-permissions/src/lib/overview/dh-admin-permission-overview.component.html
+++ b/libs/dh/admin/feature-permissions/src/lib/overview/dh-admin-permission-overview.component.html
@@ -49,4 +49,7 @@ limitations under the License.
   ></watt-empty-state>
 </watt-card>
 
-<dh-admin-permission-detail (closed)="onClosed()"></dh-admin-permission-detail>
+<dh-admin-permission-detail
+  (closed)="onClosed()"
+  (refreshData)="onRefreshData()"
+></dh-admin-permission-detail>

--- a/libs/dh/admin/feature-permissions/src/lib/overview/dh-admin-permission-overview.component.ts
+++ b/libs/dh/admin/feature-permissions/src/lib/overview/dh-admin-permission-overview.component.ts
@@ -66,28 +66,28 @@ export class DhAdminPermissionOverviewComponent implements OnInit, OnDestroy {
   @ViewChild(DhAdminPermissionDetailComponent)
   permissionDetail!: DhAdminPermissionDetailComponent;
 
+  private getPermissionQuery = this.apollo.watchQuery({
+    useInitialLoading: true,
+    notifyOnNetworkStatusChange: true,
+    query: graphql.GetPermissionsDocument,
+  });
+
   ngOnDestroy(): void {
     this.subscription.unsubscribe();
   }
 
   ngOnInit(): void {
-    this.subscription = this.apollo
-      .watchQuery({
-        useInitialLoading: true,
-        notifyOnNetworkStatusChange: true,
-        query: graphql.GetPermissionsDocument,
-      })
-      .valueChanges.subscribe({
-        next: (result) => {
-          this.permissions = result.data?.permissions ?? undefined;
-          this.loading = result.loading;
-          this.error = result.error;
-          this.dataSource.data = result.data?.permissions ?? [];
-        },
-        error: (error) => {
-          this.error = error;
-        },
-      });
+    this.subscription = this.getPermissionQuery.valueChanges.subscribe({
+      next: (result) => {
+        this.permissions = result.data?.permissions ?? undefined;
+        this.loading = result.loading;
+        this.error = result.error;
+        this.dataSource.data = result.data?.permissions ?? [];
+      },
+      error: (error) => {
+        this.error = error;
+      },
+    });
   }
 
   onRowClick(row: PermissionDto): void {
@@ -97,5 +97,9 @@ export class DhAdminPermissionOverviewComponent implements OnInit, OnDestroy {
 
   onClosed(): void {
     this.activeRow = undefined;
+  }
+
+  onRefreshData(): void {
+    this.getPermissionQuery.refetch();
   }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

### DataHub
- refresh data when permission edit is successful

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/Titans/issues/13
