### PR TITLE
fix(dh): issue with message archive searchById

### DIFF
--- a/libs/dh/message-archive/feature-search/src/lib/table.component.ts
+++ b/libs/dh/message-archive/feature-search/src/lib/table.component.ts
@@ -136,12 +136,7 @@ export class DhMessageArchiveSearchTableComponent {
 
   clearSelection = () => this.selection.set(undefined);
 
-  fetch = (variables: Variables) => {
-    // Empty the table in order to show loading state
-    // TODO: Come up with a solution that doesn't require calling this method
-    this.dataSource.reset();
-    this.dataSource.refetch(variables);
-  };
+  fetch = (variables: Variables) => this.dataSource.refetch(variables);
 
   reset = () => {
     this.dataSource.reset();

--- a/libs/dh/shared/util-apollo/src/lib/dataSource.ts
+++ b/libs/dh/shared/util-apollo/src/lib/dataSource.ts
@@ -128,7 +128,11 @@ export class ApolloDataSource<TResult, TVariables extends ConnectionVariables, T
     if (!options?.skip) this._inputChange.next(options?.variables);
   }
 
-  refetch = (variables?: Partial<TVariables>) => this._inputChange.next(variables);
+  refetch = (variables?: Partial<TVariables>) => {
+    this._data.set([]);
+    this._inputChange.next(variables);
+  };
+
   subscribeToMore: QueryResult<TResult, TVariables>['subscribeToMore'] = (options) =>
     this._query.subscribeToMore(options);
 


### PR DESCRIPTION
## Description

Do not reset entire dataSource on refetch, but instead set the data to an empty array. This is enough to trigger the loading state and prevents the issue where the filter variable was no longer present in the options variables since options had been reset.
