### PR TITLE
fix: add yarn and angular cache to watcherExclude

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,11 @@
       "siblings_only": true
     }
   },
-  "redhat.telemetry.enabled": false
+  "redhat.telemetry.enabled": false,
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.yarn/cache/**": true,
+    "**/.angular/cache/**": true,
+    "**/node_modules/*/**": true
+  }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
I was seeing an error in VS Code due to too many files being watched. This change appears to fix the issue for me.
