### PR TITLE
fix(dh): reset search when filters get reset

### DIFF
--- a/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.html
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.html
@@ -35,7 +35,11 @@ limitations under the License.
       >
     </vater-stack>
 
-    <dh-actors-filters [initial]="filters$.value" (filter)="filters$.next($event)" />
+    <dh-actors-filters
+      [initial]="filters$.value"
+      (filter)="filters$.next($event)"
+      (formReset)="searchComponent.clear()"
+    />
 
     <dh-actors-table
       [tableDataSource]="tableDataSource"

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.ts
@@ -115,7 +115,7 @@ export class DhActorsOverviewComponent implements OnInit {
         next: (result) => {
           this.isLoading = result.loading;
 
-          this.tableDataSource.data = result.data?.actors;
+          this.tableDataSource.data = result.data?.actors ?? [];
         },
         error: () => {
           this.hasError = true;

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.ts
@@ -18,6 +18,7 @@ import { Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { TranslocoModule, translate } from '@ngneat/transloco';
 import { BehaviorSubject, Observable, combineLatest, debounceTime, map } from 'rxjs';
 import { Apollo } from 'apollo-angular';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { WATT_CARD } from '@energinet-datahub/watt/card';
 import { WattTableDataSource } from '@energinet-datahub/watt/table';

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.ts
@@ -32,17 +32,16 @@ import {
   VaterStackComponent,
   VaterUtilityDirective,
 } from '@energinet-datahub/watt/vater';
+import { WattModalService } from '@energinet-datahub/watt/modal';
+import { DhPermissionRequiredDirective } from '@energinet-datahub/dh/shared/feature-authorization';
 
 import { DhActorsFiltersComponent } from './filters/dh-actors-filters.component';
 import { ActorsFilters, AllFiltersCombined } from './actors-filters';
-import { DhActor } from './dh-actor';
 import { dhActorsCustomFilterPredicate } from './dh-actors-custom-filter-predicate';
-import { dhToJSON } from './dh-json-util';
-import { DhActorsTableComponent } from './table/dh-actors-table.component';
 import { DhActorsCreateActorModalComponent } from './create/dh-actors-create-actor-modal.component';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { WattModalService } from '@energinet-datahub/watt/modal';
-import { DhPermissionRequiredDirective } from '@energinet-datahub/dh/shared/feature-authorization';
+import { DhActorsTableComponent } from './table/dh-actors-table.component';
+import { DhActor } from './dh-actor';
+import { dhToJSON } from './dh-json-util';
 
 @Component({
   standalone: true,

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
 import { TranslocoModule, translate } from '@ngneat/transloco';
 import { BehaviorSubject, Observable, combineLatest, debounceTime, map } from 'rxjs';
 import { Apollo } from 'apollo-angular';
@@ -107,6 +107,8 @@ export class DhActorsOverviewComponent implements OnInit {
 
   isLoading = true;
   hasError = false;
+
+  @ViewChild(WattSearchComponent) searchComponent!: WattSearchComponent;
 
   ngOnInit(): void {
     const subscription = this.getActorsQuery$.valueChanges

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/filters/dh-actors-filters.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/filters/dh-actors-filters.component.ts
@@ -106,7 +106,9 @@ type Form = FormGroup<{
       />
 
       <vater-spacer />
-      <watt-button variant="text" icon="undo" type="reset">{{ t('reset') }}</watt-button>
+      <watt-button variant="text" icon="undo" type="reset" (click)="formReset.emit()">
+        {{ t('reset') }}
+      </watt-button>
     </form>
   `,
 })
@@ -114,7 +116,9 @@ export class DhActorsFiltersComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
 
   @Input({ required: true }) initial!: ActorsFilters;
+
   @Output() filter = new EventEmitter<ActorsFilters>();
+  @Output() formReset = new EventEmitter<void>();
 
   formGroup!: Form;
 

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/filters/dh-actors-filters.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/filters/dh-actors-filters.component.ts
@@ -25,7 +25,7 @@ import {
   inject,
 } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { TranslocoModule, TranslocoService } from '@ngneat/transloco';
+import { TranslocoModule } from '@ngneat/transloco';
 import { Subscription, debounceTime } from 'rxjs';
 import { RxPush } from '@rx-angular/template/push';
 
@@ -110,7 +110,6 @@ type Form = FormGroup<{
   `,
 })
 export class DhActorsFiltersComponent implements OnInit, OnDestroy {
-  private transloco = inject(TranslocoService);
   private formGroupSubscription?: Subscription;
 
   @Input({ required: true }) initial!: ActorsFilters;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### DataHub
- reset search when filters get reset
- add fallback value to table data 
- use operator to clear subscription

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://github.com/Energinet-DataHub/team-titans/issues/367
