### PR TITLE
fix: ignore license headers for files in favicon folder

### DIFF
--- a/.licenserc.json
+++ b/.licenserc.json
@@ -4,6 +4,7 @@
     "**/generated/**/*",
     "apps/dh/api-dh/source/DataHub.WebApi/Clients/",
     "apps/dh/api-dh/source/DataHub.WebApi/Generated/",
+    "libs/dh/shared/assets/src/favicon/*",
     "libs/gf/msw/util-msw/src/assets/*"
   ],
   "**/*.cs": [

--- a/libs/dh/shared/assets/src/favicon/browserconfig.xml
+++ b/libs/dh/shared/assets/src/favicon/browserconfig.xml
@@ -1,19 +1,3 @@
-<!--
-@license
-Copyright 2020 Energinet DataHub A/S
-
-Licensed under the Apache License, Version 2.0 (the "License2");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
 <?xml version="1.0" encoding="utf-8"?>
 <browserconfig>
     <msapplication>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
