### PR TITLE
fix(eo, consent): Add mocks and fixes issues with onboarding flow

### DIFF
--- a/libs/eo/consent/feature-grant-consent/grant-consent.component.ts
+++ b/libs/eo/consent/feature-grant-consent/grant-consent.component.ts
@@ -192,7 +192,7 @@ export class EoGrantConsentModalComponent implements OnInit {
   protected isLoading = signal<boolean>(false);
   protected organizationName = signal<string>('');
   protected redirectUrl = signal<string>('');
-  protected opened = false;
+  public opened = false;
 
   ngOnInit(): void {
     this.setForm();

--- a/libs/eo/consent/feature-overview/consent-overview.component.ts
+++ b/libs/eo/consent/feature-overview/consent-overview.component.ts
@@ -125,7 +125,7 @@ export class EoConsentOverviewComponent implements OnInit {
         this.setColumns(userInfo.org_name);
         this.cd.detectChanges();
 
-        if (this.thirdPartyClientId) {
+        if (this.thirdPartyClientId && !this.grantConsentModal.opened) {
           this.grantConsentModal.open();
         }
       });

--- a/libs/eo/shared/data-access-mocks/src/index.ts
+++ b/libs/eo/shared/data-access-mocks/src/index.ts
@@ -18,6 +18,7 @@ import { aggregateCertificatesMocks } from './lib/aggregate-certificates';
 import { aggregateClaimsMocks } from './lib/aggregate-claims';
 import { aggregateTransfersMocks } from './lib/aggregate-transfers';
 import { authMocks } from './lib/auth';
+import { authorizationMocks } from './lib/authorization';
 import { certificatesMocks } from './lib/certificates';
 import { claimsMocks } from './lib/claims';
 import { meteringPointsMocks } from './lib/metering-points';
@@ -32,4 +33,5 @@ export const mocks = [
   claimsMocks,
   meteringPointsMocks,
   transferMocks,
+  authorizationMocks,
 ];

--- a/libs/eo/shared/data-access-mocks/src/lib/authorization.ts
+++ b/libs/eo/shared/data-access-mocks/src/lib/authorization.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { http, HttpResponse } from 'msw';
+
+export function authorizationMocks(apiBase: string) {
+  return [
+    getConsent(apiBase),
+    getConsents(apiBase),
+    postGrantConsent(apiBase)
+  ];
+}
+
+function getConsent(apiBase: string) {
+  return http.get(`${apiBase}/authorization/client/:id`, () => {
+    const data = {
+      idpClientId: '529a55d0-68c7-4129-ba3c-e06d4f1038c4',
+      name: 'MOCKED_CLIENT',
+      redirectUrl: 'https://demo.energytrackandtrace.dk',
+    };
+    return HttpResponse.json(data, { status: 200 });
+  });
+}
+
+function getConsents(apiBase: string) {
+  return http.get(`${apiBase}/authorization/consents`, () => {
+    const data = {
+      result: [
+        {
+          clientName: 'Ranularg',
+          consentDate: 1719386787,
+        },
+        {
+          clientName: 'Energinet Master Client',
+          consentDate: 1719387102,
+        },
+        {
+          clientName: 'Test',
+          consentDate: 1719388267,
+        },
+      ],
+    };
+    return HttpResponse.json(data, { status: 200 });
+  });
+}
+
+function postGrantConsent(apiBase: string) {
+  return http.post(`${apiBase}/authorization/consent/grant`, () => {
+    return HttpResponse.json({ status: 200 });
+  });
+}

--- a/libs/eo/shared/data-access-mocks/src/lib/authorization.ts
+++ b/libs/eo/shared/data-access-mocks/src/lib/authorization.ts
@@ -17,11 +17,7 @@
 import { http, HttpResponse } from 'msw';
 
 export function authorizationMocks(apiBase: string) {
-  return [
-    getConsent(apiBase),
-    getConsents(apiBase),
-    postGrantConsent(apiBase)
-  ];
+  return [getConsent(apiBase), getConsents(apiBase), postGrantConsent(apiBase)];
 }
 
 function getConsent(apiBase: string) {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

- Add mocks for `/authorization/consent` requests
- Ensure grant consent modal is not opened after consent is granted
- Make sure token refresh by the "old" auth is not triggered on the consent related API requests

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
