### PR TITLE
fix(watt): use monospace font in date- and timepicker components

### DIFF
--- a/build/infrastructure/eo/configuration.yaml
+++ b/build/infrastructure/eo/configuration.yaml
@@ -1,5 +1,5 @@
 name: eo-frontend-app
-version: 0.3.389
+version: 0.3.390
 repo: ghcr.io/energinet-datahub
 references:
   - file: k8s/energy-origin-apps/frontend/base/deployment.yaml

--- a/build/infrastructure/eo/configuration.yaml
+++ b/build/infrastructure/eo/configuration.yaml
@@ -1,5 +1,5 @@
 name: eo-frontend-app
-version: 0.3.390
+version: 0.3.391
 repo: ghcr.io/energinet-datahub
 references:
   - file: k8s/energy-origin-apps/frontend/base/deployment.yaml

--- a/libs/watt/src/lib/components/picker/shared/picker.scss
+++ b/libs/watt/src/lib/components/picker/shared/picker.scss
@@ -29,10 +29,10 @@
     }
   }
 
-  input {
+  input.mat-date-range-input-inner,
+  input.mat-mdc-input-element,
+  .mat-date-range-input-mirror {
     font-family: watt.$typography-monospace-font-family;
-    border: none;
-    outline: none;
   }
 
   input.mat-date-range-input-inner,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### Watt
- use monospace font in date- and timepicker components.

Before

![image](https://github.com/Energinet-DataHub/greenforce-frontend/assets/1096332/afb4f6fd-41f7-43a9-b705-bf37957e4eab)

After

![image](https://github.com/Energinet-DataHub/greenforce-frontend/assets/1096332/87b1e4d1-4453-4c31-8ee7-073834bf0472)


<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/team-titans/issues/299
