### PR TITLE
fix(watt, dropdown): adjust spacing and alignment

### DIFF
--- a/libs/watt/src/lib/components/dropdown/watt-dropdown.component.scss
+++ b/libs/watt/src/lib/components/dropdown/watt-dropdown.component.scss
@@ -154,8 +154,7 @@ watt-dropdown {
     margin-left: 5px;
   }
 
-  ngx-mat-select-search
-    .mat-mdc-checkbox.mat-select-search-toggle-all-checkbox {
+  ngx-mat-select-search .mat-mdc-checkbox.mat-select-search-toggle-all-checkbox {
     margin: 0;
   }
 
@@ -194,9 +193,7 @@ watt-dropdown {
     }
 
     &.mdc-list-item.mat-mdc-option-active,
-    &.mdc-list-item.mdc-list-item--selected.mat-mdc-option-active:not(
-        .mat-mdc-option-multiple
-      ),
+    &.mdc-list-item.mdc-list-item--selected.mat-mdc-option-active:not(.mat-mdc-option-multiple),
     &:hover:not(.mat-mdc-option-disabled, .contains-mat-select-search),
     &:focus:not(.mat-mdc-option-disabled) {
       background-color: var(--watt-color-primary-light);

--- a/libs/watt/src/lib/components/dropdown/watt-dropdown.component.scss
+++ b/libs/watt/src/lib/components/dropdown/watt-dropdown.component.scss
@@ -109,13 +109,23 @@ watt-dropdown {
 
 .watt-dropdown-panel {
   --watt-input-color: var(--watt-typography-text-color);
+  padding: 0;
+
+  mat-option:nth-of-type(2) {
+    border-top: 1px solid var(--watt-color-neutral-grey-300);
+  }
+
+  .mat-select-search-inner-row .mat-select-search-input,
+  mat-option.contains-mat-select-search {
+    height: 48px;
+  }
 
   // Add 2px because watt-form-field has 1px border on each side
   &:not(.watt-dropdown-panel-chip-mode) {
     min-width: calc(100% + 2px) !important;
     margin-top: -36px;
     margin-left: -1px;
-    padding-top: var(--watt-space-xs);
+    min-height: 48px;
   }
 
   .mat-mdc-checkbox.mat-select-search-toggle-all-checkbox {
@@ -140,19 +150,8 @@ watt-dropdown {
     background-color: transparent;
   }
 
-  ngx-mat-select-search
-    .mat-select-search-inner.mat-select-search-inner-toggle-all
-    .mat-select-search-input {
-    padding-left: 0;
-  }
-
-  ngx-mat-select-search .mat-select-search-inner {
+  ngx-mat-select-search .mat-select-search-inner-multiple .mat-select-search-inner-row {
     margin-left: 5px;
-  }
-
-  ngx-mat-select-search .mat-select-search-input {
-    padding: 0;
-    margin-left: 4px;
   }
 
   ngx-mat-select-search


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This pull request includes updates to the `watt-dropdown` component's styles to improve visual consistency and layout. The changes primarily focus on padding adjustments and border styling for dropdown options.

Styling adjustments for `watt-dropdown` component:

* Added padding of `0` to `.watt-dropdown-panel` and set specific height for `.mat-select-search-inner-row .mat-select-search-input` and `mat-option.contains-mat-select-search` to `48px`. (`libs/watt/src/lib/components/dropdown/watt-dropdown.component.scss`)
* Added a top border to the second `mat-option` within `.watt-dropdown-panel`. (`libs/watt/src/lib/components/dropdown/watt-dropdown.component.scss`)
* Removed padding and margin adjustments for `.mat-select-search-input` within `ngx-mat-select-search` and adjusted the margin for `.mat-select-search-inner-multiple .mat-select-search-inner-row`. (`libs/watt/src/lib/components/dropdown/watt-dropdown.component.scss`)

**BEFORE:**
<img width="242" alt="image" src="https://github.com/user-attachments/assets/a7ea1290-2bd9-4657-a141-a34344f4ac40">


**AFTER:**
<img width="297" alt="image" src="https://github.com/user-attachments/assets/3afe2b4f-2b9b-4395-9592-195fc0ed72af">

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#3458](https://github.com/Energinet-DataHub/energy-origin-issues/issues/3458)
