### PR TITLE
ETT: enhance TOS acceptance flow and add error handling

### DIFF
--- a/libs/eo/auth/data-access/auth.interceptor.ts
+++ b/libs/eo/auth/data-access/auth.interceptor.ts
@@ -39,7 +39,7 @@ export class EoAuthorizationInterceptor implements HttpInterceptor {
   private transloco: TranslocoService = inject(TranslocoService);
 
   private tokenRefreshCalls = ['PUT', 'POST', 'DELETE'];
-  private ignoreTokenRefreshUrls = ['/api/auth/token', '/api/authorization/consent/grant'];
+  private ignoreTokenRefreshUrls = ['/api/auth/token', '/api/authorization/consent/grant', '/api/authorization/terms/accept'];
   private apiBaseUrls = [this.apiBase, this.apiBase.replace('/api', '/wallet-api')];
 
   intercept(req: HttpRequest<unknown>, handler: HttpHandler) {

--- a/libs/eo/auth/data-access/auth.interceptor.ts
+++ b/libs/eo/auth/data-access/auth.interceptor.ts
@@ -39,7 +39,11 @@ export class EoAuthorizationInterceptor implements HttpInterceptor {
   private transloco: TranslocoService = inject(TranslocoService);
 
   private tokenRefreshCalls = ['PUT', 'POST', 'DELETE'];
-  private ignoreTokenRefreshUrls = ['/api/auth/token', '/api/authorization/consent/grant', '/api/authorization/terms/accept'];
+  private ignoreTokenRefreshUrls = [
+    '/api/auth/token',
+    '/api/authorization/consent/grant',
+    '/api/authorization/terms/accept',
+  ];
   private apiBaseUrls = [this.apiBase, this.apiBase.replace('/api', '/wallet-api')];
 
   intercept(req: HttpRequest<unknown>, handler: HttpHandler) {

--- a/libs/eo/auth/data-access/auth.service.ts
+++ b/libs/eo/auth/data-access/auth.service.ts
@@ -18,7 +18,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject, signal } from '@angular/core';
 import { TranslocoService } from '@ngneat/transloco';
 import { User, UserManager } from 'oidc-client-ts';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { BehaviorSubject, lastValueFrom, Subject } from 'rxjs';
 
 import { WindowService } from '@energinet-datahub/gf/util-browser';
 
@@ -113,41 +113,45 @@ export class EoAuthService {
     return this.userManager?.signinRedirect({ state: config }) ?? Promise.resolve();
   }
 
-  acceptTos(): Promise<void> {
+  async acceptTos(): Promise<void> {
     const user = this.user();
-    if (!user || user?.profile.tos_accepted)
-      return Promise.reject('User not found or already accepted TOS');
+    if(!user) {
+      this.login();
+    }
 
-    return new Promise<void>((resolve, reject) => {
-      this.http.post(`${this.apiEnvironment.apiBase}/authorization/terms/accept`, {}).subscribe(
-        () => {
-          this.user.set({
-            ...user,
-            profile: {
-              ...user.profile,
-              tos_accepted: true,
-            },
-          } as EoUser);
-          resolve();
-        },
-        (error) => {
-          this.login();
-          reject(error);
+    if (user?.profile.tos_accepted) {
+      return new Promise((resolve) => resolve());
+    }
+
+    try {
+      // Accept TOS
+      await lastValueFrom(this.http.post(`${this.apiEnvironment.apiBase}/authorization/terms/accept`, {}));
+
+      // Poll for TOS acceptance confirmation
+      const maxAttempts = 10;
+      const delayMs = 500;
+
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        const updatedUser = await this.refreshToken();
+        if (updatedUser?.profile.tos_accepted) {
+          return;
         }
-      );
-    });
-  }
 
-  private setUser(user: EoUser | null): void {
-    if (!user) return;
-    user ? this.user.set(user) : this.user.set(null);
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+
+      return Promise.reject('Max attempts reached waiting for TOS acceptance!');
+    } catch (error) {
+      this.login();
+      throw error;
+    }
   }
 
   signinCallback(): Promise<User | null> {
     return this.userManager
       ? this.userManager?.signinCallback().then((user) => {
           if (user) {
-            this.setUser(user as EoUser);
+            this.user.set(user as EoUser ?? null);
           }
           return Promise.resolve(user ?? null);
         })
@@ -163,8 +167,15 @@ export class EoAuthService {
     return this.userManager?.signoutRedirect() ?? Promise.resolve();
   }
 
-  refreshToken(): Promise<User | null> {
-    return this.userManager ? this.userManager?.signinSilent() : Promise.resolve(null);
+  async refreshToken(): Promise<User | null> {
+    const user = await this.userManager?.signinSilent();
+    if(user) {
+      this.user.set(user as EoUser ?? null);
+      return Promise.resolve(user);
+    } else {
+      this.user.set(null);
+      return Promise.resolve(null);
+    }
   }
 
   isLoggedIn(): Promise<boolean> {
@@ -184,7 +195,7 @@ export class EoAuthService {
   checkForExistingToken() {
     return this.userManager?.getUser().then((user) => {
       if (!user) return;
-      this.setUser(user as EoUser);
+      this.user.set(user as EoUser ?? null);
     });
   }
 }

--- a/libs/eo/auth/data-access/auth.service.ts
+++ b/libs/eo/auth/data-access/auth.service.ts
@@ -115,7 +115,7 @@ export class EoAuthService {
 
   async acceptTos(): Promise<void> {
     const user = this.user();
-    if(!user) {
+    if (!user) {
       this.login();
     }
 
@@ -125,7 +125,9 @@ export class EoAuthService {
 
     try {
       // Accept TOS
-      await lastValueFrom(this.http.post(`${this.apiEnvironment.apiBase}/authorization/terms/accept`, {}));
+      await lastValueFrom(
+        this.http.post(`${this.apiEnvironment.apiBase}/authorization/terms/accept`, {})
+      );
 
       // Poll for TOS acceptance confirmation
       const maxAttempts = 10;
@@ -137,7 +139,7 @@ export class EoAuthService {
           return;
         }
 
-        await new Promise(resolve => setTimeout(resolve, delayMs));
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
       }
 
       return Promise.reject('Max attempts reached waiting for TOS acceptance!');
@@ -151,7 +153,7 @@ export class EoAuthService {
     return this.userManager
       ? this.userManager?.signinCallback().then((user) => {
           if (user) {
-            this.user.set(user as EoUser ?? null);
+            this.user.set((user as EoUser) ?? null);
           }
           return Promise.resolve(user ?? null);
         })
@@ -169,8 +171,8 @@ export class EoAuthService {
 
   async refreshToken(): Promise<User | null> {
     const user = await this.userManager?.signinSilent();
-    if(user) {
-      this.user.set(user as EoUser ?? null);
+    if (user) {
+      this.user.set((user as EoUser) ?? null);
       return Promise.resolve(user);
     } else {
       this.user.set(null);
@@ -195,7 +197,7 @@ export class EoAuthService {
   checkForExistingToken() {
     return this.userManager?.getUser().then((user) => {
       if (!user) return;
-      this.user.set(user as EoUser ?? null);
+      this.user.set((user as EoUser) ?? null);
     });
   }
 }

--- a/libs/eo/auth/data-access/auth.service.ts
+++ b/libs/eo/auth/data-access/auth.service.ts
@@ -119,7 +119,7 @@ export class EoAuthService {
       this.login();
     }
 
-    if (user?.profile.tos_accepted) {
+    if (user?.profile['tos_accepted']) {
       return new Promise((resolve) => resolve());
     }
 
@@ -135,7 +135,7 @@ export class EoAuthService {
 
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
         const updatedUser = await this.refreshToken();
-        if (updatedUser?.profile.tos_accepted) {
+        if (updatedUser?.profile['tos_accepted']) {
           return;
         }
 

--- a/libs/eo/auth/feature-terms/terms.component.ts
+++ b/libs/eo/auth/feature-terms/terms.component.ts
@@ -265,20 +265,23 @@ export class EoTermsComponent {
     if (this.startedAcceptFlow() || !this.hasAcceptedTerms) return;
     this.startedAcceptFlow.set(true);
 
-    this.authService.acceptTos().then(() => {
-      const redirectUrl = this.activatedRoute.snapshot.queryParamMap.get('redirectUrl');
+    this.authService
+      .acceptTos()
+      .then(() => {
+        const redirectUrl = this.activatedRoute.snapshot.queryParamMap.get('redirectUrl');
 
-      if (redirectUrl) {
-        this.router.navigateByUrl(redirectUrl);
-      } else {
-        this.router.navigate([this.transloco.getActiveLang(), 'dashboard']);
-      }
-    }).catch(() => {
-      this.startedAcceptFlow.set(false);
-      this.toastService.open({
-        message: this.transloco.translate(this.translations.shared.error.message),
-        type: 'danger',
+        if (redirectUrl) {
+          this.router.navigateByUrl(redirectUrl);
+        } else {
+          this.router.navigate([this.transloco.getActiveLang(), 'dashboard']);
+        }
+      })
+      .catch(() => {
+        this.startedAcceptFlow.set(false);
+        this.toastService.open({
+          message: this.transloco.translate(this.translations.shared.error.message),
+          type: 'danger',
+        });
       });
-    });
   }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This pull request includes several changes to the authentication and terms acceptance flow in the `eo/auth` library. The most important changes include updating the handling of token refresh URLs, improving the `acceptTos` method to handle asynchronous operations, and adding a toast notification for error handling in the terms component.

### Authentication Improvements:
* [`libs/eo/auth/data-access/auth.interceptor.ts`](diffhunk://#diff-bfc346fbd147000fc136749dce76c253fb4a74bee99bfe340c03eb433f9c42a3L42-R42): Added a new URL to the `ignoreTokenRefreshUrls` array to include `/api/authorization/terms/accept`.
* [`libs/eo/auth/data-access/auth.service.ts`](diffhunk://#diff-7e7ef35de5c69cb1d2cfefb81a03b975caf099ecfd741e71ccc6fa9525e80a51L116-R154): Updated `acceptTos` method to use `lastValueFrom` for asynchronous handling and added polling for TOS acceptance confirmation.
* [`libs/eo/auth/data-access/auth.service.ts`](diffhunk://#diff-7e7ef35de5c69cb1d2cfefb81a03b975caf099ecfd741e71ccc6fa9525e80a51L166-R178): Modified `refreshToken` method to be asynchronous and update the user state accordingly.
* [`libs/eo/auth/data-access/auth.service.ts`](diffhunk://#diff-7e7ef35de5c69cb1d2cfefb81a03b975caf099ecfd741e71ccc6fa9525e80a51L187-R198): Updated `checkForExistingToken` to set the user state directly.

### Terms Component Enhancements:
* [`libs/eo/auth/feature-terms/terms.component.ts`](diffhunk://#diff-2a6fe44dd8575c03e149dea6ec78cfe5a0316662b24672ac4363fe348a97ff2cR36): Added `WattToastService` for error notifications and updated the `startedAcceptFlow` to use a signal for reactive state management. [[1]](diffhunk://#diff-2a6fe44dd8575c03e149dea6ec78cfe5a0316662b24672ac4363fe348a97ff2cR36) [[2]](diffhunk://#diff-2a6fe44dd8575c03e149dea6ec78cfe5a0316662b24672ac4363fe348a97ff2cR229-R237)
* [`libs/eo/auth/feature-terms/terms.component.ts`](diffhunk://#diff-2a6fe44dd8575c03e149dea6ec78cfe5a0316662b24672ac4363fe348a97ff2cR276-R281): Added error handling in the `onAccept` method to display a toast notification if the TOS acceptance fails.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#3670](https://github.com/Energinet-DataHub/energy-origin-issues/issues/3670)
