### PR TITLE
feat(dh): add download to balance responsible in eSett

### DIFF
--- a/libs/dh/esett/feature-balance-responsible/src/lib/dh-balance-responsible.component.html
+++ b/libs/dh/esett/feature-balance-responsible/src/lib/dh-balance-responsible.component.html
@@ -19,6 +19,12 @@ limitations under the License.
     <vater-stack direction="row" gap="s">
       <h3>{{ t("tabHeading") }}</h3>
       <span class="watt-chip-label">{{ totalCount }}</span>
+
+      <vater-spacer />
+
+      <watt-button icon="download" variant="text" (click)="download()">{{
+        "shared.download" | transloco
+      }}</watt-button>
     </vater-stack>
 
     <dh-balance-responsible-table

--- a/libs/dh/esett/feature-balance-responsible/src/lib/table/dh-table.component.html
+++ b/libs/dh/esett/feature-balance-responsible/src/lib/table/dh-table.component.html
@@ -14,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<dh-balance-responsible-drawer (closed)="onClose()" />
-
 <vater-flex fill="vertical" scrollable *transloco="let t; read: 'eSett.balanceResponsible'">
   <watt-table
     [dataSource]="tableDataSource"
@@ -77,3 +75,5 @@ limitations under the License.
     />
   </vater-stack>
 </vater-flex>
+
+<dh-balance-responsible-drawer (closed)="onClose()" />


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

### DataHub
- add download to balance responsible 
- move drawer after table because it was affecting spacing

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/team-titans/issues/274