### PR TITLE
chore: Bump NuGet packages

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/DataHub.WebApi.Tests.csproj
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/DataHub.WebApi.Tests.csproj
@@ -29,12 +29,12 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Monitor.Query" Version="1.5.0" />
+    <PackageReference Include="Azure.Monitor.Query" Version="1.6.0" />
     <PackageReference Include="Verify.Xunit" Version="28.4.0" />
-    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="7.0.4" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.0.4" />
+    <PackageReference Include="Energinet.DataHub.Core.TestCommon" Version="7.1.0" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="7.1.0" />
     <PackageReference Include="Energinet.DataHub.MeteringPoints.Client" Version="3.0.5" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
       <PrivateAssets>all</PrivateAssets>

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Unit/Clients/Wholesale/ProcessManager/OrchestrationInstanceMapperExtensionsTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Unit/Clients/Wholesale/ProcessManager/OrchestrationInstanceMapperExtensionsTests.cs
@@ -43,11 +43,11 @@ public class OrchestrationInstanceMapperExtensionsTests
         };
 
         var orchestrationInstanceDto = new OrchestrationInstanceTypedDto<CalculationInputV1>(
-            Id: fixture.Create<Guid>(),
-            Lifecycle: lifecycle,
-            ParameterValue: parameterValue,
-            Steps: steps,
-            CustomState: string.Empty);
+            id: fixture.Create<Guid>(),
+            lifecycle: lifecycle,
+            parameterValue: parameterValue,
+            steps: steps,
+            customState: string.Empty);
 
         // Act
         var actualDto = orchestrationInstanceDto.MapToV3CalculationDto();
@@ -82,11 +82,11 @@ public class OrchestrationInstanceMapperExtensionsTests
         };
 
         var orchestrationInstanceDto = new OrchestrationInstanceTypedDto<CalculationInputV1>(
-            Id: fixture.Create<Guid>(),
-            Lifecycle: lifecycle,
-            ParameterValue: parameterValue,
-            Steps: steps,
-            CustomState: string.Empty);
+            id: fixture.Create<Guid>(),
+            lifecycle: lifecycle,
+            parameterValue: parameterValue,
+            steps: steps,
+            customState: string.Empty);
 
         // Act
         var actualState = orchestrationInstanceDto.MapToV3OrchestrationState();
@@ -109,11 +109,11 @@ public class OrchestrationInstanceMapperExtensionsTests
         };
 
         var orchestrationInstanceDto = new OrchestrationInstanceTypedDto<CalculationInputV1>(
-            Id: fixture.Create<Guid>(),
-            Lifecycle: lifecycle,
-            ParameterValue: parameterValue,
-            Steps: steps,
-            CustomState: string.Empty);
+            id: fixture.Create<Guid>(),
+            lifecycle: lifecycle,
+            parameterValue: parameterValue,
+            steps: steps,
+            customState: string.Empty);
 
         // Act
         var actualState = orchestrationInstanceDto.MapToV3OrchestrationState();

--- a/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -53,18 +53,18 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
-    <PackageReference Include="Energinet.DataHub.ProcessManager.Client" Version="0.13.0" />
-    <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="0.0.1" />
-    <PackageReference Include="HotChocolate.AspNetCore" Version="14.1.0" />
-    <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="14.1.0" />
-    <PackageReference Include="HotChocolate.AspNetCore.CommandLine" Version="14.1.0" />
-    <PackageReference Include="HotChocolate.Data" Version="14.1.0" />
-    <PackageReference Include="HotChocolate.Diagnostics" Version="14.1.0" />
-    <PackageReference Include="HotChocolate.Types.Analyzers" Version="14.1.0">
+    <PackageReference Include="Energinet.DataHub.ProcessManager.Client" Version="0.14.0" />
+    <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="0.1.0" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="14.2.0" />
+    <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="14.2.0" />
+    <PackageReference Include="HotChocolate.AspNetCore.CommandLine" Version="14.2.0" />
+    <PackageReference Include="HotChocolate.Data" Version="14.2.0" />
+    <PackageReference Include="HotChocolate.Diagnostics" Version="14.2.0" />
+    <PackageReference Include="HotChocolate.Types.Analyzers" Version="14.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="14.0.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="14.0.1" />
     <PackageReference Include="Energinet.DataHub.MessageArchive.Client" Version="2.0.8" />
     <PackageReference Include="Energinet.DataHub.MessageArchive.Client.Abstractions" Version="2.0.8" />
     <PackageReference Include="Microsoft.FeatureManagement" Version="4.0.0" />


### PR DESCRIPTION
## Description

Use latest NuGet packages and fix constructor parameters for `OrchestrationInstanceTypedDto`.

## References

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/423

