### PR TITLE
feat: Add cancel sceduled calculation Wholesale API

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
@@ -708,7 +708,7 @@ input CalculationQueryInput {
 }
 
 input CancelScheduledCalculationInput {
-  guid: UUID!
+  calculationId: UUID!
 }
 
 input CreateActorContactDtoInput {

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
@@ -1169,6 +1169,7 @@ enum ProgressStatus {
   pending
   executing
   failed
+  canceled
   completed
 }
 

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
@@ -977,6 +977,8 @@ enum CalculationOrchestrationState {
   ACTOR_MESSAGES_ENQUEUED
   ACTOR_MESSAGES_ENQUEUING_FAILED
   COMPLETED
+  CANCELED
+  STARTED
 }
 
 enum CalculationProgressStep {

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/Dto/CancelScheduledCalculationRequestDto.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/Dto/CancelScheduledCalculationRequestDto.cs
@@ -1,0 +1,21 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Energinet.DataHub.WebApi.Clients.Wholesale.Orchestrations.Dto;
+
+/// <summary>
+/// An immutable request to cancel a scheduled calculation.
+/// </summary>
+public sealed record CancelScheduledCalculationRequestDto(
+    Guid CalculationId);

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/IWholesaleOrchestrationsClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/IWholesaleOrchestrationsClient.cs
@@ -25,4 +25,9 @@ public interface IWholesaleOrchestrationsClient
     /// Start a calculation and return its id.
     /// </summary>
     public Task<Guid> StartCalculationAsync(StartCalculationRequestDto requestDto, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Cancel a scheduled calculation. Throws an exception if the calculation is already started.
+    /// </summary>
+    public Task CancelScheduledCalculationAsync(CancelScheduledCalculationRequestDto requestDto, CancellationToken cancellationToken);
 }

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/WholesaleOrchestrationsClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/WholesaleOrchestrationsClient.cs
@@ -52,4 +52,18 @@ public class WholesaleOrchestrationsClient : IWholesaleOrchestrationsClient
         var calculationId = await actualResponse.Content.ReadFromJsonAsync<Guid>(cancellationToken);
         return calculationId;
     }
+
+    public async Task CancelScheduledCalculationAsync(
+        CancelScheduledCalculationRequestDto requestDto,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "api/CancelScheduledCalculation");
+        request.Content = new StringContent(
+            JsonConvert.SerializeObject(requestDto),
+            Encoding.UTF8,
+            "application/json");
+
+        using var actualResponse = await HttpClient.SendAsync(request, cancellationToken);
+        actualResponse.EnsureSuccessStatusCode();
+    }
 }

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/V3/WholesaleClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/V3/WholesaleClient.cs
@@ -567,6 +567,12 @@ namespace Energinet.DataHub.WebApi.Clients.Wholesale.v3
         [System.Runtime.Serialization.EnumMember(Value = @"Completed")]
         Completed = 7,
 
+        [System.Runtime.Serialization.EnumMember(Value = @"Canceled")]
+        Canceled = 8,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"Started")]
+        Started = 9,
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.3.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/V3/swagger.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/V3/swagger.json
@@ -277,7 +277,9 @@
           "ActorMessagesEnqueuing",
           "ActorMessagesEnqueued",
           "ActorMessagesEnqueuingFailed",
-          "Completed"
+          "Completed",
+          "Canceled",
+          "Started"
         ]
       },
       "CalculationState": {

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/ProgressStatus.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/ProgressStatus.cs
@@ -19,5 +19,6 @@ public enum ProgressStatus
     Pending,
     Executing,
     Failed,
+    Canceled,
     Completed,
 }

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/CalculationMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/CalculationMutation.cs
@@ -50,8 +50,15 @@ public partial class Mutation
         return calculationId;
     }
 
