### PR TITLE
ETT: enhance refreshToken method with additional query parameters for login prompt

### DIFF
--- a/libs/eo/auth/data-access/auth.service.ts
+++ b/libs/eo/auth/data-access/auth.service.ts
@@ -134,7 +134,11 @@ export class EoAuthService {
       const delayMs = 500;
 
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        const updatedUser = await this.refreshToken();
+        const updatedUser = await this.refreshToken({
+          prompt: 'login',
+          max_age: "0",
+          t: Date.now().toString()
+        });
         if (updatedUser?.profile['tos_accepted']) {
           return;
         }
@@ -169,8 +173,10 @@ export class EoAuthService {
     return this.userManager?.signoutRedirect() ?? Promise.resolve();
   }
 
-  async refreshToken(): Promise<User | null> {
-    const user = await this.userManager?.signinSilent();
+  async refreshToken(extraQueryParams?: Record<string, string | number | boolean> | undefined): Promise<User | null> {
+    const user = await this.userManager?.signinSilent({
+      extraQueryParams,
+    });
     if (user) {
       this.user.set((user as EoUser) ?? null);
       return Promise.resolve(user);

--- a/libs/eo/auth/data-access/auth.service.ts
+++ b/libs/eo/auth/data-access/auth.service.ts
@@ -136,8 +136,8 @@ export class EoAuthService {
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
         const updatedUser = await this.refreshToken({
           prompt: 'login',
-          max_age: "0",
-          t: Date.now().toString()
+          max_age: '0',
+          t: Date.now().toString(),
         });
         if (updatedUser?.profile['tos_accepted']) {
           return;
@@ -173,7 +173,9 @@ export class EoAuthService {
     return this.userManager?.signoutRedirect() ?? Promise.resolve();
   }
 
-  async refreshToken(extraQueryParams?: Record<string, string | number | boolean> | undefined): Promise<User | null> {
+  async refreshToken(
+    extraQueryParams?: Record<string, string | number | boolean> | undefined
+  ): Promise<User | null> {
     const user = await this.userManager?.signinSilent({
       extraQueryParams,
     });


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This pull request introduces enhancements to the `EoAuthService` class in the `libs/eo/auth/data-access/auth.service.ts` file, specifically focusing on the `refreshToken` method to include additional query parameters and improving the token refresh process.

Enhancements to `refreshToken` method:

* Modified the `refreshToken` method to accept `extraQueryParams` as an optional parameter and pass it to `signinSilent`. (`libs/eo/auth/data-access/auth.service.ts`)
* Updated the call to `refreshToken` to include specific query parameters (`prompt`, `max_age`, and `t`) for better control over the authentication flow. (`libs/eo/auth/data-access/auth.service.ts`)

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
