### PR TITLE
Revert change to watt-filter-chip

### DIFF
--- a/libs/watt/src/lib/components/chip/watt-filter-chip.component.ts
+++ b/libs/watt/src/lib/components/chip/watt-filter-chip.component.ts
@@ -50,7 +50,8 @@ export class WattFilterChipComponent<T = string> {
   isFirstRender = useIsFirstRender();
 
   onChange(input: HTMLInputElement): void {
-    const value = this.choice ? input.value : input.checked;
-    this.selectionChange.emit(value as T);
+    // TODO: Reverted because of issue, fix later
+    // const value = this.choice ? input.value : input.checked;
+    this.selectionChange.emit(input.value as T);
   }
 }


### PR DESCRIPTION
This PR fixes a bug with filter chip, causing errors with create calculation. I'm reverting the change for now, although that means breaking a small thing in message-archive-v2. But since that is still behind a feature flag (and it is a minor thing), I think that's okay. 