### PR TITLE
Remove "source" from consumption metering points

### DIFF
--- a/libs/eo/metering-points/shell/src/lib/eo-metering-point-table.component.ts
+++ b/libs/eo/metering-points/shell/src/lib/eo-metering-point-table.component.ts
@@ -162,7 +162,11 @@ export class EoMeteringPointsTableComponent {
     gsrn: { accessor: 'gsrn', header: 'Metering point' },
     address: { accessor: (meteringPoint) => meteringPoint.address.address1 },
     unit: { accessor: (meteringPoint) => meteringPoint.type },
-    source: { accessor: (meteringPoint) => meteringPoint.assetType },
+    source: {
+      accessor: (meteringPoint) => {
+        return meteringPoint.type === 'production' ? meteringPoint.assetType : '';
+      }
+    },
     gc: {
       accessor: (meteringPoint) => {
         const itemHasActiveContract = meteringPoint.contract ? 'active' : 'enable';

--- a/libs/eo/metering-points/shell/src/lib/eo-metering-point-table.component.ts
+++ b/libs/eo/metering-points/shell/src/lib/eo-metering-point-table.component.ts
@@ -124,7 +124,7 @@ class GranularCertificateHelperComponent {}
               toggleContract.emit({
                 checked: $event.checked,
                 gsrn: meteringPoint.gsrn,
-                type: meteringPoint.type,
+                type: meteringPoint.type
               })
             "
             [disabled]="meteringPoint.loadingContract"
@@ -165,7 +165,7 @@ export class EoMeteringPointsTableComponent {
     source: {
       accessor: (meteringPoint) => {
         return meteringPoint.type === 'production' ? meteringPoint.assetType : '';
-      }
+      },
     },
     gc: {
       accessor: (meteringPoint) => {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Remove "source" from consumption metering points

![image](https://github.com/Energinet-DataHub/greenforce-frontend/assets/86852536/ec3e4508-4b69-418d-9b00-8a70aeba992f)

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
