### PR TITLE
feat: use min and max in datepicker mask

### DIFF
--- a/libs/dh/wholesale/feature-calculations/src/lib/create/create.component.ts
+++ b/libs/dh/wholesale/feature-calculations/src/lib/create/create.component.ts
@@ -177,7 +177,7 @@ export class DhCalculationsCreateComponent implements OnInit, OnDestroy {
     tap((gridAreas) => this.selectGridAreas(gridAreas))
   );
 
-  minDate: Date | null = null;
+  minDate?: Date;
   maxDate = new Date();
 
   ngOnInit(): void {

--- a/libs/watt/src/lib/components/picker/datepicker/watt-datepicker.component.html
+++ b/libs/watt/src/lib/components/picker/datepicker/watt-datepicker.component.html
@@ -19,8 +19,8 @@ limitations under the License.
     <mat-date-range-input
       [disabled]="disabled"
       [rangePicker]="rangeDatepicker"
-      [min]="min"
-      [max]="max"
+      [min]="min() ?? null"
+      [max]="max() ?? null"
       (focusin)="onFocusIn()"
       (focusout)="onFocusOut($event)"
     >
@@ -47,7 +47,7 @@ limitations under the License.
     <input #actualInput class="mask-input" [disabled]="disabled" />
     <watt-placeholder-mask
       [primaryInputElement]="actualInput"
-      [mask]="rangeInputMask"
+      [mask]="rangeInputMask()"
       [placeholder]="rangePlaceholder"
       (maskApplied)="rangeInputChanged($event)"
     />
@@ -88,7 +88,7 @@ limitations under the License.
     <input #actualInput class="mask-input" [disabled]="disabled" />
     <watt-placeholder-mask
       [primaryInputElement]="actualInput"
-      [mask]="inputMask"
+      [mask]="inputMask()"
       [placeholder]="datePlaceholder"
       (maskApplied)="inputChanged($event)"
     />

--- a/libs/watt/src/lib/components/picker/datepicker/watt-datepicker.component.ts
+++ b/libs/watt/src/lib/components/picker/datepicker/watt-datepicker.component.ts
@@ -24,7 +24,9 @@ import {
   LOCALE_ID,
   ViewChild,
   ViewEncapsulation,
+  computed,
   inject,
+  input,
 } from '@angular/core';
 import { NgControl } from '@angular/forms';
 import {
@@ -44,7 +46,6 @@ import { WattFieldComponent } from '@energinet-datahub/watt/field';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { WattLocaleService } from '@energinet-datahub/watt/locale';
 import { MaskitoModule } from '@maskito/angular';
-import { MaskitoOptions } from '@maskito/core';
 import { maskitoDateOptionsGenerator, maskitoDateRangeOptionsGenerator } from '@maskito/kit';
 import { WattSupportedLocales } from '../../../configuration/watt-date-adapter';
 import { WattDateRange, dayjs } from '../../../utils/date';
@@ -91,8 +92,9 @@ export class WattDatepickerComponent extends WattPickerBase {
   private locale: WattSupportedLocales = inject(LOCALE_ID) as WattSupportedLocales;
   private destroyRef = inject(DestroyRef);
 
-  @Input() max: Date | null = null;
-  @Input() min: Date | null = null;
+  max = input<Date>();
+  min = input<Date>();
+
   @Input() startAt: Date | null = null;
   @Input() rangeMonthOnlyMode = false;
   @Input() label = '';
@@ -166,14 +168,26 @@ export class WattDatepickerComponent extends WattPickerBase {
   /**
    * @ignore
    */
-  inputMask: MaskitoOptions = maskitoDateOptionsGenerator({ mode: 'dd/mm/yyyy', separator: '-' });
+  inputMask = computed(() =>
+    maskitoDateOptionsGenerator({
+      mode: 'dd/mm/yyyy',
+      separator: '-',
+      max: this.max(),
+      min: this.min(),
+    })
+  );
+
   /**
    * @ignore
    */
-  rangeInputMask: MaskitoOptions = maskitoDateRangeOptionsGenerator({
-    mode: 'dd/mm/yyyy',
-    dateSeparator: '-',
-  });
+  rangeInputMask = computed(() =>
+    maskitoDateRangeOptionsGenerator({
+      mode: 'dd/mm/yyyy',
+      dateSeparator: '-',
+      max: this.max(),
+      min: this.min(),
+    })
+  );
   /**
    * @ignore
    */


### PR DESCRIPTION
This PR includes the min and max date configuration in the Maskito options. This means we can skip validating min and max in form controls, since maskito will prevent entering dates outside of this range.