### PR TITLE
Use correct scope property name. (wip)

### DIFF
--- a/libs/dh/auth/feature-msal/src/lib/b2c-config.ts
+++ b/libs/dh/auth/feature-msal/src/lib/b2c-config.ts
@@ -66,7 +66,7 @@ export function MSALInterceptorConfigFactory(
   // Note: A scope value of `null` indicates that a resource is to be unprotected and will not get tokens.
   // The order here matters. Resources with `null` scope must be first.
   protectedResourceMap.set('/assets/*', null);
-  protectedResourceMap.set('*', [config.backendId || config.clientId]);
+  protectedResourceMap.set('*', [config.scopeUri]);
 
   return {
     interactionType: InteractionType.Redirect,
@@ -77,6 +77,6 @@ export function MSALInterceptorConfigFactory(
 export function MSALGuardConfigFactory(config: DhB2CEnvironment): MsalGuardConfiguration {
   return {
     interactionType: InteractionType.Redirect,
-    authRequest: { scopes: [config.backendId || config.clientId] },
+    authRequest: { scopes: [config.scopeUri] },
   };
 }

--- a/libs/dh/shared/environments/src/lib/b2c-environment/dh-b2c-environment.ts
+++ b/libs/dh/shared/environments/src/lib/b2c-environment/dh-b2c-environment.ts
@@ -21,7 +21,7 @@ import { environment } from '../environment';
 
 export interface DhB2CEnvironment {
   readonly clientId: string;
-  readonly backendId: string | null;
+  readonly scopeUri: string;
   readonly authority: string;
   readonly knownAuthorities: string[];
 }


### PR DESCRIPTION
Property containing the scope URI to access BFF ressource is now correctly named and is no longer nullable.