### PR TITLE
refactor(dh): adjustments to balance responsible relations

### DIFF
--- a/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/balance-responsible-relation-tab/dh-balance-responsible-relation-filter.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/balance-responsible-relation-tab/dh-balance-responsible-relation-filter.component.ts
@@ -14,18 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import {
-  Component,
-  DestroyRef,
-  OnInit,
-  computed,
-  effect,
-  inject,
-  input,
-  output,
-} from '@angular/core';
+import { Component, DestroyRef, OnInit, computed, inject, input, output } from '@angular/core';
 
 import { BehaviorSubject } from 'rxjs';
 import { RxPush } from '@rx-angular/template/push';
@@ -164,12 +155,9 @@ export class DhBalanceResponsibleRelationFilterComponent implements OnInit {
   });
 
   constructor() {
-    effect(() => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const fakeReadToTriggerEffect = this.actor();
-
-      this.filtersForm.reset();
-    });
+    toObservable(this.actor)
+      .pipe(takeUntilDestroyed())
+      .subscribe(() => this.filtersForm.reset());
   }
 
   ngOnInit(): void {

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/balance-responsible-relation-tab/dh-balance-responsible-relation-tab.component.html
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/balance-responsible-relation-tab/dh-balance-responsible-relation-tab.component.html
@@ -25,10 +25,10 @@ limitations under the License.
 >
   <vater-stack direction="row" gap="s" class="watt-space-stack-m">
     <dh-balance-responsible-relation-filters
-      (filter)="store.updateFilters($event)"
-      [inital]="store.filters()"
-      [marketRole]="actor().marketRole!"
+      [actor]="actor()"
+      (filtersChanges)="store.updateFilters($event)"
     />
+
     <watt-button icon="download" variant="text" (click)="download()">{{
       "shared.download" | transloco
     }}</watt-button>

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/balance-responsible-relation-tab/dh-balance-responsible-relation-tab.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/balance-responsible-relation-tab/dh-balance-responsible-relation-tab.component.ts
@@ -26,14 +26,13 @@ import {
   VaterStackComponent,
 } from '@energinet-datahub/watt/vater';
 import { WATT_EXPANDABLE_CARD_COMPONENTS } from '@energinet-datahub/watt/expandable-card';
-
+import { exportToCSV } from '@energinet-datahub/dh/shared/ui-util';
+import { WattButtonComponent } from '@energinet-datahub/watt/button';
 import { DhActorExtended } from '@energinet-datahub/dh/market-participant/actors/domain';
 
 import { DhBalanceResponsibleRelationsTableComponent } from './table/dh-table.componen';
 import { DhBalanceResponsibleRelationsStore } from './dh-balance-responsible-relation.store';
 import { DhBalanceResponsibleRelationFilterComponent } from './dh-balance-responsible-relation-filter.component';
-import { exportToCSV } from '@energinet-datahub/dh/shared/ui-util';
-import { WattButtonComponent } from '@energinet-datahub/watt/button';
 
 @Component({
   standalone: true,
@@ -76,20 +75,7 @@ export class DhBalanceResponsibleRelationTabComponent {
   actor = input.required<DhActorExtended>();
 
   constructor() {
-    effect(
-      () => {
-        this.store.updateFilters({
-          balanceResponsibleWithNameId: null,
-          energySupplierWithNameId: null,
-          gridAreaCode: null,
-          search: null,
-          status: null,
-          actorId: this.actor().id,
-          eicFunction: this.actor().marketRole ?? null,
-        });
-      },
-      { allowSignalWrites: true }
-    );
+    effect(() => this.store.updateActor(this.actor()), { allowSignalWrites: true });
   }
 
   download() {

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/balance-responsible-relation-tab/dh-balance-responsible-relation.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/balance-responsible-relation-tab/dh-balance-responsible-relation.ts
@@ -18,7 +18,6 @@ import type { ResultOf } from '@graphql-typed-document-node/core';
 
 import {
   BalanceResponsibilityAgreementStatus,
-  EicFunction,
   GetBalanceResponsibleRelationDocument,
   InputMaybe,
   MarketParticipantMeteringPointType,
@@ -49,8 +48,6 @@ export type DhBalanceResponsibleRelationsGrouped = {
 }[];
 
 export type DhBalanceResponsibleRelationFilters = {
-  actorId: InputMaybe<Scalars['UUID']['input']>;
-  eicFunction: InputMaybe<EicFunction>;
   status: InputMaybe<BalanceResponsibilityAgreementStatus>;
   energySupplierWithNameId: InputMaybe<string>;
   gridAreaCode: InputMaybe<Scalars['UUID']['input']>;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### DataHub
- rework logic so filters are reset whenever a new market participant is loaded in the drawer.

Note: I'm not particularly happy with resetting the filters inside an `effect` but couldn't come up with a better solution, for now. Open for other suggestion. :)

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
