### PR TITLE
feat(dh): reset search input when filters get reset

### DIFF
--- a/build/infrastructure/eo/configuration.yaml
+++ b/build/infrastructure/eo/configuration.yaml
@@ -1,5 +1,5 @@
 name: eo-frontend-app
-version: 0.3.428
+version: 0.3.429
 repo: ghcr.io/energinet-datahub
 references:
   - file: k8s/energy-origin-apps/frontend/base/deployment.yaml

--- a/libs/dh/esett/feature-metering-gridarea-imbalance/src/lib/dh-metering-gridarea-imbalance.component.html
+++ b/libs/dh/esett/feature-metering-gridarea-imbalance/src/lib/dh-metering-gridarea-imbalance.component.html
@@ -22,12 +22,17 @@ limitations under the License.
 
       <vater-spacer />
 
-      <watt-search [label]="t('filters.documentId')" (search)="documentIdSearch$.next($event)" />
+      <watt-search
+        #searchComponent
+        [label]="t('filters.documentId')"
+        (search)="documentIdSearch$.next($event)"
+      />
     </vater-stack>
 
     <dh-metering-gridarea-imbalance-filters
       [initial]="filter$.value"
       (filter)="filter$.next($event)"
+      (formReset)="searchComponent.clear()"
     />
 
     <dh-metering-gridarea-imbalance-table

--- a/libs/dh/esett/feature-metering-gridarea-imbalance/src/lib/filters/dh-filters.component.html
+++ b/libs/dh/esett/feature-metering-gridarea-imbalance/src/lib/filters/dh-filters.component.html
@@ -34,5 +34,7 @@ limitations under the License.
   }}</watt-date-range-chip>
 
   <vater-spacer />
-  <watt-button variant="text" icon="undo" type="reset">{{ translate("reset") }}</watt-button>
+  <watt-button variant="text" icon="undo" type="reset" (click)="formReset.emit()">
+    {{ translate("reset") }}
+  </watt-button>
 </form>

--- a/libs/dh/esett/feature-metering-gridarea-imbalance/src/lib/filters/dh-filters.component.ts
+++ b/libs/dh/esett/feature-metering-gridarea-imbalance/src/lib/filters/dh-filters.component.ts
@@ -84,7 +84,9 @@ export class DhMeteringGridAreaImbalanceFiltersComponent implements OnInit, OnDe
   private subscription: Subscription | null = null;
 
   @Input() initial?: DhMeteringGridAreaImbalanceFilters;
+
   @Output() filter = new EventEmitter<DhMeteringGridAreaImbalanceFilters>();
+  @Output() formReset = new EventEmitter<void>();
 
   gridAreaOptions$ = this.getGridAreaOptions();
 

--- a/libs/dh/esett/feature-metering-gridarea-imbalance/src/lib/filters/dh-filters.component.ts
+++ b/libs/dh/esett/feature-metering-gridarea-imbalance/src/lib/filters/dh-filters.component.ts
@@ -25,7 +25,7 @@ import {
   inject,
 } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { TranslocoDirective, TranslocoService } from '@ngneat/transloco';
+import { TranslocoDirective } from '@ngneat/transloco';
 import { Observable, Subscription, debounceTime, map } from 'rxjs';
 import { RxPush } from '@rx-angular/template/push';
 import { Apollo } from 'apollo-angular';
