### PR TITLE
fix(eo): add resolver for certificate details title

### DIFF
--- a/libs/eo/certificates/feature-details/eo-certificate-details.component.ts
+++ b/libs/eo/certificates/feature-details/eo-certificate-details.component.ts
@@ -17,7 +17,6 @@
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
 import { NgIf } from '@angular/common';
-import { Title } from '@angular/platform-browser';
 import { map, tap } from 'rxjs';
 
 import { WATT_CARD } from '@energinet-datahub/watt/card';
@@ -122,7 +121,6 @@ import { EoStackComponent } from '@energinet-datahub/eo/shared/atomic-design/ui-
 export class EoCertificateDetailsComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
-  private titleService = inject(Title);
   private certificatesService: EoCertificatesService = inject(EoCertificatesService);
 
   certificate = signal<EoCertificate | undefined>(undefined);
@@ -142,16 +140,6 @@ export class EoCertificateDetailsComponent implements OnInit {
       )
       .subscribe((certificate) => {
         this.certificate.set(certificate);
-        this.titleService.setTitle(
-          this.titleService.getTitle() +
-            ' - ' +
-            this.capitalizeFirstLetter(certificate?.certificateType)
-        );
       });
-  }
-
-  capitalizeFirstLetter(string?: string) {
-    if (!string) return '';
-    return string.charAt(0).toUpperCase() + string.slice(1);
   }
 }

--- a/libs/eo/certificates/shell/certificates.routes.ts
+++ b/libs/eo/certificates/shell/certificates.routes.ts
@@ -15,9 +15,37 @@
  * limitations under the License.
  */
 
-import { Routes } from '@angular/router';
+import { Injectable, inject } from '@angular/core';
+import { ActivatedRouteSnapshot, Routes } from '@angular/router';
+import { map } from 'rxjs';
+
 import { EoCertificateDetailsComponent } from '@energinet-datahub/eo/certificates/feature-details';
 import { EoCertificatesOverviewComponent } from '@energinet-datahub/eo/certificates/feature-overview';
+import { EoCertificatesService } from '@energinet-datahub/eo/certificates/data-access-api';
+import { EoCertificate } from '@energinet-datahub/eo/certificates/domain';
+
+@Injectable({ providedIn: 'root' })
+export class CertificateDetailsTitleResolver {
+  private certificatesService: EoCertificatesService = inject(EoCertificatesService);
+
+  resolve(route: ActivatedRouteSnapshot) {
+    return this.certificatesService.getCertificates().pipe(
+      map((certs: EoCertificate[]) =>
+        certs.find((item) => item.federatedStreamId.streamId === route.params.id)
+      ),
+      map(
+        (cert) =>
+          'Certificate details - ' + this.capitalizeFirstLetter(cert?.certificateType) ??
+          'Certificate details'
+      )
+    );
+  }
+
+  capitalizeFirstLetter(string?: string) {
+    if (!string) return '';
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  }
+}
 
 export const eoCertificatesRoutes: Routes = [
   {
@@ -27,7 +55,7 @@ export const eoCertificatesRoutes: Routes = [
   },
   {
     path: ':id',
-    title: 'Certificate details',
+    title: CertificateDetailsTitleResolver,
     component: EoCertificateDetailsComponent,
   },
 ];


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Since the upgrade of Angular v17, the title hasn't been updated as it should on the certificate details page. 
To fix the issue, a resolver for the title has been created. 

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
