### PR TITLE
fix(signin): simplify navigation to dashboard by removing queryParams…

### DIFF
--- a/libs/eo/onboarding/shell/signin-callback.component.ts
+++ b/libs/eo/onboarding/shell/signin-callback.component.ts
@@ -67,9 +67,7 @@ export class EoSigninCallbackComponent implements OnInit {
         } else if (redirectUrl) {
           this.router.navigateByUrl(redirectUrl);
         } else {
-          this.router.navigate([this.transloco.getActiveLang(), 'dashboard'], {
-            queryParamsHandling: 'preserve',
-          });
+          this.router.navigate([this.transloco.getActiveLang(), 'dashboard']);
         }
       })
       .catch(() => {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This pull request includes a small change to the `EoSigninCallbackComponent` in the `libs/eo/onboarding/shell/signin-callback.component.ts` file. The change modifies the navigation behavior to the dashboard by removing the `queryParamsHandling: 'preserve'` option.

* [`libs/eo/onboarding/shell/signin-callback.component.ts`](diffhunk://#diff-00e15509bc7bcaf80f056d54a2a8d93efc5eedc6dc717f69644f3437d808b554L70-R70): Removed `queryParamsHandling: 'preserve'` from the navigation to the dashboard in the `EoSigninCallbackComponent`.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#3725](https://github.com/Energinet-DataHub/energy-origin-issues/issues/3725)
