### PR TITLE
fix(dh): guard against duplicate grid area codes

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/GridAreaByCodeBatchDataLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/GridAreaByCodeBatchDataLoader.cs
@@ -35,6 +35,8 @@ namespace Energinet.DataHub.WebApi.GraphQL
         protected override async Task<IReadOnlyDictionary<string, GridAreaDto>> LoadBatchAsync(
             IReadOnlyList<string> keys,
             CancellationToken cancellationToken) =>
-            (await _client.GridAreaGetAsync()).ToDictionary(x => x.Code);
+                (await _client.GridAreaGetAsync())
+                    .DistinctBy(x => x.Code)
+                    .ToDictionary(x => x.Code);
     }
 }


### PR DESCRIPTION
The GetCalculations query was returning 500 due to (presumably) some garbage data in grid areas. Since we are returning a dictionary by grid area code, it doesn't make sense to have multiple entries with the same code. This change removes duplicates, but does not make any decision on which entry to remove (DistinctBy keeps the first entry I believe).
