### PR TITLE
Improve graphql error handler

### DIFF
--- a/libs/dh/shared/data-access-graphql/src/lib/error-handler.ts
+++ b/libs/dh/shared/data-access-graphql/src/lib/error-handler.ts
@@ -21,8 +21,8 @@ import { DhApplicationInsights } from '@energinet-datahub/dh/shared/util-applica
 export const errorHandler = (logger: DhApplicationInsights) =>
   onError(({ graphQLErrors }) => {
     if (graphQLErrors) {
-      graphQLErrors.map(({ message }) => {
-        logger.trackException(new Error(message), 3);
+      graphQLErrors.map(({message, extensions}) => {
+        logger.trackException(new Error(extensions['details'] as string || message), 3);
       });
     }
   });

--- a/libs/dh/shared/data-access-graphql/src/lib/error-handler.ts
+++ b/libs/dh/shared/data-access-graphql/src/lib/error-handler.ts
@@ -21,8 +21,8 @@ import { DhApplicationInsights } from '@energinet-datahub/dh/shared/util-applica
 export const errorHandler = (logger: DhApplicationInsights) =>
   onError(({ graphQLErrors }) => {
     if (graphQLErrors) {
-      graphQLErrors.map(({message, extensions}) => {
-        logger.trackException(new Error(extensions['details'] as string || message), 3);
+      graphQLErrors.map(({ message, extensions }) => {
+        logger.trackException(new Error((extensions['details'] as string) || message), 3);
       });
     }
   });


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Improve graphql error handler

- Use error details instead of just the message to make it easier to debug the error based of logged exceptions in application insights. If no details are available, the message will be used as a fallback. 

**Before:** `Error trying to resolve field 'batches'.`

**After:** `GraphQL.Execution.UnhandledError: Error trying to resolve field 'batches'.\r\n ---> System.InvalidOperationException: No service for type 'Energinet.DataHub.WebApi.AuthorizedHttpClientFactory' has been registered.\r\n   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider provider, Type serviceType)\r\n   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)\r\n   at Energinet.DataHub.WebApi.Registr...`
