### PR TITLE
fix(wholesale): make sure settlement reports aren't calling the API twice at init

### DIFF
--- a/libs/dh/wholesale/feature-settlement-reports/src/lib/dh-wholesale-settlement-reports.component.ts
+++ b/libs/dh/wholesale/feature-settlement-reports/src/lib/dh-wholesale-settlement-reports.component.ts
@@ -79,6 +79,8 @@ export class DhWholesaleSettlementReportsComponent implements OnInit, OnDestroy 
   };
 
   query = this.apollo.watchQuery({
+    fetchPolicy: 'cache-only',
+    nextFetchPolicy: 'cache-first',
     useInitialLoading: true,
     notifyOnNetworkStatusChange: true,
     query: graphql.GetSettlementReportsDocument,


### PR DESCRIPTION
## Description

Make sure settlement reports aren't calling the API twice at init

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

