### PR TITLE
Fix Date range picker showing in danish time correctly

### DIFF
--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: eo-frontend
 description: A Helm chart for Kubernetes
 type: application
-version: 0.3.273
+version: 0.3.274

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.273
+    tag: 0.3.274

--- a/libs/eo/core/shell/src/lib/eo-core-shell.providers.ts
+++ b/libs/eo/core/shell/src/lib/eo-core-shell.providers.ts
@@ -15,18 +15,17 @@
  * limitations under the License.
  */
 import { importProvidersFrom } from '@angular/core';
-import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
-import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
-import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
+import { MatLegacyDialogModule } from '@angular/material/legacy-dialog';
+import { MatLegacySnackBarModule } from '@angular/material/legacy-snack-bar';
 import { eoAuthorizationInterceptorProvider } from '@energinet-datahub/eo/shared/services';
 import { danishLocalProviders } from '@energinet-datahub/gf/configuration-danish-locale';
 import { browserConfigurationProviders } from '@energinet-datahub/gf/util-browser';
 import { danishDatetimeProviders } from '@energinet-datahub/watt/danish-date-time';
 
 export const eoCoreShellProviders = [
-  importProvidersFrom(MatDialogModule, MatSnackBarModule, MatDateFnsModule),
   browserConfigurationProviders,
   danishLocalProviders,
   danishDatetimeProviders,
+  importProvidersFrom(MatLegacyDialogModule, MatLegacySnackBarModule),
   eoAuthorizationInterceptorProvider,
 ];

--- a/libs/eo/core/shell/src/lib/eo-shell.component.ts
+++ b/libs/eo/core/shell/src/lib/eo-shell.component.ts
@@ -16,6 +16,7 @@
  */
 import { NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core';
+import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 import { RouterModule } from '@angular/router';
 import { EoCookieBannerComponent } from '@energinet-datahub/eo/shared/atomic-design/feature-molecules';
 import { EoProductLogoDirective } from '@energinet-datahub/eo/shared/atomic-design/ui-atoms';
@@ -33,6 +34,7 @@ import { EoPrimaryNavigationComponent } from './eo-primary-navigation.component'
   imports: [
     RouterModule,
     WattShellComponent,
+    MatDateFnsModule,
     EoPrimaryNavigationComponent,
     EoCookieBannerComponent,
     EoProductLogoDirective,

--- a/libs/eo/transfers/src/lib/eo-transfers-modal.component.ts
+++ b/libs/eo/transfers/src/lib/eo-transfers-modal.component.ts
@@ -60,54 +60,61 @@ import { EoTransfersStore } from './eo-transfers.store';
       }
     `,
   ],
-  template: `<watt-modal
-    #modal
-    [title]="title"
-    size="small"
-    closeLabel="Close modal"
-    [loading]="requestLoading"
-  >
-    <form [formGroup]="form">
-      <watt-form-field>
-        <watt-label>Receiver</watt-label>
-        <input
-          wattInput
-          required="true"
-          type="text"
-          formControlName="tin"
-          [maxlength]="8"
-          data-testid="new-agreement-receiver-input"
-        />
-        <watt-error *ngIf="form.controls.tin.errors"
-          >An 8-digit TIN/CVR number is required</watt-error
+  template: `
+    <watt-modal
+      #modal
+      [title]="title"
+      size="small"
+      closeLabel="Close modal"
+      [loading]="requestLoading"
+      (closed)="whenClosed()"
+    >
+      <form [formGroup]="form">
+        <watt-form-field>
+          <watt-label>Receiver</watt-label>
+          <input
+            wattInput
+            required="true"
+            type="text"
+            formControlName="tin"
+            [maxlength]="8"
+            data-testid="new-agreement-receiver-input"
+          />
+          <watt-error *ngIf="form.controls.tin.errors">
+            An 8-digit TIN/CVR number is required
+          </watt-error>
+        </watt-form-field>
+        <watt-form-field>
+          <watt-label>Period</watt-label>
+          <watt-datepicker
+            required="true"
+            formControlName="dateRange"
+            [range]="true"
+            data-testid="new-agreement-daterange-input"
+          />
+          <watt-error *ngIf="form.controls.dateRange.errors">
+            A start and end date is required
+          </watt-error>
+        </watt-form-field>
+      </form>
+      <watt-modal-actions>
+        <watt-button
+          variant="secondary"
+          data-testid="close-new-agreement-button"
+          (click)="modal.close(false)"
         >
-      </watt-form-field>
-      <watt-form-field>
-        <watt-label>Period</watt-label>
-        <watt-datepicker
-          required="true"
-          formControlName="dateRange"
-          [range]="true"
-          data-testid="new-agreement-daterange-input"
-        />
-        <watt-error *ngIf="form.controls.dateRange.errors"> A date range is required </watt-error>
-      </watt-form-field>
-    </form>
-    <watt-modal-actions>
-      <watt-button
-        variant="secondary"
-        data-testid="close-new-agreement-button"
-        (click)="modal.close(false)"
-        >Close</watt-button
-      >
-      <watt-button
-        data-testid="create-new-agreement-button"
-        [disabled]="!form.valid"
-        (click)="createAgreement()"
-        >Create transfer agreement</watt-button
-      >
-    </watt-modal-actions>
-  </watt-modal>`,
+          Cancel
+        </watt-button>
+        <watt-button
+          data-testid="create-new-agreement-button"
+          [disabled]="!form.valid"
+          (click)="createAgreement()"
+        >
+          Create transfer agreement
+        </watt-button>
+      </watt-modal-actions>
+    </watt-modal>
+  `,
 })
 export class EoTransfersModalComponent {
   @ViewChild(WattModalComponent) modal!: WattModalComponent;
@@ -124,6 +131,10 @@ export class EoTransfersModalComponent {
     private store: EoTransfersStore,
     private cd: ChangeDetectorRef
   ) {}
+
+  whenClosed() {
+    this.resetFormValues();
+  }
 
   open() {
     this.modal.open();
@@ -143,7 +154,6 @@ export class EoTransfersModalComponent {
       next: (transfer) => {
         this.store.addTransfer(transfer);
         this.requestLoading = false;
-        this.resetFormValues();
         this.cd.detectChanges();
         this.modal.close(true);
       },

--- a/libs/eo/transfers/src/lib/eo-transfers-table.component.ts
+++ b/libs/eo/transfers/src/lib/eo-transfers-table.component.ts
@@ -95,8 +95,9 @@ interface EoTransferTableElement extends EoListedTransfer {
           [disabled]="true"
           icon="fileDownload"
           variant="text"
-          >Download</watt-button
         >
+          Download
+        </watt-button>
         <watt-button
           data-testid="new-agreement-button"
           icon="plus"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -416,9 +416,6 @@
       "@energinet-datahub/watt/tooltip": [
         "libs/ui-watt/src/lib/components/tooltip/index.ts"
       ],
-      "@energinet-datahub/watt/top-bar": [
-        "libs/ui-watt/src/lib/components/shell/top-bar/index.ts"
-      ],
       "@energinet-datahub/watt/validation-message": [
         "libs/ui-watt/src/lib/components/validation-message/index.ts"
       ],


### PR DESCRIPTION
## Description

Fix a bug where after migrating to completely standalone components, the dates in a daterange picker were wrongly showed on 1st, 2nd and 3rd days in the month.

Also fixed the text for the cancel button on the "create transfer" modal

Also fixed that the modal will reset its data no matter how it is closed