### PR TITLE
Added permission on button

### DIFF
--- a/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/dh-actor-drawer.component.html
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/dh-actor-drawer.component.html
@@ -114,6 +114,7 @@ limitations under the License.
                   <vater-stack direction="row">
                     <h3>{{ t("tabs.masterData.organization") }}</h3>
                     <watt-button
+                      *dhPermissionRequired="['actors:manage']"
                       (click)="editOrganization(actor()?.organization?.id)"
                       variant="text"
                       >{{ t("tabs.masterData.editOrganization") }}</watt-button


### PR DESCRIPTION
This pull request includes a minor change to the `dh-actor-drawer.component.html` file. The change adds a permission requirement to the "Edit Organization" button to ensure only users with the appropriate permissions can access this functionality.

* [`libs/dh/market-participant/actors/feature-actors/src/lib/drawer/dh-actor-drawer.component.html`](diffhunk://#diff-8952241426bad1008df2ef915f202a4e60136c6f1e898d64848f12a16470b54dR117): Added `*dhPermissionRequired="['actors:manage']"` to the "Edit Organization" button.