### PR TITLE
fix(watt): adjustments to modal component

### DIFF
--- a/libs/watt/src/lib/components/modal/watt-modal.component.scss
+++ b/libs/watt/src/lib/components/modal/watt-modal.component.scss
@@ -35,7 +35,7 @@
   padding: 0;
   align-items: center;
   grid-template-columns: 1fr auto;
-  grid-template-rows: 60px 1fr auto;
+  grid-template-rows: auto 1fr auto;
   grid-template-areas:
     "title close"
     "content content"
@@ -79,14 +79,14 @@
 
   .watt-modal-close {
     grid-area: close;
-    justify-self: end;
+    align-self: start;
     margin: var(--watt-space-s);
     color: var(--watt-color-primary);
   }
 
   .watt-modal-title {
     grid-area: title;
-    margin: 0 var(--watt-space-ml);
+    margin: var(--watt-space-s) var(--watt-space-ml);
     color: var(--watt-typography-text-color);
   }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

### Watt 
- add `margin` to title
- align close button
- set height of title and close button row to `auto`

These adjustments are needed to handle long `title` values.

Before

![image](https://github.com/user-attachments/assets/68fe00d7-c9a8-4f8f-90b2-2a90c48bc5e6)

After
![image](https://github.com/user-attachments/assets/cc97bda0-d013-4ade-9778-3eb2e30b7b61)


<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
