### PR TITLE
feat(dh): use new Vater components in Balance responsible tab

### DIFF
--- a/build/infrastructure/eo/configuration.yaml
+++ b/build/infrastructure/eo/configuration.yaml
@@ -1,5 +1,5 @@
 name: eo-frontend-app
-version: 0.3.350
+version: 0.3.351
 repo: ghcr.io/energinet-datahub
 references:
   - file: k8s/energy-origin-apps/frontend/base/deployment.yaml

--- a/build/infrastructure/eo/configuration.yaml
+++ b/build/infrastructure/eo/configuration.yaml
@@ -1,5 +1,5 @@
 name: eo-frontend-app
-version: 0.3.349
+version: 0.3.350
 repo: ghcr.io/energinet-datahub
 references:
   - file: k8s/energy-origin-apps/frontend/base/deployment.yaml

--- a/libs/dh/esett/feature-balance-responsible/src/lib/dh-balance-responsible.component.html
+++ b/libs/dh/esett/feature-balance-responsible/src/lib/dh-balance-responsible.component.html
@@ -14,19 +14,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<watt-card *transloco="let t; read: 'eSett.balanceResponsible'">
-  <watt-card-title>
-    <h3>{{ t("tabHeading") }}</h3>
-    <span class="watt-chip-label">{{ tableDataSource.data.length }}</span>
+<watt-card vater inset="0" *transloco="let t; read: 'eSett.balanceResponsible'">
+  <vater-flex fill="vertical" gap="m">
+    <vater-stack direction="row" gap="s">
+      <h3>{{ t("tabHeading") }}</h3>
+      <span class="watt-chip-label">{{ tableDataSource.data.length }}</span>
 
-    <watt-search [label]="'shared.search' | transloco" />
-  </watt-card-title>
+      <vater-spacer />
+      <watt-search [label]="'shared.search' | transloco" />
+    </vater-stack>
 
-  <dh-balance-responsible-table
-    [tableDataSource]="tableDataSource"
-    [isLoading]="isLoading"
-    [hasError]="hasError"
-  />
+    <dh-balance-responsible-table
+      [tableDataSource]="tableDataSource"
+      [isLoading]="isLoading"
+      [hasError]="hasError"
+    />
 
-  <watt-paginator [for]="tableDataSource" [pageSize]="100" />
+    <watt-paginator [for]="tableDataSource" [pageSize]="100" />
+  </vater-flex>
 </watt-card>

--- a/libs/dh/esett/feature-balance-responsible/src/lib/dh-balance-responsible.component.ts
+++ b/libs/dh/esett/feature-balance-responsible/src/lib/dh-balance-responsible.component.ts
@@ -22,6 +22,12 @@ import { WATT_CARD } from '@energinet-datahub/watt/card';
 import { WattTableDataSource } from '@energinet-datahub/watt/table';
 import { WattSearchComponent } from '@energinet-datahub/watt/search';
 import { WattPaginatorComponent } from '@energinet-datahub/watt/paginator';
+import {
+  VaterFlexComponent,
+  VaterSpacerComponent,
+  VaterStackComponent,
+  VaterUtilityDirective,
+} from '@energinet-datahub/watt/vater';
 
 import { DhBalanceResponsibleTableComponent } from './table/dh-table.component';
 import { DhBalanceResponsibleMessage } from './dh-balance-responsible-message';
@@ -36,14 +42,8 @@ import { DhBalanceResponsibleMessage } from './dh-balance-responsible-message';
         display: block;
       }
 
