### PR TITLE
fix(dh): remove date-fns module from providers

### DIFF
--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: eo-frontend
 description: A Helm chart for Kubernetes
 type: application
-version: 0.3.278
+version: 0.3.279

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.278
+    tag: 0.3.279

--- a/docs/dh/testing.md
+++ b/docs/dh/testing.md
@@ -92,15 +92,13 @@ In this case import `danishDatetimeProviders` in the test setup. This will add t
 
 ```ts
 import { danishDatetimeProviders } from '@energinet-datahub/watt/danish-date-time';
-import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 
 async function setup() {
   await render(MyComponent, {
     providers: [
-        danishDatetimeProviders,
-        importProvidersFrom(MatDateFnsModule),
-          // ...
-      ]
+      danishDatetimeProviders,
+      // ...
+    ]
   }
 };
 ```

--- a/libs/dh/charges/feature-create-prices/src/lib/dh-charges-create-prices.component.spec.ts
+++ b/libs/dh/charges/feature-create-prices/src/lib/dh-charges-create-prices.component.spec.ts
@@ -28,7 +28,6 @@ import { getTranslocoTestingModule } from '@energinet-datahub/dh/shared/test-uti
 
 import { DhChargesCreatePricesComponent } from './dh-charges-create-prices.component';
 import { danishLocalProviders } from '@energinet-datahub/gf/configuration-danish-locale';
-import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 
 const dateTimeFormat = 'dd-MM-yyyy';
 const danishTimeZoneIdentifier = 'Europe/Copenhagen';
