### PR TITLE
feat(ci): set dotnet version in pipelines

### DIFF
--- a/.github/workflows/dh-ci-dotnet.yml
+++ b/.github/workflows/dh-ci-dotnet.yml
@@ -28,6 +28,7 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-build-prerelease.yml@v10
     with:
       solution_file_path: apps/dh/api-dh/DataHub.WebApi.sln
+      dotnet_version: 7.0.203
       release_name_prefix: ui_dotnet
 
   # Run all tests in 'Tests.dll'
@@ -38,6 +39,7 @@ jobs:
       tests_dll_file_path: \apps\dh\api-dh\source\DataHub.WebApi.Tests\bin\Release\net7.0\Energinet.DataHub.WebApi.Tests.dll
       download_attempt_limit: 12
       environment: AzureAuth
+      dotnet_version: 7.0.203
     secrets:
       azure_tenant_id: ${{ secrets.azure_tenant_id }}
       azure_subscription_id: ${{ secrets.azure_subscription_id }}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

### Workspace
- set .NET version in pipelines

Note: The default version is 6.0.408 as seen in [this run](https://github.com/Energinet-DataHub/greenforce-frontend/actions/runs/4828488928/jobs/8603196565).

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- N/A
