### PR TITLE
feat(dh): set merge type policy for Organization type

### DIFF
--- a/libs/dh/admin/feature-user-management/src/lib/invite/dh-invite-user-modal.component.ts
+++ b/libs/dh/admin/feature-user-management/src/lib/invite/dh-invite-user-modal.component.ts
@@ -118,6 +118,7 @@ export class DhInviteUserModalComponent extends WattTypedModal {
   inOrganizationMailDomain = computed(() => {
     const email = this.emailChanged();
     const domain = this.domain();
+
     return !!email && !!domain && email.toUpperCase().endsWith(domain.toUpperCase());
   });
 

--- a/libs/dh/admin/feature-user-management/src/lib/invite/dh-invite-user-modal.component.ts
+++ b/libs/dh/admin/feature-user-management/src/lib/invite/dh-invite-user-modal.component.ts
@@ -283,7 +283,7 @@ export class DhInviteUserModalComponent extends WattTypedModal {
   }
 
   private isNewUserInfoValid() {
-    return this.userInfo.valid || this.emailExists || !this.inOrganizationMailDomain;
+    return this.userInfo.valid || this.emailExists() || !this.inOrganizationMailDomain();
   }
 
   private isRolesInfoValid() {

--- a/libs/dh/shared/data-access-graphql/src/lib/dh-graphql.providers.ts
+++ b/libs/dh/shared/data-access-graphql/src/lib/dh-graphql.providers.ts
@@ -75,6 +75,9 @@ export const graphQLProviders = makeEnvironmentProviders([
         cache: new InMemoryCache({
           typePolicies: {
             ...scalarTypePolicies,
+            Organization: {
+              merge: true,
+            },
             MessageDelegationType: {
               keyFields: ['id', 'periodId'],
             },


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
### DataHub
The `Organization` type policy fixes an issue with user invitation where after taking some user actions in a specific order, the `Organization` object resulted in a missing property because of how GraphQL merged two queries containing the `Organization` property.

The user actions are:
1. Navigate to users overview
2. Start the user invite flow
3. Select an actor from the dropdown (not DataHub)
4. Input an email that does NOT exist as part of the actor (it must match with the actor's domain)
5. Verify that the "Information" tab is shown
6. Leave the user invite flow
7. Click on a user that is already invited to the actor selected in step 3
8. Close the user details drawer
9. Start the invite flow 
10. Select the same actor from step 3
11. Input the same non-existing email from step 4
12. Verify that the "Information" tab is NOT shown

The reason for this was that two queries containing the "Organization" object were executed during those steps. In the first one (step 3), the "Organization" had a `domain` property among others, whereas in the second one (step 7), the "Organization" did NOT have the `domain` property.

Before the changes in this PR, the `domain` property was overwritten with the data from the "Organization" property in the second query.

Now, GraphQL should merge the "Organization" properties.
 
## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