-    public async Task<bool> CancelScheduledCalculationAsync(Guid guid)
+    public async Task<bool> CancelScheduledCalculationAsync(
+        Guid calculationId,
+        [Service] IWholesaleOrchestrationsClient client,
+        CancellationToken cancellationToken)
     {
-        return await Task.FromResult(true);
+        var requestDto = new CancelScheduledCalculationRequestDto(calculationId);
+
+        await client.CancelScheduledCalculationAsync(requestDto, cancellationToken);
+
+        return true;
     }
 }

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Subscription/CalculationSubscription.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Subscription/CalculationSubscription.cs
@@ -63,6 +63,7 @@ public class Subscription
         state switch
         {
             CalculationOrchestrationState.Scheduled => true,
+            CalculationOrchestrationState.Canceled => false,
             CalculationOrchestrationState.Started => true,
             CalculationOrchestrationState.Calculating => true,
             CalculationOrchestrationState.CalculationFailed => false,
@@ -71,6 +72,5 @@ public class Subscription
             CalculationOrchestrationState.ActorMessagesEnqueuingFailed => false,
             CalculationOrchestrationState.ActorMessagesEnqueued => false,
             CalculationOrchestrationState.Completed => false,
-            CalculationOrchestrationState.Canceled => false,
         };
 }

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Subscription/CalculationSubscription.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Subscription/CalculationSubscription.cs
@@ -63,6 +63,7 @@ public class Subscription
         state switch
         {
             CalculationOrchestrationState.Scheduled => true,
+            CalculationOrchestrationState.Started => true,
             CalculationOrchestrationState.Calculating => true,
             CalculationOrchestrationState.CalculationFailed => false,
             CalculationOrchestrationState.Calculated => true,
@@ -70,5 +71,6 @@ public class Subscription
             CalculationOrchestrationState.ActorMessagesEnqueuingFailed => false,
             CalculationOrchestrationState.ActorMessagesEnqueued => false,
             CalculationOrchestrationState.Completed => false,
+            CalculationOrchestrationState.Canceled => false,
         };
 }

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationType.cs
@@ -68,6 +68,7 @@ public class CalculationType : ObjectType<CalculationDto>
             .Resolve(context => context.Parent<CalculationDto>().OrchestrationState switch
             {
                 CalculationOrchestrationState.Scheduled => ProcessStatus.Neutral,
+                CalculationOrchestrationState.Canceled => ProcessStatus.Neutral,
                 CalculationOrchestrationState.Started => ProcessStatus.Info,
                 CalculationOrchestrationState.Calculating => ProcessStatus.Info,
                 CalculationOrchestrationState.CalculationFailed => ProcessStatus.Danger,
@@ -76,7 +77,6 @@ public class CalculationType : ObjectType<CalculationDto>
                 CalculationOrchestrationState.ActorMessagesEnqueuingFailed => ProcessStatus.Danger,
                 CalculationOrchestrationState.ActorMessagesEnqueued => ProcessStatus.Info,
                 CalculationOrchestrationState.Completed => ProcessStatus.Success,
-                CalculationOrchestrationState.Canceled => ProcessStatus.Neutral,
             });
 
         descriptor

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationType.cs
@@ -76,7 +76,7 @@ public class CalculationType : ObjectType<CalculationDto>
                 CalculationOrchestrationState.ActorMessagesEnqueuingFailed => ProcessStatus.Danger,
                 CalculationOrchestrationState.ActorMessagesEnqueued => ProcessStatus.Info,
                 CalculationOrchestrationState.Completed => ProcessStatus.Success,
-                CalculationOrchestrationState.Canceled => ProcessStatus.Warning,
+                CalculationOrchestrationState.Canceled => ProcessStatus.Neutral,
             });
 
         descriptor
@@ -119,6 +119,7 @@ public class CalculationType : ObjectType<CalculationDto>
         state switch
         {
             CalculationOrchestrationState.Scheduled => CalculationProgressStep.Schedule,
+            CalculationOrchestrationState.Canceled => CalculationProgressStep.Schedule,
             CalculationOrchestrationState.Started => CalculationProgressStep.Calculate,
             CalculationOrchestrationState.Calculating => CalculationProgressStep.Calculate,
             CalculationOrchestrationState.CalculationFailed => CalculationProgressStep.Calculate,
@@ -127,7 +128,6 @@ public class CalculationType : ObjectType<CalculationDto>
             CalculationOrchestrationState.ActorMessagesEnqueuingFailed => CalculationProgressStep.ActorMessageEnqueue,
             CalculationOrchestrationState.ActorMessagesEnqueued => CalculationProgressStep.ActorMessageEnqueue,
             CalculationOrchestrationState.Completed => CalculationProgressStep.ActorMessageEnqueue,
-            CalculationOrchestrationState.Canceled => CalculationProgressStep.Schedule,
         };
 
     /// <summary>