@@ -79,7 +79,6 @@ type Filters = FormControls<DhMeteringGridAreaImbalanceFilters>;
   ],
 })
 export class DhMeteringGridAreaImbalanceFiltersComponent implements OnInit, OnDestroy {
-  private transloco = inject(TranslocoService);
   private apollo = inject(Apollo);
   private subscription: Subscription | null = null;
 

--- a/libs/dh/esett/feature-outgoing-messages/src/lib/dh-outgoing-messages.component.html
+++ b/libs/dh/esett/feature-outgoing-messages/src/lib/dh-outgoing-messages.component.html
@@ -22,14 +22,22 @@ limitations under the License.
 
       <vater-spacer />
 
-      <watt-search [label]="t('filters.documentId')" (search)="documentIdSearch$.next($event)" />
+      <watt-search
+        #searchComponent
+        [label]="t('filters.documentId')"
+        (search)="documentIdSearch$.next($event)"
+      />
 
       <watt-button icon="download" variant="text" (click)="download()">{{
         "shared.download" | transloco
       }}</watt-button>
     </vater-stack>
 
-    <dh-outgoing-messages-filters [initial]="filter$.value" (filter)="filter$.next($event)" />
+    <dh-outgoing-messages-filters
+      [initial]="filter$.value"
+      (filter)="filter$.next($event)"
+      (formReset)="searchComponent.clear()"
+    />
 
     <dh-outgoing-messages-table
       [tableDataSource]="tableDataSource"

--- a/libs/dh/esett/feature-outgoing-messages/src/lib/filters/dh-filters.component.html
+++ b/libs/dh/esett/feature-outgoing-messages/src/lib/filters/dh-filters.component.html
@@ -55,5 +55,7 @@ limitations under the License.
   }}</watt-date-range-chip>
 
   <vater-spacer />
-  <watt-button variant="text" icon="undo" type="reset">{{ t("reset") }}</watt-button>
+  <watt-button variant="text" icon="undo" type="reset" (click)="formReset.emit()">
+    {{ t("reset") }}
+  </watt-button>
 </form>

--- a/libs/dh/esett/feature-outgoing-messages/src/lib/filters/dh-filters.component.ts
+++ b/libs/dh/esett/feature-outgoing-messages/src/lib/filters/dh-filters.component.ts
@@ -89,7 +89,9 @@ export class DhOutgoingMessagesFiltersComponent implements OnInit, OnDestroy {
   private subscription: Subscription | null = null;
 
   @Input() initial?: DhOutgoingMessagesFilters;
+
   @Output() filter = new EventEmitter<DhOutgoingMessagesFilters>();
+  @Output() formReset = new EventEmitter<void>();
 
   calculationTypeOptions$ = this.getCalculationTypeOptions();
   messageTypeOptions$ = this.getMessageTypeOptions();

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.html
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.html
@@ -22,7 +22,11 @@ limitations under the License.
 
       <vater-spacer />
 
-      <watt-search [label]="'shared.search' | transloco" (search)="searchInput$.next($event)" />
+      <watt-search
+        #searchComponent
+        [label]="'shared.search' | transloco"
+        (search)="searchInput$.next($event)"
+      />
 
       <watt-button icon="download" variant="text" (click)="download()">{{
         "shared.download" | transloco

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/dh-actors-overview.component.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { TranslocoModule, translate } from '@ngneat/transloco';
 import { BehaviorSubject, Observable, combineLatest, debounceTime, map } from 'rxjs';
 import { Apollo } from 'apollo-angular';
@@ -107,8 +107,6 @@ export class DhActorsOverviewComponent implements OnInit {
 
   isLoading = true;
   hasError = false;
-
-  @ViewChild(WattSearchComponent) searchComponent!: WattSearchComponent;
 
   ngOnInit(): void {
     const subscription = this.getActorsQuery$.valueChanges

--- a/libs/watt/src/lib/components/search/watt-search.component.ts
+++ b/libs/watt/src/lib/components/search/watt-search.component.ts
@@ -58,9 +58,7 @@ export class WattSearchComponent {
   @Output() search = new EventEmitter<string>();
 
   public clear(): void {
-    if (this.input.nativeElement.value === '') {
-      return;
-    }
+    if (this.input.nativeElement.value === '') return;
 
     this.input.nativeElement.value = '';
 

--- a/libs/watt/src/lib/components/search/watt-search.component.ts
+++ b/libs/watt/src/lib/components/search/watt-search.component.ts
@@ -58,6 +58,10 @@ export class WattSearchComponent {
   @Output() search = new EventEmitter<string>();
 
   public clear(): void {
+    if (this.input.nativeElement.value === '') {
+      return;
+    }
+
     this.input.nativeElement.value = '';
 
     this.search.emit(this.input.nativeElement.value);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### DataHub
- reset search input when filters get reset
- remove unused import

### Watt
- do not clear input if it's already empty

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- N/A
