### PR TITLE
chore(dh): remove create-calculation-minimum-date feature flag

### DIFF
--- a/libs/dh/shared/feature-flags/src/lib/dh-feature-flags.ts
+++ b/libs/dh/shared/feature-flags/src/lib/dh-feature-flags.ts
@@ -42,16 +42,6 @@ export const dhFeatureFlagsConfig = {
     created: latestBump,
     disabledEnvironments: [DhAppEnvironment.preprod, DhAppEnvironment.prod],
   },
-  // This should be removed when there is no longer a need to create calculations
-  // in closed periods OR as soon as possible after go-live
-  'create-calculation-minimum-date': {
-    created: '28-07-2024', // Intentionally not using latest bump, so it expires after go-live
-    disabledEnvironments: [
-      DhAppEnvironment.test_001,
-      DhAppEnvironment.preprod,
-      DhAppEnvironment.prod,
-    ],
-  },
   // This feature flag should be removed in favor of injected environment variables
   // from terraform, whenever the new web application setup is ready (outlaws).
   'quarterly-resolution-transition-datetime-override': {

--- a/libs/dh/wholesale/feature-calculations/src/lib/create/create.component.ts
+++ b/libs/dh/wholesale/feature-calculations/src/lib/create/create.component.ts
@@ -171,10 +171,7 @@ export class DhCalculationsCreateComponent {
   minScheduledAt = new Date();
   scheduledAt = toSignal(this.formGroup.controls.scheduledAt.valueChanges);
 
-  minDate = this.ffs.isEnabled('create-calculation-minimum-date')
-    ? getMinDate()
-    : new Date('2021-02-01'); // Temporary minimum date for certain environments
-
+  minDate = getMinDate();
   maxDate = computed(() =>
     dayjs(this.scheduledAt() ?? new Date())
       .subtract(1, 'day')


### PR DESCRIPTION
## Description

Per agreement, it should no longer be possible to create new calculations with a period starting more than 38 months ago.