@@ -139,6 +139,7 @@ public class CalculationType : ObjectType<CalculationDto>
         state switch
         {
             CalculationOrchestrationState.Scheduled => ProgressStatus.Pending,
+            CalculationOrchestrationState.Canceled => ProgressStatus.Canceled,
             CalculationOrchestrationState.Started => ProgressStatus.Completed,
             CalculationOrchestrationState.Calculating => ProgressStatus.Completed,
             CalculationOrchestrationState.CalculationFailed => ProgressStatus.Completed,
@@ -147,7 +148,6 @@ public class CalculationType : ObjectType<CalculationDto>
             CalculationOrchestrationState.ActorMessagesEnqueuingFailed => ProgressStatus.Completed,
             CalculationOrchestrationState.ActorMessagesEnqueued => ProgressStatus.Completed,
             CalculationOrchestrationState.Completed => ProgressStatus.Completed,
-            CalculationOrchestrationState.Canceled => ProgressStatus.Failed, // TODO: Is this correct?
         };
 
     /// <summary>
@@ -159,6 +159,7 @@ public class CalculationType : ObjectType<CalculationDto>
         state switch
         {
             CalculationOrchestrationState.Scheduled => ProgressStatus.Pending,
+            CalculationOrchestrationState.Canceled => ProgressStatus.Pending,
             CalculationOrchestrationState.Started => ProgressStatus.Executing,
             CalculationOrchestrationState.Calculating => ProgressStatus.Executing,
             CalculationOrchestrationState.CalculationFailed => ProgressStatus.Failed,
@@ -167,7 +168,6 @@ public class CalculationType : ObjectType<CalculationDto>
             CalculationOrchestrationState.ActorMessagesEnqueuingFailed => ProgressStatus.Completed,
             CalculationOrchestrationState.ActorMessagesEnqueued => ProgressStatus.Completed,
             CalculationOrchestrationState.Completed => ProgressStatus.Completed,
-            CalculationOrchestrationState.Canceled => ProgressStatus.Pending,
         };
 
     /// <summary>
@@ -179,6 +179,7 @@ public class CalculationType : ObjectType<CalculationDto>
         state switch
         {
             CalculationOrchestrationState.Scheduled => ProgressStatus.Pending,
+            CalculationOrchestrationState.Canceled => ProgressStatus.Pending,
             CalculationOrchestrationState.Started => ProgressStatus.Pending,
             CalculationOrchestrationState.Calculating => ProgressStatus.Pending,
             CalculationOrchestrationState.CalculationFailed => ProgressStatus.Pending,
@@ -187,6 +188,5 @@ public class CalculationType : ObjectType<CalculationDto>
             CalculationOrchestrationState.ActorMessagesEnqueuingFailed => ProgressStatus.Failed,
             CalculationOrchestrationState.ActorMessagesEnqueued => ProgressStatus.Completed,
             CalculationOrchestrationState.Completed => ProgressStatus.Completed,
-            CalculationOrchestrationState.Canceled => ProgressStatus.Pending,
         };
 }

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationType.cs
@@ -68,6 +68,7 @@ public class CalculationType : ObjectType<CalculationDto>
             .Resolve(context => context.Parent<CalculationDto>().OrchestrationState switch
             {
                 CalculationOrchestrationState.Scheduled => ProcessStatus.Neutral,
+                CalculationOrchestrationState.Started => ProcessStatus.Info,
                 CalculationOrchestrationState.Calculating => ProcessStatus.Info,
                 CalculationOrchestrationState.CalculationFailed => ProcessStatus.Danger,
                 CalculationOrchestrationState.Calculated => ProcessStatus.Info,
@@ -75,6 +76,7 @@ public class CalculationType : ObjectType<CalculationDto>
                 CalculationOrchestrationState.ActorMessagesEnqueuingFailed => ProcessStatus.Danger,
                 CalculationOrchestrationState.ActorMessagesEnqueued => ProcessStatus.Info,
                 CalculationOrchestrationState.Completed => ProcessStatus.Success,
+                CalculationOrchestrationState.Canceled => ProcessStatus.Warning,
             });
 
         descriptor
@@ -117,6 +119,7 @@ public class CalculationType : ObjectType<CalculationDto>
         state switch
         {
             CalculationOrchestrationState.Scheduled => CalculationProgressStep.Schedule,
+            CalculationOrchestrationState.Started => CalculationProgressStep.Calculate,
             CalculationOrchestrationState.Calculating => CalculationProgressStep.Calculate,
             CalculationOrchestrationState.CalculationFailed => CalculationProgressStep.Calculate,
             CalculationOrchestrationState.Calculated => CalculationProgressStep.Calculate,
@@ -124,6 +127,7 @@ public class CalculationType : ObjectType<CalculationDto>
             CalculationOrchestrationState.ActorMessagesEnqueuingFailed => CalculationProgressStep.ActorMessageEnqueue,
             CalculationOrchestrationState.ActorMessagesEnqueued => CalculationProgressStep.ActorMessageEnqueue,
             CalculationOrchestrationState.Completed => CalculationProgressStep.ActorMessageEnqueue,
+            CalculationOrchestrationState.Canceled => CalculationProgressStep.Schedule,
         };
 
     /// <summary>
