### PR TITLE
refactor(dh): move ApolloModule to shell providers

### DIFF
--- a/libs/dh/core/shell/src/lib/dh-core-shell.component.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.component.ts
@@ -18,7 +18,6 @@ import { Component, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { TranslocoPipe } from '@ngneat/transloco';
 import { RxPush } from '@rx-angular/template/push';
-import { ApolloModule } from 'apollo-angular';
 
 import { WattShellComponent } from '@energinet-datahub/watt/shell';
 import { DhTopBarStore } from '@energinet-datahub/dh-shared-data-access-top-bar';
@@ -38,7 +37,6 @@ import { DhPrimaryNavigationComponent } from './dh-primary-navigation.component'
   standalone: true,
   imports: [
     TranslocoPipe,
-    ApolloModule,
     RouterOutlet,
     RxPush,
 

--- a/libs/dh/core/shell/src/lib/dh-core-shell.providers.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.providers.ts
@@ -30,6 +30,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { FormGroupDirective } from '@angular/forms';
 import { IPublicClientApplication } from '@azure/msal-browser';
 import { of } from 'rxjs';
+import { ApolloModule } from 'apollo-angular';
 
 import { translocoProviders } from '@energinet-datahub/dh/globalization/configuration-localization';
 import { dhWattTranslationsProviders } from '@energinet-datahub/dh/globalization/configuration-watt-translation';
@@ -104,7 +105,7 @@ const msalProviders = [
 ];
 
 export const dhCoreShellProviders = [
-  importProvidersFrom([MatDialogModule, MatSnackBarModule, DhApiModule.forRoot()]),
+  importProvidersFrom([MatDialogModule, MatSnackBarModule, DhApiModule.forRoot(), ApolloModule]),
   FormGroupDirective,
   environment.production ? applicationInsightsProviders : [],
   dhWattTranslationsProviders,

--- a/libs/dh/profile/feature-profile-modal/src/lib/dh-profile-modal/dh-profile-modal.component.ts
+++ b/libs/dh/profile/feature-profile-modal/src/lib/dh-profile-modal/dh-profile-modal.component.ts
@@ -16,7 +16,7 @@
  */
 import { TranslocoDirective, TranslocoPipe, translate } from '@ngneat/transloco';
 import { Component, ViewChild, inject, signal } from '@angular/core';
-import { Apollo, ApolloModule, MutationResult } from 'apollo-angular';
+import { Apollo, MutationResult } from 'apollo-angular';
 import {
   FormControl,
   FormGroup,
@@ -55,7 +55,6 @@ type UserPreferencesForm = FormGroup<{
     TranslocoDirective,
     TranslocoPipe,
     ReactiveFormsModule,
-    ApolloModule,
 
     WATT_MODAL,
     WattTextFieldComponent,
@@ -67,9 +66,8 @@ type UserPreferencesForm = FormGroup<{
     DhMitIDButtonComponent,
   ],
   styles: `
-
     h4 {
-      margin:0;
+      margin: 0;
       margin-bottom: var(--watt-space-s);
     }
 
@@ -77,7 +75,9 @@ type UserPreferencesForm = FormGroup<{
       width: 75%;
     }
 
-    .phone-field, .lang-field, .mitid-field {
+    .phone-field,
+    .lang-field,
+    .mitid-field {
       width: 50%;
       display: block;
     }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### DataHub
- move `ApolloModule` to core providers so `Apollo` injectable is provided globally. Before this change, `ApolloModule` had to be imported in *some* `..Modal` components due to `No provider for _Apollo!` error.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
