### PR TITLE
feat(dh): implement replace certificate with client secret

### DIFF
--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -664,6 +664,14 @@
             "generateSecretError": "Noget gik galt. Client Secret blev ikke genereret. Prøv igen",
             "copy": "Kopier",
             "replaceClientSecretWithCertificate": "Erstat Client Secret med certifikat",
+            "replaceCertificateWithClientSecret": "Erstat certifikat med Client Secret",
+            "certificate": {
+              "replaceCertificateModal": {
+                "title": "Generer Client Secret og erstat certifikat?",
+                "message": "Hvis Client Secret bliver genereret, erstatter den det uploadede certifikat.",
+                "cancel": "Fortryd"
+              }
+            },
             "clientSecret": {
               "removeSecretModal": {
                 "title": "Slet Client Secret?",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -671,6 +671,14 @@
             "generateSecretError": "An error occurred while generating the Client Secret. Please try again",
             "copy": "Copy",
             "replaceClientSecretWithCertificate": "Replace Client Secret with certificate",
+            "replaceCertificateWithClientSecret": "Replace certificate with Client Secret",
+            "certificate": {
+              "replaceCertificateModal": {
+                "title": "Generate Client Secret and replace certificate?",
+                "message": "If a Client Secret is generated, this will replace the existing certificate.",
+                "cancel": "Cancel"
+              }
+            },
             "clientSecret": {
               "removeSecretModal": {
                 "title": "Delete Client Secret?",

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/b2b-access-tab/certificate/dh-certificate-view.component.html
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/b2b-access-tab/certificate/dh-certificate-view.component.html
@@ -55,7 +55,11 @@ limitations under the License.
       </watt-table>
     </watt-card>
 
-    <vater-stack direction="row" justify="flex-end">
+    <vater-stack direction="row" justify="flex-end" gap="m">
+      <watt-button variant="secondary" (click)="replaceCertificate()">{{
+        t("replaceCertificateWithClientSecret")
+      }}</watt-button>
+
       <dh-certificate-uploader [actorId]="actorId" />
     </vater-stack>
   </vater-flex>

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/b2b-access-tab/certificate/dh-certificate-view.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/b2b-access-tab/certificate/dh-certificate-view.component.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input, effect, inject, signal } from '@angular/core';
+import { Component, Input, effect, inject, Injector, signal } from '@angular/core';
 import { TranslocoDirective, TranslocoPipe, TranslocoService } from '@ngneat/transloco';
 import { NgIf } from '@angular/common';
 import { toSignal } from '@angular/core/rxjs-interop';
@@ -33,6 +33,7 @@ import { WATT_TABLE, WattTableColumnDef, WattTableDataSource } from '@energinet-
 
 import { DhRemoveCertificateModalComponent } from './dh-remove-certificate-modal.component';
 import { DhCertificateUploaderComponent } from './dh-certificate-uploader.component';
+import { DhReplaceCertificateModalComponent } from './dh-replace-certificate-modal.component';
 
 type DhCertificateTableRow = {
   translationKey: string;
@@ -75,6 +76,7 @@ type DhCertificateTableRow = {
   ],
 })
 export class DhCertificateComponent {
+  private readonly injector = inject(Injector);
   private readonly store = inject(DhMarketPartyCredentialsStore);
   private readonly toastService = inject(WattToastService);
   private readonly transloco = inject(TranslocoService);
@@ -124,6 +126,14 @@ export class DhCertificateComponent {
           });
         }
       },
+    });
+  }
+
+  replaceCertificate(): void {
+    this.modalService.open({
+      component: DhReplaceCertificateModalComponent,
+      injector: this.injector,
+      data: { actorId: this.actorId },
     });
   }
 

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/b2b-access-tab/certificate/dh-replace-certificate-modal.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/b2b-access-tab/certificate/dh-replace-certificate-modal.component.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, inject } from '@angular/core';
+import { TranslocoDirective } from '@ngneat/transloco';
+
+import { WATT_DIALOG_DATA, WATT_MODAL } from '@energinet-datahub/watt/modal';
+import { WattButtonComponent } from '@energinet-datahub/watt/button';
+
+import { DhGenerateClientSecretComponent } from '../client-secret/dh-generate-client-secret.component';
+
+@Component({
+  selector: 'dh-replace-certificate-modal',
+  standalone: true,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+    `,
+  ],
+  template: `
+    <watt-modal
+      #modal
+      *transloco="
+        let t;
+        read: 'marketParticipant.actorsOverview.drawer.tabs.b2bAccess.certificate.replaceCertificateModal'
+      "
+      [title]="t('title')"
+    >
+      <p>{{ t('message') }}</p>
+
+      <watt-modal-actions>
+        <watt-button variant="secondary" (click)="modal.close(false)">
+          {{ t('cancel') }}
+        </watt-button>
+
+        <dh-generate-client-secret [actorId]="actorId" (uploadSuccess)="modal.close(true)" />
+      </watt-modal-actions>
+    </watt-modal>
+  `,
+  imports: [TranslocoDirective, WATT_MODAL, WattButtonComponent, DhGenerateClientSecretComponent],
+})
+export class DhReplaceCertificateModalComponent {
+  actorId: string = inject(WATT_DIALOG_DATA).actorId;
+}

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/b2b-access-tab/client-secret/dh-client-secret-view.component.html
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/b2b-access-tab/client-secret/dh-client-secret-view.component.html
@@ -65,6 +65,7 @@ limitations under the License.
       <watt-button variant="secondary" (click)="replaceClientSecret()">{{
         t("replaceClientSecretWithCertificate")
       }}</watt-button>
+
       <dh-generate-client-secret [actorId]="actorId" />
     </vater-stack>
   </vater-flex>

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/b2b-access-tab/client-secret/dh-generate-client-secret.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/b2b-access-tab/client-secret/dh-generate-client-secret.component.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input, inject } from '@angular/core';
+import { Component, Input, inject, Output, EventEmitter } from '@angular/core';
 import { TranslocoDirective, TranslocoService } from '@ngneat/transloco';
 import { toSignal } from '@angular/core/rxjs-interop';
 
@@ -55,6 +55,8 @@ export class DhGenerateClientSecretComponent {
 
   @Input({ required: true }) actorId = '';
 
+  @Output() uploadSuccess = new EventEmitter<void>();
+
   generateSecret(): void {
     this.store.generateClientSecret({
       actorId: this.actorId,
@@ -70,6 +72,7 @@ export class DhGenerateClientSecretComponent {
 
     this.toastService.open({ type: 'success', message });
 
+    this.uploadSuccess.emit();
     this.store.getCredentials(this.actorId);
   };
 

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/b2b-access-tab/dh-b2b-access-tab.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/b2b-access-tab/dh-b2b-access-tab.component.ts
@@ -88,6 +88,8 @@ export class DhB2bAccessTabComponent implements OnChanges {
   @Input({ required: true }) actorId = '';
 
   ngOnChanges(): void {
+    this.store.resetClientSecret();
+
     this.store.getCredentials(this.actorId);
   }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### DataHub
- implement replace certificate with client secret
- reset client secret when loading data in tab

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/team-titans/issues/326
