### PR TITLE
fix(ui-watt): watt-date-range-chip end date

### DIFF
--- a/libs/ui-watt/src/lib/components/input/datepicker/+storybook/watt-datepicker-reactive-forms.stories.ts
+++ b/libs/ui-watt/src/lib/components/input/datepicker/+storybook/watt-datepicker-reactive-forms.stories.ts
@@ -136,12 +136,12 @@ export const WithInitialValue: StoryFn<WattDatepickerStoryConfig> = (args) => ({
     exampleFormControlSingle: new FormControl(initialValueSingle),
     exampleFormControlRange: new FormControl({
       start: initialValueRangeStart,
-      end: initialValueRangeEnd_StartOfDay,
+      end: initialValueRangeEnd_EndOfDay,
     }),
     exampleChipFormControlSingle: new FormControl(initialValueSingle),
     exampleChipFormControlRange: new FormControl({
       start: initialValueRangeStart,
-      end: initialValueRangeEnd_StartOfDay,
+      end: initialValueRangeEnd_EndOfDay,
     }),
     ...args,
   },

--- a/libs/ui-watt/src/lib/components/input/datepicker/watt-date-range-chip.component.ts
+++ b/libs/ui-watt/src/lib/components/input/datepicker/watt-date-range-chip.component.ts
@@ -15,16 +15,31 @@
  * limitations under the License.
  */
 
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Injectable, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { DateRange, MatDatepickerModule } from '@angular/material/datepicker';
+import {
+  DateRange,
+  DefaultMatCalendarRangeStrategy,
+  MAT_DATE_RANGE_SELECTION_STRATEGY,
+  MatDatepickerModule,
+} from '@angular/material/datepicker';
+import endOfDay from 'date-fns/endOfDay';
 
 import { WattDatePipe } from '../../../configuration/watt-date.pipe';
 import { WattIconComponent } from '../../../foundations/icon/icon.component';
 import { WattMenuChipComponent } from '../../chip/watt-menu-chip.component';
 
+@Injectable()
+export class EndOfDaySelectionStrategy extends DefaultMatCalendarRangeStrategy<Date> {
+  override selectionFinished(date: Date, currentRange: DateRange<Date>): DateRange<Date> {
+    const range = super.selectionFinished(date, currentRange);
+    return range.end ? new DateRange(range.start, endOfDay(range.end)) : range;
+  }
+}
+
 @Component({
   standalone: true,
+  providers: [{ provide: MAT_DATE_RANGE_SELECTION_STRATEGY, useClass: EndOfDaySelectionStrategy }],
   imports: [
     CommonModule,
     MatDatepickerModule,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Change end output for watt-date-range-chip to be end of day. 

<!--- Please leave a helpful description of the pull request here. --->

<!--- Are there any issues, pull requests or similar that should be linked here? --->


