### PR TITLE
feat(print): add print styles to hide header and footer, adjust terms component

### DIFF
--- a/libs/eo/auth/feature-terms/terms.component.ts
+++ b/libs/eo/auth/feature-terms/terms.component.ts
@@ -68,6 +68,11 @@ const selector = 'eo-auth-terms';
         min-height: 100vh;
         margin: 0;
 
+        @media print {
+          --eo-scroll-view-padding: 0;
+          --eo-scroll-view-max-height: fit-content;
+        }
+
         eo-header {
           grid-area: header;
         }

--- a/libs/eo/shared/components/ui-footer/footer.component.ts
+++ b/libs/eo/shared/components/ui-footer/footer.component.ts
@@ -35,6 +35,10 @@ const selector = 'eo-footer';
       display: block;
       width: 100%;
 
+      @media print {
+        display: none;
+      }
+
       footer {
         background-color: #102427;
         background-image: url('/assets/landing-page/footer-bg@small.svg');

--- a/libs/eo/shared/components/ui-header/eo-header.component.ts
+++ b/libs/eo/shared/components/ui-header/eo-header.component.ts
@@ -25,6 +25,12 @@ import { EoProductLogoDirective } from '@energinet-datahub/eo/shared/components/
   selector: 'eo-header',
   styles: [
     `
+      :host {
+        @media print {
+          display: none;
+        }
+      }
+
       .toolbar {
         display: flex;
         justify-content: space-between;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This pull request focuses on improving the print layout for various components in the `eo` library by adding media queries to handle print-specific styles. The most important changes include hiding certain components when printing and adjusting the layout for better print compatibility.

Print layout improvements:

* [`libs/eo/auth/feature-terms/terms.component.ts`](diffhunk://#diff-2a6fe44dd8575c03e149dea6ec78cfe5a0316662b24672ac4363fe348a97ff2cR71-R75): Added print-specific styles to adjust padding and max-height for the `eo-auth-terms` component.
* [`libs/eo/shared/components/ui-footer/footer.component.ts`](diffhunk://#diff-aedbd5ba03f536f1fc6b66ea9ee80f8d2d0974ae43fc3f94c32e04363ea0dd53R38-R41): Added a media query to hide the `eo-footer` component when printing.
* [`libs/eo/shared/components/ui-header/eo-header.component.ts`](diffhunk://#diff-974825d16f436baacd93a4120c997c772327c2a2fd2700cff0980407466a6ad3R28-R33): Added a media query to hide the `eo-header` component when printing.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
