### PR TITLE
Fixed default menu style, removed legacy tooltip

### DIFF
--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: eo-frontend
 description: A Helm chart for Kubernetes
 type: application
-version: 0.3.329
+version: 0.3.330

--- a/build/infrastructure/eo/chart/Chart.yaml
+++ b/build/infrastructure/eo/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: eo-frontend
 description: A Helm chart for Kubernetes
 type: application
-version: 0.3.328
+version: 0.3.329

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.329
+    tag: 0.3.330

--- a/build/infrastructure/eo/chart/values.yaml
+++ b/build/infrastructure/eo/chart/values.yaml
@@ -2,4 +2,4 @@ app:
   replicaCount: 2
   image:
     name: ghcr.io/energinet-datahub/eo-frontend-app
-    tag: 0.3.328
+    tag: 0.3.329

--- a/libs/dh/market-participant/feature-organization/src/lib/overview/dh-market-participant-organization-overview-grid-areas-list.component.ts
+++ b/libs/dh/market-participant/feature-organization/src/lib/overview/dh-market-participant-organization-overview-grid-areas-list.component.ts
@@ -16,7 +16,7 @@
  */
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
-import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MarketParticipantGridAreaDto } from '@energinet-datahub/dh/shared/domain';
 
 @Component({

--- a/libs/ui-watt/src/lib/styles/@energinet-datahub/watt/theme/light-theme.scss
+++ b/libs/ui-watt/src/lib/styles/@energinet-datahub/watt/theme/light-theme.scss
@@ -70,7 +70,8 @@ $watt-theme: mat.define-light-theme(
 @include mat.sidenav-theme($watt-theme);
 @include mat.legacy-table-theme($watt-theme);
 @include mat.legacy-tabs-theme($watt-theme);
-@include mat.legacy-tooltip-theme($watt-theme);
+@include mat.tooltip-theme($watt-theme);
+@include mat.menu-theme($watt-theme);
 @include mat.toolbar-theme($watt-theme);
 @include mat.stepper-theme($watt-theme);
 @include mat.divider-theme($watt-theme);


### PR DESCRIPTION
Removed legacy tooltip, readded styles for menu

Keept the default style, because organization is going to be removed.

- https://github.com/Energinet-DataHub/greenforce-frontend/issues/1930
