### PR TITLE
feat(dh): refresh data in drawer when permission edit is successful

### DIFF
--- a/libs/dh/admin/feature-permissions/src/lib/details/dh-admin-permission-detail.component.ts
+++ b/libs/dh/admin/feature-permissions/src/lib/details/dh-admin-permission-detail.component.ts
@@ -17,6 +17,7 @@
 import { Component, ViewChild, Output, EventEmitter, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslocoModule } from '@ngneat/transloco';
+import { map, Subscription } from 'rxjs';
 
 import { WattDrawerComponent, WattDrawerModule } from '@energinet-datahub/watt/drawer';
 import { WattCardModule } from '@energinet-datahub/watt/card';
@@ -29,6 +30,8 @@ import { WattButtonModule } from '@energinet-datahub/watt/button';
 import { DhPermissionRequiredDirective } from '@energinet-datahub/dh/shared/feature-authorization';
 import { DhEditPermissionModalComponent } from '@energinet-datahub/dh/admin/feature-edit-permission-modal';
 import { PermissionDto } from '@energinet-datahub/dh/shared/domain';
+
+import { getPermissionsWatchQuery } from '../shared/dh-get-permissions-watch-query';
 
 @Component({
   selector: 'dh-admin-permission-detail',
@@ -51,6 +54,9 @@ import { PermissionDto } from '@energinet-datahub/dh/shared/domain';
   ],
 })
 export class DhAdminPermissionDetailComponent {
+  private getPermissionQuery = getPermissionsWatchQuery();
+  private subscription?: Subscription;
+
   @ViewChild(WattDrawerComponent)
   drawer!: WattDrawerComponent;
 
@@ -64,10 +70,14 @@ export class DhAdminPermissionDetailComponent {
     this.drawer.close();
     this.closed.emit();
     this.selectedPermission = null;
+
+    this.subscription?.unsubscribe();
   }
 
   open(permission: PermissionDto): void {
-    this.selectedPermission = permission;
+    this.subscription?.unsubscribe();
+    this.loadData(permission.id);
+
     this.drawer.open();
   }
 
@@ -77,5 +87,19 @@ export class DhAdminPermissionDetailComponent {
     if (saveSuccess) {
       this.refreshData.emit();
     }
+  }
+
+  private loadData(permissionId: number): void {
+    this.subscription = this.getPermissionQuery.valueChanges
+      .pipe(
+        map((result) =>
+          result.data.permissions.find((permission) => permission.id === permissionId)
+        )
+      )
+      .subscribe({
+        next: (result) => {
+          this.selectedPermission = result ?? null;
+        },
+      });
   }
 }

--- a/libs/dh/admin/feature-permissions/src/lib/overview/dh-admin-permission-overview.component.ts
+++ b/libs/dh/admin/feature-permissions/src/lib/overview/dh-admin-permission-overview.component.ts
@@ -14,22 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ApolloError } from '@apollo/client';
-import { Apollo } from 'apollo-angular';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Subscription } from 'rxjs';
 
 import { DhPermissionsTableComponent } from '@energinet-datahub/dh/admin/ui-permissions-table';
 import { WattEmptyStateModule } from '@energinet-datahub/watt/empty-state';
 import { WattSpinnerModule } from '@energinet-datahub/watt/spinner';
-import { graphql, PermissionDto } from '@energinet-datahub/dh/shared/domain';
+import { PermissionDto } from '@energinet-datahub/dh/shared/domain';
 import { DhEmDashFallbackPipeScam } from '@energinet-datahub/dh/shared/ui-util';
 import { WattTableColumnDef, WattTableDataSource, WATT_TABLE } from '@energinet-datahub/watt/table';
 import { WattCardModule } from '@energinet-datahub/watt/card';
 
 import { DhAdminPermissionDetailComponent } from '../details/dh-admin-permission-detail.component';
+import { getPermissionsWatchQuery } from '../shared/dh-get-permissions-watch-query';
 
 @Component({
   selector: 'dh-admin-permission-overview',
@@ -49,8 +49,9 @@ import { DhAdminPermissionDetailComponent } from '../details/dh-admin-permission
   ],
 })
 export class DhAdminPermissionOverviewComponent implements OnInit, OnDestroy {
-  private apollo = inject(Apollo);
-  subscription!: Subscription;
+  private getPermissionQuery = getPermissionsWatchQuery();
+  private subscription!: Subscription;
+
   permissions?: PermissionDto[];
   loading = false;
   error?: ApolloError;
@@ -65,12 +66,6 @@ export class DhAdminPermissionOverviewComponent implements OnInit, OnDestroy {
 
   @ViewChild(DhAdminPermissionDetailComponent)
   permissionDetail!: DhAdminPermissionDetailComponent;
-
-  private getPermissionQuery = this.apollo.watchQuery({
-    useInitialLoading: true,
-    notifyOnNetworkStatusChange: true,
-    query: graphql.GetPermissionsDocument,
-  });
 
   ngOnDestroy(): void {
     this.subscription.unsubscribe();

--- a/libs/dh/admin/feature-permissions/src/lib/shared/dh-get-permissions-watch-query.ts
+++ b/libs/dh/admin/feature-permissions/src/lib/shared/dh-get-permissions-watch-query.ts
@@ -1,3 +1,19 @@
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { inject } from '@angular/core';
 import { Apollo } from 'apollo-angular';
 

--- a/libs/dh/admin/feature-permissions/src/lib/shared/dh-get-permissions-watch-query.ts
+++ b/libs/dh/admin/feature-permissions/src/lib/shared/dh-get-permissions-watch-query.ts
@@ -1,0 +1,14 @@
+import { inject } from '@angular/core';
+import { Apollo } from 'apollo-angular';
+
+import { graphql } from '@energinet-datahub/dh/shared/domain';
+
+export function getPermissionsWatchQuery() {
+  const apollo = inject(Apollo);
+
+  return apollo.watchQuery({
+    useInitialLoading: true,
+    notifyOnNetworkStatusChange: true,
+    query: graphql.GetPermissionsDocument,
+  });
+}

--- a/libs/dh/shared/feature-flags/src/lib/feature-flags.service.ts
+++ b/libs/dh/shared/feature-flags/src/lib/feature-flags.service.ts
@@ -40,9 +40,6 @@ export class DhFeatureFlagsService {
     dhEnvironment: DhAppEnvironmentConfig,
     @Inject(dhFeatureFlagsToken) private dhFeatureFlags: FeatureFlagConfig
   ) {
-    /**
-     * Treat pre-prod as prod
-     */
     this.environment = dhEnvironment.current;
   }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### DataHub
- refresh data in drawer when permission edit is successful

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/Titans/issues/13