@@ -135,6 +139,7 @@ public class CalculationType : ObjectType<CalculationDto>
         state switch
         {
             CalculationOrchestrationState.Scheduled => ProgressStatus.Pending,
+            CalculationOrchestrationState.Started => ProgressStatus.Completed,
             CalculationOrchestrationState.Calculating => ProgressStatus.Completed,
             CalculationOrchestrationState.CalculationFailed => ProgressStatus.Completed,
             CalculationOrchestrationState.Calculated => ProgressStatus.Completed,
@@ -142,6 +147,7 @@ public class CalculationType : ObjectType<CalculationDto>
             CalculationOrchestrationState.ActorMessagesEnqueuingFailed => ProgressStatus.Completed,
             CalculationOrchestrationState.ActorMessagesEnqueued => ProgressStatus.Completed,
             CalculationOrchestrationState.Completed => ProgressStatus.Completed,
+            CalculationOrchestrationState.Canceled => ProgressStatus.Failed, // TODO: Is this correct?
         };
 
     /// <summary>
@@ -153,6 +159,7 @@ public class CalculationType : ObjectType<CalculationDto>
         state switch
         {
             CalculationOrchestrationState.Scheduled => ProgressStatus.Pending,
+            CalculationOrchestrationState.Started => ProgressStatus.Executing,
             CalculationOrchestrationState.Calculating => ProgressStatus.Executing,
             CalculationOrchestrationState.CalculationFailed => ProgressStatus.Failed,
             CalculationOrchestrationState.Calculated => ProgressStatus.Completed,
@@ -160,6 +167,7 @@ public class CalculationType : ObjectType<CalculationDto>
             CalculationOrchestrationState.ActorMessagesEnqueuingFailed => ProgressStatus.Completed,
             CalculationOrchestrationState.ActorMessagesEnqueued => ProgressStatus.Completed,
             CalculationOrchestrationState.Completed => ProgressStatus.Completed,
+            CalculationOrchestrationState.Canceled => ProgressStatus.Pending,
         };
 
     /// <summary>
@@ -171,6 +179,7 @@ public class CalculationType : ObjectType<CalculationDto>
         state switch
         {
             CalculationOrchestrationState.Scheduled => ProgressStatus.Pending,
+            CalculationOrchestrationState.Started => ProgressStatus.Pending,
             CalculationOrchestrationState.Calculating => ProgressStatus.Pending,
             CalculationOrchestrationState.CalculationFailed => ProgressStatus.Pending,
             CalculationOrchestrationState.Calculated => ProgressStatus.Pending,
@@ -178,5 +187,6 @@ public class CalculationType : ObjectType<CalculationDto>
             CalculationOrchestrationState.ActorMessagesEnqueuingFailed => ProgressStatus.Failed,
             CalculationOrchestrationState.ActorMessagesEnqueued => ProgressStatus.Completed,
             CalculationOrchestrationState.Completed => ProgressStatus.Completed,
+            CalculationOrchestrationState.Canceled => ProgressStatus.Pending,
         };
 }

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -945,13 +945,15 @@
       },
       "states": {
         "SCHEDULED": "Planlagt",
+        "STARTED": "Startet",
         "CALCULATING": "Beregner...",
         "CALCULATION_FAILED": "Beregning fejlet",
         "CALCULATED": "Beregnet",
         "ACTOR_MESSAGES_ENQUEUING": "Danner beskeder...",
         "ACTOR_MESSAGES_ENQUEUING_FAILED": "Beskeddannelse fejlet",
         "ACTOR_MESSAGES_ENQUEUED": "Beskeder dannet",
-        "COMPLETED": "Beskeder dannet"
+        "COMPLETED": "Beskeder dannet",
+        "CANCELED": "Annulleret"
       },
       "executionTypes": {
         "EXTERNAL": "Ekstern",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -946,13 +946,15 @@
       },
       "states": {
         "SCHEDULED": "Scheduled",
+        "STARTED": "Started",
         "CALCULATING": "Calculating...",
         "CALCULATION_FAILED": "Calculation failed",
         "CALCULATED": "Calculated",
         "ACTOR_MESSAGES_ENQUEUING": "Enqueuing messages...",
         "ACTOR_MESSAGES_ENQUEUING_FAILED": "Enqueuing messages failed",
         "ACTOR_MESSAGES_ENQUEUED": "Messages enqueued",
-        "COMPLETED": "Messages enqueued"
+        "COMPLETED": "Messages enqueued",
+        "CANCELED": "Canceled"
       },
       "executionTypes": {
         "EXTERNAL": "External",

--- a/libs/dh/wholesale/feature-calculations/src/lib/details/details.component.ts
+++ b/libs/dh/wholesale/feature-calculations/src/lib/details/details.component.ts
@@ -115,14 +115,14 @@ export class DhCalculationsDetailsComponent {
   });
 
   cancelModalClosed = (shouldCancel: boolean) => {
-    const guid = this.id();
-    if (shouldCancel && guid) {
+    const calculationId = this.id();
+    if (shouldCancel && calculationId) {
       this.toast.open({
         type: 'loading',
         message: this.transloco.translate('wholesale.calculations.details.toast.loading'),
       });
 
-      this.cancelCalculation.mutate({ variables: { input: { guid } } });
+      this.cancelCalculation.mutate({ variables: { input: { calculationId } } });
     }
   };
 

--- a/libs/watt/src/lib/components/progress-tracker/watt-progress-tracker-step.component.scss
+++ b/libs/watt/src/lib/components/progress-tracker/watt-progress-tracker-step.component.scss
@@ -34,6 +34,12 @@
   --watt-progress-tracker-step-fill-color: var(--watt-color-primary);
 }
 
