### PR TITLE
feat(dh): add query param for graphQL request with the operation name

### DIFF
--- a/libs/dh/shared/data-access-graphql/src/lib/dh-graphql.module.ts
+++ b/libs/dh/shared/data-access-graphql/src/lib/dh-graphql.module.ts
@@ -17,7 +17,7 @@
 import { ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core';
 import { ApolloModule, APOLLO_OPTIONS } from 'apollo-angular';
 import { HttpLink } from 'apollo-angular/http';
-import { InMemoryCache, ApolloLink } from '@apollo/client/core';
+import { InMemoryCache, ApolloLink, Operation } from '@apollo/client/core';
 
 import { DhApiEnvironment, dhApiEnvironmentToken } from '@energinet-datahub/dh/shared/environments';
 import { DhApplicationInsights } from '@energinet-datahub/dh/shared/util-application-insights';
@@ -62,7 +62,11 @@ export class DhGraphQLModule {
               }),
               link: ApolloLink.from([
                 errorHandler(dhApplicationInsights),
-                httpLink.create({ uri: `${dhApiEnvironment.apiBase}/graphql` }),
+                httpLink.create({
+                  uri: (operation: Operation) => {
+                    return `${dhApiEnvironment.apiBase}/graphql?${operation.operationName}`;
+                  },
+                }),
               ]),
             };
           },


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Add query param for graphQL request with the operation name. 
Before, all requests were `/graphql` in the network tab. Now, the operation name is added `/graphql?some-awesome-operation` to make it easier to identify the requests. 


