### PR TITLE
feat(dh): apollo signal reset function

### DIFF
--- a/libs/dh/shared/util-apollo/src/lib/mutation.spec.ts
+++ b/libs/dh/shared/util-apollo/src/lib/mutation.spec.ts
@@ -73,7 +73,7 @@ describe('mutation', () => {
       expect(onError).toHaveBeenCalled();
     })));
 
-  it('should respond with initial data after reset', fakeAsync(() =>
+  it('should clear result after reset', fakeAsync(() =>
     TestBed.runInInjectionContext(() => {
       const result = mutation(TEST_MUTATION);
       result.mutate();

--- a/libs/dh/shared/util-apollo/src/lib/mutation.spec.ts
+++ b/libs/dh/shared/util-apollo/src/lib/mutation.spec.ts
@@ -72,4 +72,18 @@ describe('mutation', () => {
       tick();
       expect(onError).toHaveBeenCalled();
     })));
+
+  it('should respond with initial data after reset', fakeAsync(() =>
+    TestBed.runInInjectionContext(() => {
+      const result = mutation(TEST_MUTATION);
+      result.mutate();
+      const op = controller.expectOne(TEST_MUTATION);
+      const data = { __typename: 'Mutation' };
+      op.flush({ data });
+      tick();
+      result.reset();
+      expect(result.data()).toBeUndefined();
+      expect(result.error()).toBeUndefined();
+      expect(result.loading()).toBe(false);
+    })));
 });

--- a/libs/dh/shared/util-apollo/src/lib/mutation.ts
+++ b/libs/dh/shared/util-apollo/src/lib/mutation.ts
@@ -42,6 +42,7 @@ export function mutation<TResult, TVariables>(
   const client = inject(Apollo);
   const destroyRef = inject(DestroyRef);
 
+  // Centralize the initial state of the mutation result
   const initialState = {
     data: undefined,
     error: undefined,

--- a/libs/dh/shared/util-apollo/src/lib/mutation.ts
+++ b/libs/dh/shared/util-apollo/src/lib/mutation.ts
@@ -42,17 +42,10 @@ export function mutation<TResult, TVariables>(
   const client = inject(Apollo);
   const destroyRef = inject(DestroyRef);
 
-  // Centralize the initial state of the mutation result
-  const initialState = {
-    data: undefined,
-    error: undefined,
-    loading: false,
-  };
-
   // Signals holding the result values
-  const data = signal<TResult | undefined>(initialState.data);
-  const error = signal<ApolloError | undefined>(initialState.error);
-  const loading = signal(initialState.loading);
+  const data = signal<TResult | undefined>(undefined);
+  const error = signal<ApolloError | undefined>(undefined);
+  const loading = signal(false);
 
   return {
     // Upcast to prevent writing to signals
@@ -60,9 +53,9 @@ export function mutation<TResult, TVariables>(
     error: error as Signal<ApolloError | undefined>,
     loading: loading as Signal<boolean>,
     reset: () => {
-      data.set(initialState.data);
-      error.set(initialState.error);
-      loading.set(initialState.loading);
+      data.set(undefined);
+      error.set(undefined);
+      loading.set(false);
     },
     mutate(options?: Partial<MutationOptions<TResult, TVariables>>) {
       const mergedOptions = { ...parentOptions, ...options };

--- a/libs/dh/shared/util-apollo/src/lib/mutation.ts
+++ b/libs/dh/shared/util-apollo/src/lib/mutation.ts
@@ -42,16 +42,27 @@ export function mutation<TResult, TVariables>(
   const client = inject(Apollo);
   const destroyRef = inject(DestroyRef);
 
+  const initialState = {
+    data: undefined,
+    error: undefined,
+    loading: false,
+  };
+
   // Signals holding the result values
-  const data = signal<TResult | undefined>(undefined);
-  const error = signal<ApolloError | undefined>(undefined);
-  const loading = signal(true);
+  const data = signal<TResult | undefined>(initialState.data);
+  const error = signal<ApolloError | undefined>(initialState.error);
+  const loading = signal(initialState.loading);
 
   return {
     // Upcast to prevent writing to signals
     data: data as Signal<TResult | undefined>,
     error: error as Signal<ApolloError | undefined>,
     loading: loading as Signal<boolean>,
+    reset: () => {
+      data.set(initialState.data);
+      error.set(initialState.error);
+      loading.set(initialState.loading);
+    },
     mutate(options?: Partial<MutationOptions<TResult, TVariables>>) {
       const mergedOptions = { ...parentOptions, ...options };
       const { onCompleted, onError, ...mutationOptions } = mergedOptions;

--- a/libs/dh/shared/util-apollo/src/lib/query.spec.ts
+++ b/libs/dh/shared/util-apollo/src/lib/query.spec.ts
@@ -120,4 +120,18 @@ describe('query', () => {
       expect(result.loading()).toBe(false);
       expect(result.networkStatus()).toBe(NetworkStatus.ready);
     })));
+
+  it('should respond with initial data after reset', fakeAsync(() =>
+    TestBed.runInInjectionContext(() => {
+      const result = query(TEST_QUERY);
+      const op = controller.expectOne(TEST_QUERY);
+      const data = { __type: { name: 'Query' } };
+      op.flush({ data });
+      tick();
+      result.reset();
+      expect(result.data()).toBeUndefined();
+      expect(result.error()).toBeUndefined();
+      expect(result.loading()).toBe(true);
+      expect(result.networkStatus()).toBe(NetworkStatus.loading);
+    })));
 });

--- a/libs/dh/shared/util-apollo/src/lib/query.spec.ts
+++ b/libs/dh/shared/util-apollo/src/lib/query.spec.ts
@@ -121,7 +121,7 @@ describe('query', () => {
       expect(result.networkStatus()).toBe(NetworkStatus.ready);
     })));
 
-  it('should respond with initial data after reset', fakeAsync(() =>
+  it('should clear result after reset', fakeAsync(() =>
     TestBed.runInInjectionContext(() => {
       const result = query(TEST_QUERY);
       const op = controller.expectOne(TEST_QUERY);
@@ -131,7 +131,7 @@ describe('query', () => {
       result.reset();
       expect(result.data()).toBeUndefined();
       expect(result.error()).toBeUndefined();
-      expect(result.loading()).toBe(true);
-      expect(result.networkStatus()).toBe(NetworkStatus.loading);
+      expect(result.loading()).toBe(false);
+      expect(result.networkStatus()).toBe(NetworkStatus.ready);
     })));
 });

--- a/libs/dh/shared/util-apollo/src/lib/query.ts
+++ b/libs/dh/shared/util-apollo/src/lib/query.ts
@@ -108,19 +108,11 @@ export function query<TResult, TVariables extends OperationVariables>(
     catchError((error: ApolloError) => fromApolloError<TResult>(error))
   );
 
-  // Centralize the initial state of the query result
-  const initialState = {
-    data: undefined,
-    error: undefined,
-    loading: !options?.skip,
-    networkStatus: options?.skip ? NetworkStatus.ready : NetworkStatus.loading,
-  };
-
   // Signals holding the result values
-  const data = signal<TResult | undefined>(initialState.data);
-  const error = signal<ApolloError | undefined>(initialState.error);
-  const loading = signal(initialState.loading);
-  const networkStatus = signal(initialState.networkStatus);
+  const data = signal<TResult | undefined>(undefined);
+  const error = signal<ApolloError | undefined>(undefined);
+  const loading = signal(!options?.skip);
+  const networkStatus = signal(options?.skip ? NetworkStatus.ready : NetworkStatus.loading);
 
   // Update the signal values based on the result of the query
   const subscription = result$.subscribe((result) => {
@@ -145,10 +137,10 @@ export function query<TResult, TVariables extends OperationVariables>(
     networkStatus: networkStatus as Signal<NetworkStatus>,
     reset: () => {
       reset$.next();
-      data.set(initialState.data);
-      error.set(initialState.error);
-      loading.set(initialState.loading);
-      networkStatus.set(initialState.networkStatus);
+      data.set(undefined);
+      error.set(undefined);
+      loading.set(false);
+      networkStatus.set(NetworkStatus.ready);
     },
     setOptions: (options: Partial<QueryOptions<TVariables>>) => {
       const result = firstValueFrom(result$.pipe(filter((result) => !result.loading)));

--- a/libs/dh/shared/util-apollo/src/lib/query.ts
+++ b/libs/dh/shared/util-apollo/src/lib/query.ts
@@ -27,6 +27,7 @@ import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import {
   BehaviorSubject,
   Observable,
+  Subject,
   catchError,
   filter,
   firstValueFrom,
@@ -37,6 +38,7 @@ import {
   startWith,
   switchMap,
   take,
+  takeUntil,
   withLatestFrom,
 } from 'rxjs';
 import { exists } from '@energinet-datahub/dh/shared/util-operators';
@@ -70,6 +72,9 @@ export function query<TResult, TVariables extends OperationVariables>(
   const client = inject(Apollo);
   const destroyRef = inject(DestroyRef);
 
+  // Make it possible to reset query and subscriptions to their initial state
+  const reset$ = new Subject<void>();
+
   // The `refetch` function on Apollo's `QueryRef` does not properly handle backpressure by
   // cancelling the previous request. As a workaround, the `valueChanges` is unsubscribed to and
   // a new `watchQuery` (with optionally new variables) is executed each time `refetch` is called.
@@ -88,7 +93,8 @@ export function query<TResult, TVariables extends OperationVariables>(
         skipWhile((data) => !data), // Wait until data is available
         map(() => ref), // Then emit the ref
         take(1), // And complete the observable
-        startWith(null) // Clear the ref immediately in case of refetch (to prevent stale ref)
+        startWith(null), // Clear the ref immediately in case of refetch (to prevent stale ref)
+        takeUntil(reset$) // Stop subscription if the query is reset
       )
     ),
     shareReplay(1), // Make sure the ref is available to late subscribers (in `subscribeToMore`)
@@ -97,16 +103,24 @@ export function query<TResult, TVariables extends OperationVariables>(
   );
 
   const result$ = ref$.pipe(
-    // The inner observable will be recreated each time the `variables$` emits
-    switchMap((ref) => ref.valueChanges),
+    // The inner observable will be recreated each time the `options$` emits
+    switchMap((ref) => ref.valueChanges.pipe(takeUntil(reset$))),
     catchError((error: ApolloError) => fromApolloError<TResult>(error))
   );
 
+  // Centralize the initial state of the query result
+  const initialState = {
+    data: undefined,
+    error: undefined,
+    loading: !options?.skip,
+    networkStatus: options?.skip ? NetworkStatus.ready : NetworkStatus.loading,
+  };
+
   // Signals holding the result values
-  const data = signal<TResult | undefined>(undefined);
-  const error = signal<ApolloError | undefined>(undefined);
-  const loading = signal(!options?.skip);
-  const networkStatus = signal(options?.skip ? NetworkStatus.ready : NetworkStatus.loading);
+  const data = signal<TResult | undefined>(initialState.data);
+  const error = signal<ApolloError | undefined>(initialState.error);
+  const loading = signal(initialState.loading);
+  const networkStatus = signal(initialState.networkStatus);
 
   // Update the signal values based on the result of the query
   const subscription = result$.subscribe((result) => {
@@ -129,6 +143,13 @@ export function query<TResult, TVariables extends OperationVariables>(
     error: error as Signal<ApolloError | undefined>,
     loading: loading as Signal<boolean>,
     networkStatus: networkStatus as Signal<NetworkStatus>,
+    reset: () => {
+      reset$.next();
+      data.set(initialState.data);
+      error.set(initialState.error);
+      loading.set(initialState.loading);
+      networkStatus.set(initialState.networkStatus);
+    },
     setOptions: (options: Partial<QueryOptions<TVariables>>) => {
       const result = firstValueFrom(result$.pipe(filter((result) => !result.loading)));
       options$.next({ ...options$.value, skip: false, ...options });
@@ -155,7 +176,8 @@ export function query<TResult, TVariables extends OperationVariables>(
           map(({ data }) => data),
           exists(), // The data should generally be available, but types says otherwise
           withLatestFrom(refReplay$), // Ensure the ref (and cache) is ready,
-          takeUntilDestroyed(destroyRef) // Stop the subscription when the component is destroyed
+          takeUntilDestroyed(destroyRef), // Stop the subscription when the component is destroyed
+          takeUntil(reset$) // Or when resetting the query
         )
         .subscribe({
           next([data, ref]) {

--- a/libs/dh/shared/util-apollo/src/lib/query.ts
+++ b/libs/dh/shared/util-apollo/src/lib/query.ts
@@ -72,7 +72,7 @@ export function query<TResult, TVariables extends OperationVariables>(
   const client = inject(Apollo);
   const destroyRef = inject(DestroyRef);
 
-  // Make it possible to reset query and subscriptions to their initial state
+  // Make it possible to reset query and subscriptions to a pending state
   const reset$ = new Subject<void>();
 
   // The `refetch` function on Apollo's `QueryRef` does not properly handle backpressure by


### PR DESCRIPTION
This PR makes it possible to reset queries and mutations to an initial, pending state, essentially clearing the result fields. This can come in handy if, for example, you are using `lazyQuery` to do some validations in combination with `computed`:

```ts
validation = lazyQuery(GetUserByEmailDocument);

userExists = computed(() => this.validation.data()?.user ? true : false);

resetForm() {
  // This will cause `userExists` to be `false` again
  this.validation.reset();
}

async validate(email: string) {
  await validation.query({ variables: { email }});
}
```