@@ -63,7 +62,7 @@ describe(DhChargesCreatePricesComponent, () => {
   async function setup() {
     const { fixture } = await render(DhChargesCreatePricesComponent, {
       providers: [
-        importProvidersFrom(MatLegacySnackBarModule, MatDateFnsModule),
+        importProvidersFrom(MatLegacySnackBarModule),
         danishLocalProviders,
         danishDatetimeProviders,
       ],

--- a/libs/dh/charges/feature-prices/src/lib/dh-charges-prices.component.spec.ts
+++ b/libs/dh/charges/feature-prices/src/lib/dh-charges-prices.component.spec.ts
@@ -25,8 +25,6 @@ import { danishDatetimeProviders } from '@energinet-datahub/watt/danish-date-tim
 import { DrawerDatepickerService } from './drawer/charge-content/drawer-datepicker/drawer-datepicker.service';
 import { danishLocalProviders } from '@energinet-datahub/gf/configuration-danish-locale';
 import { danishTimeZoneIdentifier } from '@energinet-datahub/watt/datepicker';
-import { importProvidersFrom } from '@angular/core';
-import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 
 import { DhChargesPricesComponent } from './dh-charges-prices.component';
 
@@ -36,11 +34,7 @@ const dateTimeFormat = 'dd-MM-yyyy';
 describe(DhChargesPricesComponent, () => {
   async function setup() {
     const { fixture } = await render(`<dh-charges-prices></dh-charges-prices>`, {
-      providers: [
-        danishLocalProviders,
-        danishDatetimeProviders,
-        importProvidersFrom(MatDateFnsModule),
-      ],
+      providers: [danishLocalProviders, danishDatetimeProviders],
       componentProviders: [
         {
           provide: DrawerDatepickerService,

--- a/libs/dh/charges/feature-prices/src/lib/drawer/charge-content/dh-charge-content.component.spec.ts
+++ b/libs/dh/charges/feature-prices/src/lib/drawer/charge-content/dh-charge-content.component.spec.ts
@@ -33,8 +33,6 @@ import { TestBed } from '@angular/core/testing';
 import { runOnPushChangeDetection } from '@energinet-datahub/dh/shared/test-util-metering-point';
 import { danishTimeZoneIdentifier } from '@energinet-datahub/watt/datepicker';
 import { danishLocalProviders } from '@energinet-datahub/gf/configuration-danish-locale';
-import { importProvidersFrom } from '@angular/core';
-import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 import { DhChargeContentComponent } from './dh-charge-content.component';
 import { DrawerDatepickerService } from './drawer-datepicker/drawer-datepicker.service';
 
@@ -75,7 +73,6 @@ describe(DhChargeContentComponent, () => {
         DhMarketParticipantDataAccessApiStore,
         danishLocalProviders,
         danishDatetimeProviders,
-        importProvidersFrom(MatDateFnsModule),
       ],
       componentProviders: [
         {

--- a/libs/dh/core/shell/src/lib/dh-core-shell.component.spec.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.component.spec.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 import { By } from '@angular/platform-browser';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { render, RenderResult } from '@testing-library/angular';
 
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { danishDatetimeProviders } from '@energinet-datahub/watt/danish-date-time';
 import { WattShellComponent } from '@energinet-datahub/watt/shell';
 import { getTranslocoTestingModule } from '@energinet-datahub/dh/shared/test-util-i18n';

--- a/libs/dh/core/shell/src/lib/dh-core-shell.component.spec.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.component.spec.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 import { By } from '@angular/platform-browser';
-import { importProvidersFrom } from '@angular/core';
-import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 import { render, RenderResult } from '@testing-library/angular';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -31,7 +29,7 @@ describe(DhCoreShellComponent, () => {
   beforeEach(async () => {
     view = await render(DhCoreShellComponent, {
       imports: [getTranslocoTestingModule(), HttpClientTestingModule],
-      providers: [MsalServiceFake, danishDatetimeProviders, importProvidersFrom(MatDateFnsModule)],
+      providers: [MsalServiceFake, danishDatetimeProviders],
     });
   });
 

--- a/libs/dh/core/shell/src/lib/dh-core-shell.component.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.component.ts
@@ -31,7 +31,6 @@ import {
   DhSignupMitIdComponent,
 } from '@energinet-datahub/dh/shared/feature-authorization';
 import { ApolloModule } from 'apollo-angular';
-import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 
 @Component({
   selector: 'dh-shell',
@@ -39,7 +38,6 @@ import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
   templateUrl: './dh-core-shell.component.html',
   standalone: true,
   imports: [
-    MatDateFnsModule,
     TranslocoModule,
     ApolloModule,
     DhLanguagePickerComponent,

--- a/libs/dh/core/shell/src/lib/dh-core-shell.providers.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.providers.ts
@@ -42,6 +42,7 @@ import { applicationInsightsProviders } from '@energinet-datahub/dh/shared/util-
 import { dhAuthorizationInterceptor } from '@energinet-datahub/dh/shared/feature-authorization';
 import { TranslocoModule } from '@ngneat/transloco';
 import { danishLocalProviders } from '@energinet-datahub/gf/configuration-danish-locale';
+import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 
 export const dhCoreShellProviders = [
   importProvidersFrom([
@@ -49,6 +50,7 @@ export const dhCoreShellProviders = [
     DhApiModule.forRoot(),
     MsalModule,
     TranslocoModule,
+    MatDateFnsModule,
   ]),
   environment.production ? applicationInsightsProviders : [],
   uiWattTranslationsProviders,

--- a/libs/dh/core/shell/src/lib/dh-core-shell.providers.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.providers.ts
@@ -18,7 +18,6 @@ import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { importProvidersFrom } from '@angular/core';
 import { MatLegacySnackBarModule } from '@angular/material/legacy-snack-bar';
 import { TranslocoModule } from '@ngneat/transloco';
-import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 import {
   MsalInterceptor,
   MsalModule,
@@ -49,7 +48,6 @@ export const dhCoreShellProviders = [
     DhApiModule.forRoot(),
     MsalModule,
     TranslocoModule,
-    MatDateFnsModule,
   ]),
   environment.production ? applicationInsightsProviders : [],
   uiWattTranslationsProviders,

--- a/libs/dh/core/shell/src/lib/dh-core-shell.providers.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.providers.ts
@@ -16,7 +16,9 @@
  */
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { importProvidersFrom } from '@angular/core';
-
+import { MatLegacySnackBarModule } from '@angular/material/legacy-snack-bar';
+import { TranslocoModule } from '@ngneat/transloco';
+import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 import {
   MsalInterceptor,
   MsalModule,
@@ -37,12 +39,9 @@ import { DhApiModule } from '@energinet-datahub/dh/shared/data-access-api';
 import { graphQLProviders } from '@energinet-datahub/dh/shared/data-access-graphql';
 import { dhB2CEnvironmentToken, environment } from '@energinet-datahub/dh/shared/environments';
 import { danishDatetimeProviders } from '@energinet-datahub/watt/danish-date-time';
-import { MatLegacySnackBarModule } from '@angular/material/legacy-snack-bar';
 import { applicationInsightsProviders } from '@energinet-datahub/dh/shared/util-application-insights';
 import { dhAuthorizationInterceptor } from '@energinet-datahub/dh/shared/feature-authorization';
-import { TranslocoModule } from '@ngneat/transloco';
 import { danishLocalProviders } from '@energinet-datahub/gf/configuration-danish-locale';
-import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 
 export const dhCoreShellProviders = [
   importProvidersFrom([

--- a/libs/dh/wholesale/feature-search/src/lib/dh-wholesale-search.component.spec.ts
+++ b/libs/dh/wholesale/feature-search/src/lib/dh-wholesale-search.component.spec.ts
@@ -23,13 +23,12 @@ import { danishDatetimeProviders } from '@energinet-datahub/watt/danish-date-tim
 import { MatLegacySnackBarModule } from '@angular/material/legacy-snack-bar';
 import { importProvidersFrom } from '@angular/core';
 import { ApolloModule } from 'apollo-angular';
-import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 import { DhWholesaleSearchComponent } from './dh-wholesale-search.component';
 
 async function setup() {
   await render(`<dh-wholesale-search></dh-wholesale-search>`, {
     providers: [
-      importProvidersFrom(MatLegacySnackBarModule, MatDateFnsModule),
+      importProvidersFrom(MatLegacySnackBarModule),
       graphQLProviders,
       danishDatetimeProviders,
     ],

--- a/libs/dh/wholesale/feature-start/src/lib/dh-wholesale-start.cy.ts
+++ b/libs/dh/wholesale/feature-start/src/lib/dh-wholesale-start.cy.ts
@@ -24,13 +24,12 @@ import { graphQLProviders } from '@energinet-datahub/dh/shared/data-access-graph
 import { translocoProviders } from '@energinet-datahub/dh/globalization/configuration-localization';
 import { importProvidersFrom } from '@angular/core';
 import { ApolloModule } from 'apollo-angular';
-import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 import { DhWholesaleStartComponent } from './dh-wholesale-start.component';
 
 it('mounts', () => {
   cy.mount(DhWholesaleStartComponent, {
     providers: [
-      importProvidersFrom(MatLegacySnackBarModule, MatDateFnsModule),
+      importProvidersFrom(MatLegacySnackBarModule),
       graphQLProviders,
       translocoProviders,
       danishDatetimeProviders,

--- a/libs/eo/core/shell/src/lib/eo-core-shell.providers.ts
+++ b/libs/eo/core/shell/src/lib/eo-core-shell.providers.ts
@@ -17,6 +17,7 @@
 import { importProvidersFrom } from '@angular/core';
 import { MatLegacyDialogModule } from '@angular/material/legacy-dialog';
 import { MatLegacySnackBarModule } from '@angular/material/legacy-snack-bar';
+
 import { eoAuthorizationInterceptorProvider } from '@energinet-datahub/eo/shared/services';
 import { danishLocalProviders } from '@energinet-datahub/gf/configuration-danish-locale';
 import { browserConfigurationProviders } from '@energinet-datahub/gf/util-browser';

--- a/libs/ui-watt/src/lib/components/input/timepicker/watt-timepicker.module.spec.ts
+++ b/libs/ui-watt/src/lib/components/input/timepicker/watt-timepicker.module.spec.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, importProvidersFrom } from '@angular/core';
+import { Component } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { render, screen } from '@testing-library/angular';
@@ -26,7 +26,6 @@ import { WattTimepickerComponent } from './';
 import { WATT_FORM_FIELD } from '../../form-field';
 import { WattDateRange } from '../../../utils/date';
 import { danishDatetimeProviders } from '../../../configuration/watt-danish-datetime.providers';
-import { MatDateFnsModule } from '@angular/material-date-fns-adapter';
 
 const backspace = '{backspace}';
 const ARIA_VALUENOW = 'aria-valuenow';
@@ -50,11 +49,7 @@ describe(WattTimepickerComponent, () => {
     }
 
     const { fixture } = await render(TestComponent, {
-      providers: [
-        danishLocalProviders,
-        danishDatetimeProviders,
-        importProvidersFrom(MatDateFnsModule),
-      ],
+      providers: [danishLocalProviders, danishDatetimeProviders],
       imports: [
         WattTimepickerComponent,
         ReactiveFormsModule,

--- a/libs/ui-watt/src/lib/configuration/watt-danish-datetime.providers.ts
+++ b/libs/ui-watt/src/lib/configuration/watt-danish-datetime.providers.ts
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
+import { makeEnvironmentProviders } from '@angular/core';
 import { MAT_DATE_FNS_FORMATS } from '@angular/material-date-fns-adapter';
 import * as daLocale from 'date-fns/locale/da/index.js';
 
 import { WattDateAdapter } from './watt-date-adapter';
-import { makeEnvironmentProviders } from '@angular/core';
 
 export const danishDatetimeProviders = makeEnvironmentProviders([
   { provide: MAT_DATE_LOCALE, useValue: daLocale },

--- a/libs/ui-watt/src/lib/configuration/watt-date-adapter.ts
+++ b/libs/ui-watt/src/lib/configuration/watt-date-adapter.ts
@@ -39,6 +39,7 @@ export class WattDateAdapter extends DateFnsAdapter {
    */
   override getDateNames(): string[] {
     const dateNames = super.getDateNames();
+
     return this.locale.code === danishLocale
       ? dateNames.map((dateName) => dateName.replace(/\./g, ''))
       : dateNames;

--- a/libs/ui-watt/src/lib/configuration/watt-locale.service.ts
+++ b/libs/ui-watt/src/lib/configuration/watt-locale.service.ts
@@ -16,6 +16,7 @@
  */
 import { Injectable } from '@angular/core';
 import { DateAdapter } from '@angular/material/core';
+
 import { WattDateAdapter, WattSupportedLocales } from './watt-date-adapter';
 
 @Injectable({


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### DataHub
- remove `MatDateFnsModule` from providers. The reason is that our own `danishDatetimeProviders` provide the same providers that are coming from `MatDateFnsModule`. If we want to keep both `MatDateFnsModule` and `danishDatetimeProviders` then **the order is important** and `danishDatetimeProviders` **must** come last. Otherwise `MatDateFnsModule` will overwrite our providers.
- remove `MatDateFnsModule` from spec files
- update documentation

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- Closes #1827