### PR TITLE
fix(dh): make feature flags fail again

### DIFF
--- a/libs/dh/shared/feature-flags/src/lib/dh-feature-flags.spec.ts
+++ b/libs/dh/shared/feature-flags/src/lib/dh-feature-flags.spec.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import { dayjs } from '@energinet-datahub/watt/date';
+
 import { DhFeatureFlag, DhFeatureFlags, dhFeatureFlagsConfig } from './dh-feature-flags';
 
 const maxAgeOfDays = 62;
@@ -22,7 +23,7 @@ const maxAgeOfDays = 62;
 const featureFlagCases = Object.keys(dhFeatureFlagsConfig).map((featureFlag) => {
   const created = (dhFeatureFlagsConfig[featureFlag as DhFeatureFlags] as DhFeatureFlag).created;
   const parsedDate = dayjs(created, 'DD-MM-YYYY');
-  const diffInDays = parsedDate.diff(new Date(), 'days');
+  const diffInDays = dayjs(new Date()).diff(parsedDate, 'days');
 
   return [featureFlag, diffInDays];
 });

--- a/libs/dh/shared/feature-flags/src/lib/dh-feature-flags.ts
+++ b/libs/dh/shared/feature-flags/src/lib/dh-feature-flags.ts
@@ -23,7 +23,7 @@ export type DhFeatureFlag = {
 
 export type FeatureFlagConfig = Record<string, DhFeatureFlag>;
 
-const latestBump = '20-06-2024';
+const latestBump = '26-08-2024';
 
 /**
  * Feature flag example:


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### DataHub

Feature flags tests didn't fail because the difference between `parsedDate` and `new Date()` gave a negative number, which always satisfied the assertion. This PR fixes that.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
