### PR TITLE
fix(dh): wrap filters in admin page

### DIFF
--- a/libs/dh/admin/feature-user-management/src/lib/tabs/users-tab/dh-users-tab.component.ts
+++ b/libs/dh/admin/feature-user-management/src/lib/tabs/users-tab/dh-users-tab.component.ts
@@ -57,8 +57,9 @@ import { WattPaginatorComponent } from '@energinet-datahub/watt/paginator';
       }
 
       .filter-container {
-        display: inline-flex;
+        display: flex;
         gap: var(--watt-space-m);
+        flex-wrap: wrap;
       }
 
       .users-overview {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### DataHub
- wrap filters in admin page when there's not enough space to fit in one row. Currently a vertical scroll appears on smaller screens.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- N/A
