### PR TITLE
hack(dh): filter grid areas in test 001

### DIFF
--- a/libs/dh/shared/feature-flags/src/lib/feature-flags.ts
+++ b/libs/dh/shared/feature-flags/src/lib/feature-flags.ts
@@ -41,6 +41,10 @@ export const dhFeatureFlagsConfig = {
       DhAppEnvironment.test_002,
     ],
   },
+  'calculations-include-all-grid-areas': {
+    created: '18-03-2024',
+    disabledEnvironments: [DhAppEnvironment.test_001],
+  },
 } satisfies FeatureFlagConfig;
 
 export type DhFeatureFlags = keyof typeof dhFeatureFlagsConfig;

--- a/libs/dh/wholesale/feature-calculations/src/lib/create/create.component.ts
+++ b/libs/dh/wholesale/feature-calculations/src/lib/create/create.component.ts
@@ -38,6 +38,7 @@ import { WattSpinnerComponent } from '@energinet-datahub/watt/spinner';
 import { WattToastService } from '@energinet-datahub/watt/toast';
 import { WattValidationMessageComponent } from '@energinet-datahub/watt/validation-message';
 import { WattTextFieldComponent } from '@energinet-datahub/watt/text-field';
+import { DhFeatureFlagsService } from '@energinet-datahub/dh/shared/feature-flags';
 import {
   CreateCalculationDocument,
   GetGridAreasDocument,
@@ -91,6 +92,8 @@ export class DhCalculationsCreateComponent implements OnInit, OnDestroy {
   private executionTypeChanged_$ = new Subject<void>();
 
   @ViewChild('modal') modal?: WattModalComponent;
+
+  featureFlagsService = inject(DhFeatureFlagsService);
 
   loading = false;
 
@@ -149,6 +152,12 @@ export class DhCalculationsCreateComponent implements OnInit, OnDestroy {
     this.executionTypeChanged_$.pipe(startWith('')),
   ]).pipe(
     map(([gridAreas, dateRange]) => filterValidGridAreas(gridAreas, dateRange)),
+    map((gridAreas) =>
+      // HACK: This is a temporary solution to filter out grid areas that has no data
+      this.featureFlagsService.isEnabled('calculations-include-all-grid-areas')
+        ? gridAreas
+        : gridAreas.filter((g) => ['803', '804', '533', '543', '584', '950'].includes(g.code))
+    ),
     map((gridAreas) => {
       this.setMinDate(gridAreas);
       this.validatePeriod(gridAreas);


### PR DESCRIPTION
## Description

If a user starts a calculation with a grid area that has no data (which is most of them), the calculation will fail. This creates a lot of noise for the wholesale operation. This is a temporary hack to make sure that only a specific subset of grid areas can be selected when starting new calculations. I made this as a feature flag so it could only apply to test-001 AND to periodically get the reminder that this hack exists.