### PR TITLE
fix(dh): remove "organizations:manage" permission

### DIFF
--- a/libs/dh/market-participant/actors/feature-organizations/src/lib/drawer/dh-organization-drawer.component.html
+++ b/libs/dh/market-participant/actors/feature-organizations/src/lib/drawer/dh-organization-drawer.component.html
@@ -18,7 +18,7 @@ limitations under the License.
   <watt-drawer #drawer (closed)="onClose()">
     <watt-drawer-actions>
       <watt-button
-        *dhPermissionRequired="['organizations:manage']"
+        *dhPermissionRequired="['actors:manage']"
         variant="secondary"
         (click)="isEditModalVisible = true"
         >{{ t("edit") }}</watt-button
@@ -86,10 +86,7 @@ limitations under the License.
             </watt-table>
           </watt-card>
         </watt-tab>
-        <watt-tab
-          [label]="t('tabs.history.tabLabel')"
-          *dhPermissionRequired="['organizations:manage']"
-        >
+        <watt-tab [label]="t('tabs.history.tabLabel')" *dhPermissionRequired="['actors:manage']">
           <vater-stack [fill]="'horizontal'" [align]="'center'">
             <watt-spinner *ngIf="isLoadingAuditLog" />
           </vater-stack>

--- a/libs/dh/shared/data-access-mocks/src/lib/data/admin-get-permissions.ts
+++ b/libs/dh/shared/data-access-mocks/src/lib/data/admin-get-permissions.ts
@@ -31,8 +31,8 @@ export const adminPermissionsMock: GetPermissionsQuery = {
     {
       __typename: 'Permission',
       id: 2,
-      name: 'organizations:manage',
-      description: 'Description for OrganizationManage',
+      name: 'actors:manage',
+      description: 'Description for ActorsManage',
       created: parseISO('2023-03-07T00:00:00+00:00'),
     },
   ],

--- a/libs/dh/shared/data-access-mocks/src/lib/data/marketParticipantUserRoleGetUserRoleWithPermissions.json
+++ b/libs/dh/shared/data-access-mocks/src/lib/data/marketParticipantUserRoleGetUserRoleWithPermissions.json
@@ -8,8 +8,8 @@
     "permissions": [
       {
         "id": 1,
-        "name": "organizations:manage",
-        "description": "Permission to manage organization"
+        "name": "actors:manage",
+        "description": "Permission to manage actors"
       },
       {
         "id": 2,
@@ -32,8 +32,8 @@
     "permissions": [
       {
         "id": 1,
-        "name": "organizations:manage",
-        "description": "Permission to manage organization"
+        "name": "actors:manage",
+        "description": "Permission to manage actors"
       },
       {
         "id": 2,

--- a/libs/dh/shared/data-access-mocks/src/lib/data/marketParticipantUserRolePermissions.json
+++ b/libs/dh/shared/data-access-mocks/src/lib/data/marketParticipantUserRolePermissions.json
@@ -1,8 +1,8 @@
 [
   {
     "id": 1,
-    "name": "organizations:manage",
-    "description": "Permission to manage organization"
+    "name": "actors:manage",
+    "description": "Permission to manage actors"
   },
   {
     "id": 2,

--- a/libs/dh/shared/domain/src/lib/permission.ts
+++ b/libs/dh/shared/domain/src/lib/permission.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 export const permissions = [
-  'organizations:manage',
   'grid-areas:manage',
   'actors:manage',
   'users:manage',
@@ -28,4 +27,5 @@ export const permissions = [
   'imbalance-prices:manage',
   'actor-master-data:manage',
 ] as const;
+
 export type Permission = (typeof permissions)[number];


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### DataHub
- replace "organizations:manage" with "actors:manage"

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- N/A
