### PR TITLE
chore: bump `.github` workflows to v11

### DIFF
--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -28,7 +28,7 @@ jobs:
   # Markdown check and YAML validation
   #
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@v10
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@v11
     with:
       skip_license_check: true # Handled by another workflow
       skip_yaml_lint: false

--- a/.github/workflows/dh-cd.yml
+++ b/.github/workflows/dh-cd.yml
@@ -35,7 +35,7 @@ jobs:
   dotnet_update_coverage_report:
     needs: changes
     if: ${{ needs.changes.outputs.dh_dotnet == 'true' }}
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@v10
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@v11
     with:
       solution_file_path: apps/dh/api-dh/DataHub.WebApi.sln
       environment: AzureAuth
@@ -49,7 +49,7 @@ jobs:
   dotnet_promote_prerelease:
     needs: changes
     if: ${{ needs.changes.outputs.dh_dotnet == 'true' }}
-    uses: Energinet-DataHub/.github/.github/workflows/promote-prerelease.yml@v10
+    uses: Energinet-DataHub/.github/.github/workflows/promote-prerelease.yml@v11
     with:
       release_name_prefix: ui_dotnet
 
@@ -60,7 +60,7 @@ jobs:
   frontend_promote_prerelease:
     needs: changes
     if: ${{ needs.changes.outputs.dh_frontend == 'true' }}
-    uses: Energinet-DataHub/.github/.github/workflows/promote-prerelease.yml@v10
+    uses: Energinet-DataHub/.github/.github/workflows/promote-prerelease.yml@v11
     with:
       release_name_prefix: ui_frontend
 
@@ -83,7 +83,7 @@ jobs:
       - run: echo "${{ toJSON(needs) }}"
 
       - name: Find associated pull request
-        uses: Energinet-DataHub/.github/.github/actions/find-related-pr-number@v10
+        uses: Energinet-DataHub/.github/.github/actions/find-related-pr-number@v11
         id: find_pull_request
 
       - name: Repository Dispatch
@@ -109,7 +109,7 @@ jobs:
     if: |
       always() &&
       contains(needs.*.result, 'failure')
-    uses: Energinet-DataHub/.github/.github/workflows/notify-team.yml@v10
+    uses: Energinet-DataHub/.github/.github/workflows/notify-team.yml@v11
     with:
       team_name: TexasRangers
       subject: "Deployment dispatch failed: UI + BFF"

--- a/.github/workflows/dh-ci-dotnet.yml
+++ b/.github/workflows/dh-ci-dotnet.yml
@@ -28,7 +28,6 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-build-prerelease.yml@v10
     with:
       solution_file_path: apps/dh/api-dh/DataHub.WebApi.sln
-      dotnet_version: 7.0.203
       release_name_prefix: ui_dotnet
 
   # Run all tests in 'Tests.dll'
@@ -39,7 +38,6 @@ jobs:
       tests_dll_file_path: \apps\dh\api-dh\source\DataHub.WebApi.Tests\bin\Release\net7.0\Energinet.DataHub.WebApi.Tests.dll
       download_attempt_limit: 12
       environment: AzureAuth
-      dotnet_version: 7.0.203
     secrets:
       azure_tenant_id: ${{ secrets.azure_tenant_id }}
       azure_subscription_id: ${{ secrets.azure_subscription_id }}

--- a/.github/workflows/dh-ci-dotnet.yml
+++ b/.github/workflows/dh-ci-dotnet.yml
@@ -25,7 +25,7 @@ jobs:
 
   # Build all projects within solution
   dotnet_ci_build:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-build-prerelease.yml@v10
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-build-prerelease.yml@v11
     with:
       solution_file_path: apps/dh/api-dh/DataHub.WebApi.sln
       release_name_prefix: ui_dotnet
@@ -33,7 +33,7 @@ jobs:
   # Run all tests in 'Tests.dll'
   dotnet_ci_test:
     needs: dotnet_ci_build
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v10
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-postbuild-test.yml@v11
     with:
       tests_dll_file_path: \apps\dh\api-dh\source\DataHub.WebApi.Tests\bin\Release\net7.0\Energinet.DataHub.WebApi.Tests.dll
       download_attempt_limit: 12

--- a/.github/workflows/dh-healthchecks.yml
+++ b/.github/workflows/dh-healthchecks.yml
@@ -61,7 +61,7 @@ jobs:
     if: |
       always() &&
       contains(needs.*.result, 'failure')
-    uses: Energinet-DataHub/.github/.github/workflows/notify-team.yml@v10
+    uses: Energinet-DataHub/.github/.github/workflows/notify-team.yml@v11
     with:
       team_name: TexasRangers
       subject: DH UI Frontend Healthchecks - Failed

--- a/.github/workflows/watt-cd.yml
+++ b/.github/workflows/watt-cd.yml
@@ -77,7 +77,7 @@ jobs:
     if: |
       always() &&
       contains(needs.*.result, 'failure')
-    uses: Energinet-DataHub/.github/.github/workflows/notify-team.yml@v10
+    uses: Energinet-DataHub/.github/.github/workflows/notify-team.yml@v11
     with:
       team_name: TexasRangers
       subject: "Deployment dispatch failed: Watt + UI"


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### Workspace
- remove .NET version from workflow. Note: 7.0.203 is now a default version in `dotnet-build-prerelease` workflow
- bump `.github` workflows to v11

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- N/A
