### PR TITLE
fix(watt): remove left padding from chips

### DIFF
--- a/libs/watt/src/lib/components/field/watt-field.component.scss
+++ b/libs/watt/src/lib/components/field/watt-field.component.scss
@@ -68,6 +68,10 @@ watt-field {
 
   &:not(.watt-field--chip) {
     min-height: 100px;
+
+    label .watt-field-wrapper {
+      padding-left: var(--watt-space-s);
+    }
   }
 
   &.watt-field--chip .watt-field-wrapper {
@@ -104,7 +108,6 @@ watt-field {
       @include watt.typography-watt-text-s;
       display: flex;
       min-height: 46px;
-      padding-left: var(--watt-space-s);
       width: 100%;
       border-radius: var(--watt-input-border-radius);
       border: 1px solid var(--watt-border-color);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

The watt-field component was applying some left padding (in order to position input fields correctly), but this was also wrongly applying to chips components. This PR fixes that.
