### PR TITLE
fix(dh, wholesale): Fix API error handling in getCalculations()

### DIFF
--- a/libs/dh/shared/data-access-mocks/src/lib/wholesale.ts
+++ b/libs/dh/shared/data-access-mocks/src/lib/wholesale.ts
@@ -421,10 +421,13 @@ function downloadSettlementReportData(apiBase: string) {
 
 function getCalculations() {
   return graphql.mockGetCalculationsQuery((req, res, ctx) => {
-    if(!req.variables.executionTime) {
+    if (!req.variables.executionTime) {
       return res(ctx.status(500), ctx.delay(300));
     } else {
-      return res(ctx.delay(300), ctx.data({ __typename: 'Query', calculations: mockedCalculations }));
+      return res(
+        ctx.delay(300),
+        ctx.data({ __typename: 'Query', calculations: mockedCalculations })
+      );
       //return res(ctx.status(404), ctx.delay(300));
     }
   });

--- a/libs/dh/shared/data-access-mocks/src/lib/wholesale.ts
+++ b/libs/dh/shared/data-access-mocks/src/lib/wholesale.ts
@@ -421,9 +421,12 @@ function downloadSettlementReportData(apiBase: string) {
 
 function getCalculations() {
   return graphql.mockGetCalculationsQuery((req, res, ctx) => {
-    return res(ctx.delay(300), ctx.data({ __typename: 'Query', calculations: mockedCalculations }));
-    //return res(ctx.status(404), ctx.delay(300));
-    //return res(ctx.status(500), ctx.delay(300));
+    if(!req.variables.executionTime) {
+      return res(ctx.status(500), ctx.delay(300));
+    } else {
+      return res(ctx.delay(300), ctx.data({ __typename: 'Query', calculations: mockedCalculations }));
+      //return res(ctx.status(404), ctx.delay(300));
+    }
   });
 }
 

--- a/libs/dh/wholesale/feature-calculations/src/lib/table/table.component.ts
+++ b/libs/dh/wholesale/feature-calculations/src/lib/table/table.component.ts
@@ -41,7 +41,7 @@ import {
   VaterUtilityDirective,
 } from '@energinet-datahub/watt/vater';
 import { DhCalculationsFiltersComponent } from '../filters/filters.component';
-import { BehaviorSubject, switchMap } from 'rxjs';
+import { BehaviorSubject, filter, switchMap } from 'rxjs';
 import sub from 'date-fns/sub';
 import startOfDay from 'date-fns/startOfDay';
 import endOfDay from 'date-fns/endOfDay';
@@ -94,6 +94,7 @@ export class DhCalculationsTableComponent implements OnInit {
   });
 
   calculations$ = this.filter$.pipe(
+    filter((variables) => !!variables.executionTime?.start && !!variables.executionTime?.end),
     switchMap(
       (variables) =>
         this.apollo.watchQuery({


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Currently, the filter$ is also returning empty execution times, which makes GraphQL fail. 

- Add a filter to avoid nullable execution times causing the application to fail. 
- Adjust mocks to return an error like the actual API if nullable execution times are sent to the API. 

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

[#74](https://app.zenhub.com/workspaces/mandalorian-5fd22a1a59e4740018f5ab5a/issues/gh/energinet-datahub/team-mandalorian/74)
