### PR TITLE
fix(dh): improvements to `query` function

### DIFF
--- a/libs/dh/shared/util-apollo/src/lib/query.spec.ts
+++ b/libs/dh/shared/util-apollo/src/lib/query.spec.ts
@@ -107,6 +107,27 @@ describe('query', () => {
       expect(result.networkStatus()).toBe(NetworkStatus.ready);
     })));
 
+  it('should start a new query on refetch after it has errored', fakeAsync(() =>
+    TestBed.runInInjectionContext(() => {
+      const result = query(TEST_QUERY);
+      const op = controller.expectOne(TEST_QUERY);
+      op.flush({ errors: [new GraphQLError('TestError')] });
+      tick();
+
+      expect(result.error()).toBeInstanceOf(ApolloError);
+      expect(result.loading()).toBe(false);
+
+      result.refetch();
+
+      const newOp = controller.expectOne(TEST_QUERY);
+      const data = { __type: { name: 'Success' } };
+      newOp.flush({ data });
+      tick();
+
+      expect(result.data()).toEqual(data);
+      expect(result.loading()).toBe(false);
+    })));
+
   it('should start a new query on setOptions', fakeAsync(() =>
     TestBed.runInInjectionContext(() => {
       const result = query(TEST_QUERY, { skip: true });

--- a/libs/dh/shared/util-apollo/src/lib/query.ts
+++ b/libs/dh/shared/util-apollo/src/lib/query.ts
@@ -104,8 +104,12 @@ export function query<TResult, TVariables extends OperationVariables>(
 
   const result$ = ref$.pipe(
     // The inner observable will be recreated each time the `options$` emits
-    switchMap((ref) => ref.valueChanges.pipe(takeUntil(reset$))),
-    catchError((error: ApolloError) => fromApolloError<TResult>(error))
+    switchMap((ref) =>
+      ref.valueChanges.pipe(
+        takeUntil(reset$),
+        catchError((error: ApolloError) => fromApolloError<TResult>(error))
+      )
+    )
   );
 
   // Signals holding the result values

--- a/libs/dh/shared/util-apollo/src/lib/query.ts
+++ b/libs/dh/shared/util-apollo/src/lib/query.ts
@@ -150,7 +150,12 @@ export function query<TResult, TVariables extends OperationVariables>(
     refetch: (variables?: Partial<TVariables>) => {
       const result = firstValueFrom(result$.pipe(filter((result) => !result.loading)));
       const mergedVariables = { ...options$.value?.variables, ...variables } as TVariables;
-      options$.next({ ...options$.value, skip: false, variables: mergedVariables });
+      options$.next({
+        ...options$.value,
+        skip: false,
+        variables: mergedVariables,
+        fetchPolicy: 'network-only',
+      });
       return result;
     },
     subscribeToMore<TSubscriptionData, TSubscriptionVariables>({


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### DataHub
- do not complete stream on error by moving `catchError` operator inside `valueChanges`
- add `fetchPolicy` on `refetch` method
- add test to verify behaviour. The test show that a query can be recovered from error state when calling `refetch`. The test DO NOT show that `loading` Signal is set to `true` after `refetch` is called because I couldn't figure out how to set the `query` in that state. However, this is what happens in the browser.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
