### PR TITLE
chore: upgarde Bun to latest

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -34,7 +34,7 @@ on:
 
 env:
   # keep in sync with "engines.bun" and "volta.bun" in "package.json"
-  BUN_VERSION: 1.1.13
+  BUN_VERSION: 1.1.26
 
 jobs:
   changes:

--- a/.github/workflows/dh-ci-frontend.yml
+++ b/.github/workflows/dh-ci-frontend.yml
@@ -23,7 +23,7 @@ env:
   IS_MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' }}
   IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
   # keep in sync with "engines.bun" and "volta.bun" in "package.json"
-  BUN_VERSION: 1.1.13
+  BUN_VERSION: 1.1.26
 
 jobs:
   #

--- a/.github/workflows/dh-healthchecks.yml
+++ b/.github/workflows/dh-healthchecks.yml
@@ -14,7 +14,7 @@
 name: DH UI Frontend Healthchecks
 env:
   # keep in sync with "engines.bun" and "volta.bun" in "package.json"
-  BUN_VERSION: 1.1.13
+  BUN_VERSION: 1.1.26
   # See https://github.com/cypress-io/cypress/issues/25357
   ELECTRON_EXTRA_LAUNCH_ARGS: --disable-gpu
 on:

--- a/.github/workflows/eo-cd.yml
+++ b/.github/workflows/eo-cd.yml
@@ -24,7 +24,7 @@ env:
   is-main-branch: ${{ github.ref == 'refs/heads/main' }}
   is-pull-request: ${{ github.event_name == 'pull_request' }}
   # keep in sync with "engines.bun" and "volta.bun" in "package.json"
-  BUN_VERSION: 1.1.13
+  BUN_VERSION: 1.1.26
 
   # Nx Cloud
   NX_BRANCH: ${{ github.event.number }}

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -22,7 +22,7 @@ env:
   is-main-branch: ${{ github.ref == 'refs/heads/main' }}
   is-pull-request: ${{ github.event_name == 'pull_request' }}
   # keep in sync with "engines.bun" and "volta.bun" in "package.json"
-  BUN_VERSION: 1.1.13
+  BUN_VERSION: 1.1.26
 
   # Nx Cloud
   NX_BRANCH: ${{ github.event.number }}

--- a/.github/workflows/license-check-ci.yml
+++ b/.github/workflows/license-check-ci.yml
@@ -22,7 +22,7 @@ env:
   is-main-branch: ${{ github.ref == 'refs/heads/main' }}
   is-pull-request: ${{ github.event_name == 'pull_request' }}
   # keep in sync with "engines.bun" and "volta.bun" in "package.json"
-  BUN_VERSION: 1.1.13
+  BUN_VERSION: 1.1.26
 
   # Nx Cloud
   NX_BRANCH: ${{ github.event.number }}

--- a/.github/workflows/production-dependencies-license-check.yml
+++ b/.github/workflows/production-dependencies-license-check.yml
@@ -6,7 +6,7 @@ concurrency:
 
 env:
   # keep in sync with "engines.bun" and "volta.bun" in "package.json"
-  BUN_VERSION: 1.1.13
+  BUN_VERSION: 1.1.26
 
 on:
   pull_request:

--- a/.github/workflows/watt-cd.yml
+++ b/.github/workflows/watt-cd.yml
@@ -17,7 +17,7 @@ name: Watt CD
 
 env:
   # keep in sync with "engines.bun" and "volta.bun" in "package.json"
-  BUN_VERSION: 1.1.13
+  BUN_VERSION: 1.1.26
 
 on:
   push:

--- a/.github/workflows/watt-ci.yml
+++ b/.github/workflows/watt-ci.yml
@@ -21,7 +21,7 @@ on:
 env:
   APP_NAME: designsystem
   # keep in sync with "engines.bun" and "volta.bun" in "package.json"
-  BUN_VERSION: 1.1.13
+  BUN_VERSION: 1.1.26
 
 jobs:
   #

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": "20.11.0",
     "npm": "Please use Bun instead of npm to install dependencies.",
     "yarn": "Please use Bun instead of yarn to install dependencies.",
-    "bun": "1.1.13"
+    "bun": "1.1.26"
   },
   "scripts": {
     "postinstall": "bun husky install",
@@ -223,9 +223,9 @@
     "//node-comment": "Keep this in sync with 'engines' config at the top of the current file",
     "node": "20.11.0",
     "//bun-comment": "Keep this in sync with GitHub actions pipelines",
-    "bun": "1.1.13"
+    "bun": "1.1.26"
   },
-  "packageManager": "bun@1.1.13",
+  "packageManager": "bun@1.1.26",
   "msw": {
     "workerDirectory": "libs/gf/msw/util-msw/src/assets"
   }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### Workspace
- upgrade Bun to v1.1.26

**Note**: Doesn't look like Volta automatically upgrades to this new version, so after merge you should run `bun upgrade`.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
