### PR TITLE
feat(api-docs): update dev portal link handling

### DIFF
--- a/libs/eo/api-documentation/shell/api-documentation.component.ts
+++ b/libs/eo/api-documentation/shell/api-documentation.component.ts
@@ -79,7 +79,7 @@ const selector = 'eo-api-documentation';
         <br />
 
         <watt-nav-list>
-          <watt-nav-list-item [link]="devPortalHref" target="_blank">
+          <watt-nav-list-item [link]="devPortalHref" (click)="gotoDevPortal($event)">
             <span class="icon-link">
               <watt-icon name="openInNew" />
               {{ translations.documentation.endpoints | transloco }}
@@ -105,4 +105,9 @@ export class EoApiDocumentationComponent {
   protected afterViewInit = signal<boolean>(false);
   protected devPortalHref: string = inject(eoApiEnvironmentToken).developerPortal;
   protected links = this.docs.map((doc) => ({ title: doc.title, src: '/' + this.activeLang + '/documentation/' + doc.id }));
+
+  gotoDevPortal(event: Event) {
+    event.preventDefault();
+    window.location.assign(this.devPortalHref);
+  }
 }


### PR DESCRIPTION
## Description
This commit updates the `api-documentation.component.ts` file to handle the dev portal link in a better way. It replaces the `target="_blank"` attribute with a click event listener that prevents the default behavior and instead opens the dev portal link in the current window. This change improves the user experience and ensures that the link is handled consistently across different browsers.

Note: This commit is based on recent user commits and repository commits.

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
