### PR TITLE
Disable sonarcloud

### DIFF
--- a/.github/workflows/eo-cd.yml
+++ b/.github/workflows/eo-cd.yml
@@ -142,26 +142,26 @@ jobs:
           yaml_file: build/infrastructure/eo/chart/values.yaml
           yaml_path: app.image.tag
 
-  sonarcloud:
-    name: SonarCloud
-    if: ${{ needs.affected.outputs.is-affected == 'true' }}
-    needs: affected
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        with:
-          args: >
-            -Dsonar.projectKey=energinet-datahub_energy-origin-frontend
-            -Dsonar.organization=energinet-datahub
-            -Dsonar.sources=apps/eo/app-eo,libs/eo
-            -Dsonar.exclusions=**/*.spec.ts,jest.config.ts,test-setup.ts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.EO_SONAR_TOKEN }}
+  # sonarcloud:
+  #   name: SonarCloud
+  #   if: ${{ needs.affected.outputs.is-affected == 'true' }}
+  #   needs: affected
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+  #     - name: SonarCloud Scan
+  #       uses: SonarSource/sonarcloud-github-action@master
+  #       with:
+  #         args: >
+  #           -Dsonar.projectKey=energinet-datahub_energy-origin-frontend
+  #           -Dsonar.organization=energinet-datahub
+  #           -Dsonar.sources=apps/eo/app-eo,libs/eo
+  #           -Dsonar.exclusions=**/*.spec.ts,jest.config.ts,test-setup.ts
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+  #         SONAR_TOKEN: ${{ secrets.EO_SONAR_TOKEN }}
 
   bump_helm_chart_version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sonarcloud is not working on EO at the moment. This PR will disabled it for now, so it is possible to merge PR´s again.
