### PR TITLE
fix(eo, landing-page): remove condition if user is logged in

### DIFF
--- a/libs/eo/landing-page/shell/src/lib/login-button.component.ts
+++ b/libs/eo/landing-page/shell/src/lib/login-button.component.ts
@@ -42,19 +42,11 @@ import { translations } from '@energinet-datahub/eo/translations';
     @if (type() === 'default') {
       <button class="button primary" (click)="onClick()">
         <watt-icon name="login" />
-        @if (isLoggedIn()) {
-          {{ translations.loginButton.authenticated | transloco }}
-        } @else {
-          {{ translations.loginButton.unauthenticated | transloco }}
-        }
+        {{ translations.loginButton.unauthenticated | transloco }}
       </button>
     } @else {
       <watt-button variant="text" class="login" data-testid="login-button" (click)="onClick()">
-        @if (isLoggedIn()) {
-          {{ translations.loginButton.authenticated | transloco }}
-        } @else {
-          {{ translations.loginButton.unauthenticated | transloco }}
-        }
+        {{ translations.loginButton.unauthenticated | transloco }}
       </watt-button>
     }
   `,
@@ -62,9 +54,9 @@ import { translations } from '@energinet-datahub/eo/translations';
 export class EoLoginButtonComponent {
   type = input<'text' | 'default'>('default');
 
-  private authService = inject(EoAuthService);
-  private destroyRef = inject(DestroyRef);
-  private window = inject(WindowService).nativeWindow;
+  private readonly authService = inject(EoAuthService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly window = inject(WindowService).nativeWindow;
 
   protected translations = translations;
   protected isLoggedIn!: WritableSignal<boolean>;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

There is some hydration issue in Angular which causes the @if and @else to be rendered at the same time for the login button at the landing-page. The fix should be available in v19. Until then I've removed the condition so we always shows the text as "unauthorized" 

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
