### PR TITLE
Renamed task

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "update": "nx migrate latest",
     "workspace-generator": "nx workspace-generator",
     "take": "yarn ts-node --esm --project ./tools/github/tsconfig.json ./tools/github/create-branch-from-issue.ts",
-    "create": "yarn ts-node --esm --project ./tools/github/tsconfig.json ./tools/github/create-branch.ts",
+    "branch": "yarn ts-node --esm --project ./tools/github/tsconfig.json ./tools/github/create-branch.ts",
     "pr": "yarn ts-node --esm --project ./tools/github/tsconfig.json ./tools/github/create-pr.ts"
   },
   "dependencies": {


### PR DESCRIPTION
Renamed task from create to branch, to avoid name conflict with yarn. It also better reflects what it does.