### PR TITLE
Only release dotnet if changes

### DIFF
--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -52,7 +52,7 @@ jobs:
 
   dh_ci_dotnet:
     needs: changes
-    if: ${{ needs.changes.outputs.dh_dotnet == 'true' || needs.changes.outputs.dh_frontend == 'true' }}
+    if: ${{ needs.changes.outputs.dh_dotnet == 'true' }}
     uses: ./.github/workflows/dh-ci-dotnet.yml
     secrets: inherit
 

--- a/.github/workflows/dh-cd.yml
+++ b/.github/workflows/dh-cd.yml
@@ -34,7 +34,7 @@ jobs:
 
   dotnet_promote_prerelease:
     needs: changes
-    if: ${{ needs.changes.outputs.dh_dotnet == 'true' || needs.changes.outputs.dh_frontend == 'true' }}
+    if: ${{ needs.changes.outputs.dh_dotnet == 'true' }}
     uses: Energinet-DataHub/.github/.github/workflows/promote-prerelease.yml@v14
     with:
       release_name_prefix: ui_dotnet


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
This pull request includes changes to the GitHub workflow configuration files to refine the conditions under which certain jobs are executed. Specifically, it removes the dependency on `dh_frontend` outputs for the `dh_ci_dotnet` and `dotnet_promote_prerelease` jobs.

Changes in GitHub workflow configurations:

* [`.github/workflows/ci-orchestrator.yml`](diffhunk://#diff-c2a8e2dd83b46864483c9706f8e843ef2eef7e0a17b4ae45194a5a671e3c8739L55-R55): Modified the `if` condition for the `dh_ci_dotnet` job to only check for `dh_dotnet` outputs.
* [`.github/workflows/dh-cd.yml`](diffhunk://#diff-2097bc6b995e5600ae4b86db05e241f7045182bfe072452e55c43f64b381eeceL37-R37): Modified the `if` condition for the `dotnet_promote_prerelease` job to only check for `dh_dotnet` outputs.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