-      watt-card-title {
-        align-items: center;
-        display: flex;
-        gap: var(--watt-space-s);
-      }
-
-      watt-search {
-        margin-left: auto;
+      h3 {
+        margin: 0;
       }
 
       watt-paginator {
@@ -63,6 +63,10 @@ import { DhBalanceResponsibleMessage } from './dh-balance-responsible-message';
     WATT_CARD,
     WattSearchComponent,
     WattPaginatorComponent,
+    VaterFlexComponent,
+    VaterStackComponent,
+    VaterSpacerComponent,
+    VaterUtilityDirective,
 
     DhBalanceResponsibleTableComponent,
   ],

--- a/libs/dh/esett/feature-balance-responsible/src/lib/table/dh-table.component.html
+++ b/libs/dh/esett/feature-balance-responsible/src/lib/table/dh-table.component.html
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<ng-container *transloco="let t; read: 'eSett.balanceResponsible'">
+<vater-flex fill="vertical" scrollable *transloco="let t; read: 'eSett.balanceResponsible'">
   <watt-table
     [dataSource]="tableDataSource"
     [columns]="columns"
@@ -66,21 +66,15 @@ limitations under the License.
     </ng-container>
   </watt-table>
 
-  <ng-container *ngIf="!isLoading && tableDataSource.filteredData.length === 0">
-    <div class="watt-space-inset-m">
-      <watt-empty-state
-        *ngIf="!hasError"
-        icon="cancel"
-        [title]="t('emptyTitle')"
-        [message]="t('emptyMessage')"
-      />
-
-      <watt-empty-state
-        *ngIf="hasError"
-        icon="custom-power"
-        [title]="t('errorTitle')"
-        [message]="t('errorMessage')"
-      />
-    </div>
-  </ng-container>
-</ng-container>
+  <vater-stack
+    fill="vertical"
+    justify="center"
+    *ngIf="!isLoading && tableDataSource.filteredData.length === 0"
+  >
+    <watt-empty-state
+      [icon]="hasError ? 'custom-power' : 'cancel'"
+      [title]="hasError ? t('errorTitle') : t('emptyTitle')"
+      [message]="hasError ? t('errorMessage') : t('emptyMessage')"
+    />
+  </vater-stack>
+</vater-flex>

--- a/libs/dh/esett/feature-balance-responsible/src/lib/table/dh-table.component.ts
+++ b/libs/dh/esett/feature-balance-responsible/src/lib/table/dh-table.component.ts
@@ -20,6 +20,7 @@ import { TranslocoDirective, TranslocoPipe } from '@ngneat/transloco';
 
 import { WATT_TABLE, WattTableColumnDef, WattTableDataSource } from '@energinet-datahub/watt/table';
 import { WattEmptyStateComponent } from '@energinet-datahub/watt/empty-state';
+import { VaterFlexComponent, VaterStackComponent } from '@energinet-datahub/watt/vater';
 
 import { DhBalanceResponsibleMessage } from '../dh-balance-responsible-message';
 
@@ -30,11 +31,20 @@ import { DhBalanceResponsibleMessage } from '../dh-balance-responsible-message';
   styles: [
     `
       :host {
-        display: block;
+        display: contents;
       }
     `,
   ],
-  imports: [NgIf, TranslocoDirective, TranslocoPipe, WATT_TABLE, WattEmptyStateComponent],
+  imports: [
+    NgIf,
+    TranslocoDirective,
+    TranslocoPipe,
+
+    WATT_TABLE,
+    WattEmptyStateComponent,
+    VaterFlexComponent,
+    VaterStackComponent,
+  ],
 })
 export class DhBalanceResponsibleTableComponent {
   columns: WattTableColumnDef<DhBalanceResponsibleMessage> = {

--- a/libs/watt/src/lib/components/tabs/watt-tabs.component.scss
+++ b/libs/watt/src/lib/components/tabs/watt-tabs.component.scss
@@ -17,6 +17,11 @@
 @use "@energinet-datahub/watt/utils" as watt;
 
 watt-tabs {
+  .mat-tab-group,
+  .mat-tab-body-wrapper {
+    height: 100%;
+  }
+
   .mat-tab-group.mat-primary
     .mat-tab-label.cdk-focused.cdk-keyboard-focused:focus {
     background-color: var(--watt-color-primary-ultralight);
@@ -50,6 +55,7 @@ watt-tabs {
   .mat-tab-body.mat-tab-body-active,
   .mat-tab-group.mat-tab-group-dynamic-height .mat-tab-body.mat-tab-body-active,
   .mat-tab-group-dynamic-height .mat-tab-body-content {
+    position: relative;
     overflow: initial;
   }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### DataHub
- use new Vater components in Balance responsible tab

### Design System
- add height to tabs so new Vater components can work inside tabs

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/team-titans/issues/274
