### PR TITLE
fix: quarterly-resolution-transition-datetime-override

### DIFF
--- a/libs/dh/shared/assets/src/assets/configuration/dh-app-environment.local.json
+++ b/libs/dh/shared/assets/src/assets/configuration/dh-app-environment.local.json
@@ -1,6 +1,5 @@
 {
   "current": "localhost",
-  "quarterlyResolutionTransitionDatetime": "2023-01-31T23:00:00Z",
   "applicationInsights": {
     "instrumentationKey": "<instrumentation-key>"
   }

--- a/libs/dh/shared/environments/src/lib/app-environment/dh-app-environment.ts
+++ b/libs/dh/shared/environments/src/lib/app-environment/dh-app-environment.ts
@@ -22,7 +22,6 @@ import { environment } from '../environment';
 
 export interface DhAppEnvironmentConfig {
   current: DhAppEnvironment;
-  quarterlyResolutionTransitionDatetime: string;
   applicationInsights: {
     instrumentationKey: string;
   };

--- a/libs/dh/shared/feature-flags/src/lib/feature-flags.service.spec.ts
+++ b/libs/dh/shared/feature-flags/src/lib/feature-flags.service.spec.ts
@@ -35,7 +35,6 @@ describe('Feature flags service', () => {
     const isFeatureEnabled = new DhFeatureFlagsService(
       {
         current: DhAppEnvironment.local,
-        quarterlyResolutionTransitionDatetime: '',
         applicationInsights: {
           instrumentationKey: '',
         },
@@ -74,7 +73,6 @@ describe('Feature flags service', () => {
       const isFeatureEnabled = new DhFeatureFlagsService(
         {
           current: environment as DhAppEnvironment,
-          quarterlyResolutionTransitionDatetime: '',
           applicationInsights: {
             instrumentationKey: '',
           },

--- a/libs/dh/shared/feature-flags/src/lib/feature-flags.ts
+++ b/libs/dh/shared/feature-flags/src/lib/feature-flags.ts
@@ -59,6 +59,12 @@ export const dhFeatureFlagsConfig = {
       DhAppEnvironment.prod,
     ],
   },
+  // This feature flag should be removed in favor of injected environment variables
+  // from terraform, whenever the new web application setup is ready (outlaws).
+  'quarterly-resolution-transition-datetime-override': {
+    created: '06-05-2024',
+    disabledEnvironments: [DhAppEnvironment.preprod, DhAppEnvironment.prod],
+  },
 } satisfies FeatureFlagConfig;
 
 export type DhFeatureFlags = keyof typeof dhFeatureFlagsConfig;

--- a/libs/dh/wholesale/feature-calculations/src/lib/create/create.component.ts
+++ b/libs/dh/wholesale/feature-calculations/src/lib/create/create.component.ts
@@ -102,11 +102,13 @@ export class DhCalculationsCreateComponent implements OnInit, OnDestroy {
 
   @ViewChild('modal') modal?: WattModalComponent;
 
-  featureFlagsService = inject(DhFeatureFlagsService);
+  ffs = inject(DhFeatureFlagsService);
 
   environment = inject(dhAppEnvironmentToken);
 
-  resolutionTransitionDate = this.environment.quarterlyResolutionTransitionDatetime;
+  resolutionTransitionDate = this.ffs.isEnabled('quarterly-resolution-transition-datetime-override')
+    ? '2023-01-31T23:00:00Z'
+    : '2023-04-30T22:00:00Z';
 
   loading = false;
 
@@ -165,7 +167,7 @@ export class DhCalculationsCreateComponent implements OnInit, OnDestroy {
     map(([gridAreas, dateRange]) => filterValidGridAreas(gridAreas, dateRange)),
     map((gridAreas) =>
       // HACK: This is a temporary solution to filter out grid areas that has no data
-      this.featureFlagsService.isEnabled('calculations-include-all-grid-areas')
+      this.ffs.isEnabled('calculations-include-all-grid-areas')
         ? gridAreas
         : gridAreas.filter((g) => ['803', '804', '533', '543', '584', '950'].includes(g.code))
     ),


### PR DESCRIPTION
[Tak GitHub actions fordi du automatisk formaterer min (STRING) dato til et andet format, jeg skulle heller ikke bruge tidszonen til noget...](https://github.com/Energinet-DataHub/dh3-environments/pull/982) (hackede virkede ikke)

![ace-ventura-spank-you-very-much](https://github.com/Energinet-DataHub/greenforce-frontend/assets/22732929/d2fde44c-c64d-493a-b8a3-2d1883697cf1)
