### PR TITLE
feat(watt): adjust color in sidenav

### DIFF
--- a/libs/watt/src/lib/components/shell/nav-list/watt-nav-list.component.scss
+++ b/libs/watt/src/lib/components/shell/nav-list/watt-nav-list.component.scss
@@ -17,10 +17,11 @@
 @use "@energinet-datahub/watt/utils" as watt;
 
 watt-nav-list {
-  background-color: var(--watt-color-primary-dark);
+  background-color: var(--watt-sidenav-background-color);
 
   watt-nav-list-item {
     display: block;
+
     a {
       @include watt.space-inset-squish-m;
       display: block;
@@ -31,7 +32,7 @@ watt-nav-list {
 
     a:hover,
     a.active {
-      background-color: var(--watt-color-primary);
+      background-color: var(--watt-nav-list-hover-background-color);
     }
 
     a.active {
@@ -41,14 +42,14 @@ watt-nav-list {
 
   &.watt-nav-list--expandable {
     .mat-expansion-panel {
-      background-color: var(--watt-color-primary-dark);
+      background-color: var(--watt-sidenav-background-color);
       border-radius: 0;
     }
 
     .mat-expansion-panel-header.mat-expanded:hover,
     .mat-expansion-panel:not(.mat-expanded)
       .mat-expansion-panel-header:hover:not([aria-disabled="true"]) {
-      background-color: var(--watt-color-primary);
+      background-color: var(--watt-nav-list-hover-background-color);
     }
 
     .mat-expansion-panel-header {

--- a/libs/watt/src/lib/components/shell/shell.component.scss
+++ b/libs/watt/src/lib/components/shell/shell.component.scss
@@ -36,7 +36,7 @@
 
 .watt-sidenav {
   width: 245px;
-  background-color: var(--watt-color-primary-dark);
+  background-color: var(--watt-sidenav-background-color);
 
   @include watt.media("<Large") {
     width: calc(245px + 44px); // Added closing button width

--- a/libs/watt/src/lib/foundations/_variables.scss
+++ b/libs/watt/src/lib/foundations/_variables.scss
@@ -108,4 +108,8 @@
   --watt-toolbar-z-index-when-drawer-is-closed: 2;
 
   --watt-toolbar-z-index: var(--watt-toolbar-z-index-when-drawer-is-closed);
+
+  // Components
+  --watt-sidenav-background-color: #09505d;
+  --watt-nav-list-hover-background-color: #07404a;
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### Watt
- update color for sidenav and nav list item `active`/`hover` state

After / Before in DH and ET&T apps 👇

![image](https://github.com/user-attachments/assets/7e32ebc4-d8b5-42b3-a9e9-78b3ddb5240f)

![image](https://github.com/user-attachments/assets/dd29c9be-1571-4ee6-b4cc-9804698ce586)



<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