+.watt-progress-tracker-step-canceled {
+  --watt-progress-tracker-step-text-color: var(--watt-color-neutral-grey-600);
+  --watt-progress-tracker-step-bridge-color: var(--watt-color-neutral-grey-600);
+  --watt-progress-tracker-step-fill-color: var(--watt-color-neutral-grey-600);
+}
+
 .watt-progress-tracker-step-failed {
   --watt-progress-tracker-step-text-color: var(--watt-color-state-danger);
   --watt-progress-tracker-step-bridge-color: var(--watt-color-state-danger);

--- a/libs/watt/src/lib/components/progress-tracker/watt-progress-tracker-step.component.ts
+++ b/libs/watt/src/lib/components/progress-tracker/watt-progress-tracker-step.component.ts
@@ -46,8 +46,11 @@ import { WattSpinnerComponent } from '../spinner/watt-spinner.component';
         @case ('completed') {
           <watt-icon name="checkmark" size="xs" />
         }
-        @case ('failed') {
+        @case ('canceled') {
           <watt-icon name="close" size="xs" />
+        }
+        @case ('failed') {
+          <watt-icon name="priorityHigh" size="xs" />
         }
       }
     </div>
@@ -55,7 +58,7 @@ import { WattSpinnerComponent } from '../spinner/watt-spinner.component';
   `,
 })
 export class WattProgressTrackerStepComponent {
-  status = input.required<'pending' | 'executing' | 'completed' | 'failed'>();
+  status = input.required<'pending' | 'executing' | 'completed' | 'canceled' | 'failed'>();
   label = input<string>();
   current = input(false);
   ariaCurrent = computed(() => (this.current() ? 'step' : false));

--- a/libs/watt/src/lib/foundations/icon/icons.ts
+++ b/libs/watt/src/lib/foundations/icon/icons.ts
@@ -77,6 +77,7 @@ const materialIcons = {
   smartDisplay: 'smart_display',
   windmill: 'energy',
   solarPower: 'solar_power',
+  priorityHigh: 'priority_high',
 };
 
 /**


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

- Add cancel sceduled calculation Wholesale API
- Call new Wholesale API in calculation mutation
  - This updates mutation input name from `guid` to `calculationId`
- Update Wholesale API client with new orchestration states
  - The frontend might need to be updated to use these states:
    - `Started` should be shown as calculating
    - `Canceled` should be shown as canceled

Requires merged Wholesale PR's:
- [x] https://github.com/Energinet-DataHub/opengeh-wholesale/pull/2697
- [x] https://github.com/Energinet-DataHub/opengeh-wholesale/pull/2686

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/210
