### PR TITLE
fix(dh): trying to fix flaky b2c healthchecks

### DIFF
--- a/apps/dh/e2e-dh/src/e2e/b2c-healthchecks.cy.ts
+++ b/apps/dh/e2e-dh/src/e2e/b2c-healthchecks.cy.ts
@@ -30,7 +30,7 @@ const environments = [
 ];
 
 environments.forEach((env) => {
-  it(`[B2C Healthcheck] ${env.name}`, () => {
+  it(`[B2C Healthcheck] ${env.name}`, {retries: 3}, () => {
     // Should be able to reach the app
     cy.request(env.url).then((resp) => {
       expect(resp.status).to.eq(200);
@@ -38,7 +38,7 @@ environments.forEach((env) => {
 
     // Should have correct redirect_uri
     cy.visit(env.url);
-    cy.location('href').should((url) => {
+    cy.location('href', {timeout: 10000}).should((url) => {
       expect(url).to.include(`redirect_uri=${encodeURIComponent(env.url)}`);
     });
   });

--- a/apps/dh/e2e-dh/src/e2e/b2c-healthchecks.cy.ts
+++ b/apps/dh/e2e-dh/src/e2e/b2c-healthchecks.cy.ts
@@ -30,7 +30,7 @@ const environments = [
 ];
 
 environments.forEach((env) => {
-  it(`[B2C Healthcheck] ${env.name}`, {retries: 3}, () => {
+  it(`[B2C Healthcheck] ${env.name}`, { retries: 3 }, () => {
     // Should be able to reach the app
     cy.request(env.url).then((resp) => {
       expect(resp.status).to.eq(200);
@@ -38,7 +38,7 @@ environments.forEach((env) => {
 
     // Should have correct redirect_uri
     cy.visit(env.url);
-    cy.location('href', {timeout: 10000}).should((url) => {
+    cy.location('href', { timeout: 10000 }).should((url) => {
       expect(url).to.include(`redirect_uri=${encodeURIComponent(env.url)}`);
     });
   });


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
Trying to fix flaky b2c health checks
- Increasing the timeout for the redirect to `10000ms`
- Setting the retries to `3` 