### PR TITLE
fix(dh): set button in loading state while a request is active

### DIFF
--- a/libs/dh/admin/feature-invite-user-modal/src/lib/dh-invite-user-modal.component.html
+++ b/libs/dh/admin/feature-invite-user-modal/src/lib/dh-invite-user-modal.component.html
@@ -29,7 +29,12 @@ limitations under the License.
     #stepper
     (completed)="inviteUser()"
   >
-    <watt-stepper-step [label]="t('email')" [stepControl]="baseInfo" [nextButtonLabel]="t('next')">
+    <watt-stepper-step
+      [label]="t('email')"
+      [stepControl]="baseInfo"
+      [nextButtonLabel]="t('next')"
+      [loadingNextButton]="checkingForAssociatedActors()"
+    >
       <form [formGroup]="userInfo" class="userInfoForm">
         @if ((actors$ | push).length > 1) {
           <watt-dropdown

--- a/libs/dh/shared/data-access-mocks/src/lib/admin.ts
+++ b/libs/dh/shared/data-access-mocks/src/lib/admin.ts
@@ -61,6 +61,7 @@ export function adminMocks(apiBase: string) {
     putMarketParticipantPermissionsUpdate(apiBase),
     postMarketParticipantUserRoleCreate(apiBase),
     putMarketParticipantUserUpdateUserIdentity(apiBase),
+    postMarketParticipantUserInviteUser(apiBase),
     putMarketParticipantUserRoleAssignmentUpdateAssignments(apiBase),
     getMarketParticipantUserRoleGetAssignable(apiBase),
     getActorOrganization(apiBase),
@@ -187,6 +188,13 @@ function postMarketParticipantUserRoleCreate(apiBase: string) {
 
 function putMarketParticipantUserUpdateUserIdentity(apiBase: string) {
   return http.put(`${apiBase}/v1/MarketParticipantUser/UpdateUserIdentity`, async () => {
+    await delay(mswConfig.delay);
+    return new HttpResponse(null, { status: 200 });
+  });
+}
+
+function postMarketParticipantUserInviteUser(apiBase: string) {
+  return http.post(`${apiBase}/v1/MarketParticipantUser/InviteUser`, async () => {
     await delay(mswConfig.delay);
     return new HttpResponse(null, { status: 200 });
   });

--- a/libs/dh/shared/data-access-mocks/src/lib/data/marketParticipantOrganizationGetFilteredActors.ts
+++ b/libs/dh/shared/data-access-mocks/src/lib/data/marketParticipantOrganizationGetFilteredActors.ts
@@ -23,7 +23,7 @@ export const marketParticipantOrganizationGetFilteredActors: MarketParticipantFi
       value: '5790001330583',
     },
     name: {
-      value: 'Energinet DataHub A/S (DataHub systemadministrator)',
+      value: 'Energinet DataHub A/S',
     },
     marketRoles: ['DataHubAdministrator'],
     gridAreaCodes: [],

--- a/libs/watt/src/lib/components/stepper/watt-stepper-step.component.ts
+++ b/libs/watt/src/lib/components/stepper/watt-stepper-step.component.ts
@@ -31,6 +31,7 @@ export class WattStepperStepComponent extends MatStep {
 
   @Input() nextButtonLabel?: string;
   @Input() disableNextButton = false;
+  @Input() loadingNextButton = false;
   @Input() previousButtonLabel?: string;
   @Input() enabled = true;
 

--- a/libs/watt/src/lib/components/stepper/watt-stepper.component.html
+++ b/libs/watt/src/lib/components/stepper/watt-stepper.component.html
@@ -54,6 +54,7 @@ limitations under the License.
           *ngIf="!(onLastStep$ | push)"
           variant="secondary"
           (click)="nextStep(step)"
+          [loading]="step.loadingNextButton"
           [disabled]="step.disableNextButton"
         >
           {{ step.nextButtonLabel }}<watt-icon name="right" />


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

### DataHub
- set button in loading state while a request is active
- update mock

### Watt
- extend step component to allow setting next button in loading state

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- N/A
