### PR TITLE
refactor(eo, transfer): transfer agreement mocks

### DIFF
--- a/libs/eo/shared/data-access-mocks/src/lib/transfer.ts
+++ b/libs/eo/shared/data-access-mocks/src/lib/transfer.ts
@@ -18,6 +18,7 @@
 //#endregion
 import { http, delay, HttpResponse } from 'msw';
 import { transferActivityLogResponse } from './data/activity-logs';
+import { addDays, getUnixTime, subDays } from 'date-fns';
 
 export function transferMocks(apiBase: string) {
   return [
@@ -29,86 +30,87 @@ export function transferMocks(apiBase: string) {
   ];
 }
 
+
+const enum Users {
+  CharlotteCSR = '39293595',
+  IvanIvaerksaetter = '12345678',
+  PeterProducent = '11223344',
+  FrankFabrikant = '55555555',
+  BrianBoligHaj = '66666666',
+  ViggoVindmolle = '77777777',
+  ErikEnerginet = '28980671',
+}
+
 const senderName = 'Producent A/S';
-const statuses = ['Active', 'Inactive', 'Proposal', 'ProposalExpired'];
-const randomStatus = () => statuses[Math.floor(Math.random() * statuses.length)];
+type transferAgreementStatus = 'Active' | 'Inactive' | 'Proposal' | 'ProposalExpired';
+interface TransferAgreement {
+  id: string;
+  startDate: number;
+  endDate?: number;
+  senderName: string;
+  senderTin: string;
+  receiverTin: string;
+  transferAgreementStatus: transferAgreementStatus;
+}
+
+const activeTransferAgreement: TransferAgreement = {
+  id: 'f44211b2-78fa-4fa0-9215-23369abf24ea',
+  startDate: getUnixTime(subDays(new Date(), 10)),
+  endDate: getUnixTime(addDays(new Date(), 10)),
+  senderName,
+  senderTin: Users.PeterProducent,
+  receiverTin: Users.IvanIvaerksaetter,
+  transferAgreementStatus: 'Active',
+};
+
+const activeTransferAgreementNotSender: TransferAgreement = {
+  id: 'f44211b2-78fa-4fa0-9215-23369abf24eb',
+  startDate: getUnixTime(subDays(new Date(), 10)),
+  endDate: getUnixTime(addDays(new Date(), 10)),
+  senderName: 'Ukendt virksomhed',
+  senderTin: Users.CharlotteCSR,
+  receiverTin: Users.PeterProducent,
+  transferAgreementStatus: 'Active',
+};
+
+const inactiveTransferAgreement = {
+  id: '0f190d46-7736-4f71-ad07-63dbaeeb689a',
+  startDate: getUnixTime(addDays(new Date(), 10)),
+  senderName,
+  senderTin: Users.PeterProducent,
+  receiverTin: Users.FrankFabrikant,
+  transferAgreementStatus: 'Inactive',
+};
+
+const transferAgreementProposal = {
+  id: '8892efde-2d14-48a5-85ad-85cb45386790',
+  startDate: getUnixTime(addDays(new Date(), 5)),
+  endDate: getUnixTime(addDays(new Date(), 11)),
+  senderName,
+  senderTin: Users.PeterProducent,
+  receiverTin: Users.BrianBoligHaj,
+  transferAgreementStatus: 'Proposal',
+};
+
+const transferAgreementProposalExpired = {
+  id: 'fe1a2948-a2eb-4464-b6bc-c0be0289b1cc',
+  startDate: getUnixTime(subDays(new Date(), 30)),
+  endDate: getUnixTime(subDays(new Date(), 10)),
+  senderName,
+  senderTin: Users.PeterProducent,
+  receiverTin: Users.ErikEnerginet,
+  transferAgreementStatus: 'ProposalExpired',
+};
 
 function getTransferAgreements(apiBase: string) {
   return http.get(`${apiBase}/transfer/transfer-agreements/overview`, async () => {
     const data = {
       result: [
-        {
-          id: 'f44211b2-78fa-4fa0-9215-23369abf24ea',
-          startDate: 1702371600,
-          endDate: 1702396800,
-          senderName,
-          senderTin: '11223344',
-          receiverTin: '39293595',
-          transferAgreementStatus: 'Active',
-        },
-        {
-          id: '0f190d46-7736-4f71-ad07-63dbaeeb689a',
-          startDate: 1702371600,
-          endDate: 1702378800,
-          senderName,
-          senderTin: '11223344',
-          receiverTin: '12345678',
-          transferAgreementStatus: 'Inactive',
-        },
-        {
-          id: '8892efde-2d14-48a5-85ad-85cb45386790',
-          startDate: 1702382400,
-          endDate: 1702386000,
-          senderName,
-          senderTin: '11223344',
-          receiverTin: '12345678',
-          transferAgreementStatus: 'Proposal',
-        },
-        {
-          id: 'fe1a2948-a2eb-4464-b6bc-c0be0289b1cc',
-          startDate: 1702407600,
-          endDate: 1702443600,
-          senderName,
-          senderTin: '11223344',
-          receiverTin: '39293595',
-          transferAgreementStatus: 'ProposalExpired',
-        },
-        {
-          id: 'b1dd65a9-ded0-4ff2-bf4e-fb04c8bf6b1e',
-          startDate: 1702393200,
-          endDate: 1702411200,
-          senderName,
-          senderTin: '11223344',
-          receiverTin: '12345678',
-          transferAgreementStatus: randomStatus(),
-        },
-        {
-          id: 'e31acbac-d26d-4c5b-aaa4-98fb49c740c5',
-          startDate: 1702414800,
-          endDate: 1702440000,
-          senderName,
-          senderTin: '11223344',
-          receiverTin: '12345678',
-          transferAgreementStatus: randomStatus(),
-        },
-        {
-          id: '427e47ed-47b3-45f0-8d62-e2a9930090f0',
-          startDate: 1702447200,
-          endDate: 1702533600,
-          senderName,
-          senderTin: '11223344',
-          receiverTin: '12345678',
-          transferAgreementStatus: randomStatus(),
-        },
-        {
-          id: '3e3b749b-6149-4e34-bc6e-a13ffed0f28c',
-          startDate: 1702537200,
-          endDate: 1702551600,
-          senderName,
-          senderTin: '11223344',
-          receiverTin: '12345678',
-          transferAgreementStatus: randomStatus(),
-        },
+        activeTransferAgreement,
+        activeTransferAgreementNotSender,
+        inactiveTransferAgreement,
+        transferAgreementProposal,
+        transferAgreementProposalExpired,
       ],
     };
     await delay(1000);

--- a/libs/eo/shared/data-access-mocks/src/lib/transfer.ts
+++ b/libs/eo/shared/data-access-mocks/src/lib/transfer.ts
@@ -30,7 +30,6 @@ export function transferMocks(apiBase: string) {
   ];
 }
 
-
 const enum Users {
   CharlotteCSR = '39293595',
   IvanIvaerksaetter = '12345678',

--- a/libs/eo/transfers/src/lib/eo-transfers.service.ts
+++ b/libs/eo/transfers/src/lib/eo-transfers.service.ts
@@ -18,7 +18,7 @@
 //#endregion
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable, inject } from '@angular/core';
-import { map, switchMap } from 'rxjs';
+import { map, Observable, switchMap } from 'rxjs';
 
 import { EoApiEnvironment, eoApiEnvironmentToken } from '@energinet-datahub/eo/shared/environments';
 import { getUnixTime } from 'date-fns';
@@ -84,16 +84,25 @@ export class EoTransfersService {
       .pipe(
         map((x) => x.result),
         switchMap((transfers) => {
-          const receiverTins = transfers
-            .filter((transfer) => transfer.receiverTin && transfer.receiverTin !== '')
-            .map((transfer) => transfer.receiverTin);
+          const receiverTins = Array.from(
+            new Set(
+              transfers
+                .filter(
+                  (transfer) =>
+                    transfer.receiverTin &&
+                    transfer.receiverTin !== '' &&
+                    transfer.receiverTin !== this.user()?.profile.org_cvr
+                )
+                .map((transfer) => transfer.receiverTin)
+            )
+          );
 
           return this.getCompanyNames(receiverTins).pipe(
             map((companyNames) => {
-              return transfers.map((transfer, index) => ({
+              return transfers.map((transfer) => ({
                 ...transfer,
                 ...this.setSender(transfer),
-                receiverName: companyNames[index],
+                receiverName: this.getReceiverName(transfer, companyNames),
                 startDate: transfer.startDate,
                 endDate: transfer.endDate ? transfer.endDate : null,
               }));
@@ -101,6 +110,12 @@ export class EoTransfersService {
           );
         })
       );
+  }
+
+  private getReceiverName(transfer: EoListedTransfer, companyNamesMap: Map<string, string>) {
+    if (!transfer.receiverTin) return null;
+    if (transfer.receiverTin === this.user()?.profile.org_cvr) return this.user()?.profile.name;
+    return companyNamesMap.get(transfer.receiverTin) ?? null;
   }
 
   private setSender(transfer: EoListedTransfer) {
@@ -115,7 +130,7 @@ export class EoTransfersService {
     };
   }
 
-  getCompanyNames(cvrNumbers: string[]) {
+  getCompanyNames(cvrNumbers: string[]): Observable<Map<string, string>> {
     return this.http
       .post<{ result: { companyCvr: string; companyName: string }[] }>(
         `${this.#apiBase}/transfer/cvr`,
@@ -126,11 +141,7 @@ export class EoTransfersService {
       .pipe(
         map((response) => response.result),
         map((companysData) => {
-          return cvrNumbers.map((cvrNumber) => {
-            return (
-              companysData.find((company) => company.companyCvr === cvrNumber)?.companyName ?? null
-            );
-          });
+          return new Map(companysData.map((company) => [company.companyCvr, company.companyName]));
         })
       );
   }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
This pull request includes significant changes to the `libs/eo/shared/data-access-mocks` and `libs/eo/transfers` modules to improve the handling of transfer agreements and enhance the `EoTransfersService` class. The most important changes include the addition of new utility functions, refactoring of transfer agreement data structures, and improvements to the `EoTransfersService` class.

Improvements to `libs/eo/shared/data-access-mocks`:

* [`libs/eo/shared/data-access-mocks/src/lib/transfer.ts`](diffhunk://#diff-47fc638e22e36cc864088dfefc29a74488f4157cf1f68b4ba65ab249b897a303R21): Added utility functions from `date-fns` and refactored transfer agreement data structures to use a new `TransferAgreement` interface and predefined user constants. [[1]](diffhunk://#diff-47fc638e22e36cc864088dfefc29a74488f4157cf1f68b4ba65ab249b897a303R21) [[2]](diffhunk://#diff-47fc638e22e36cc864088dfefc29a74488f4157cf1f68b4ba65ab249b897a303R33-R113)

Enhancements to `EoTransfersService`:

* [`libs/eo/transfers/src/lib/eo-transfers.service.ts`](diffhunk://#diff-af1cfe180bc0b8a300137194879ab275449cadd8fe1e7d72ff03c53cfafca4e5L21-R21): Added `Observable` import and refactored `getCompanyNames` method to return a `Map` instead of an array. [[1]](diffhunk://#diff-af1cfe180bc0b8a300137194879ab275449cadd8fe1e7d72ff03c53cfafca4e5L21-R21) [[2]](diffhunk://#diff-af1cfe180bc0b8a300137194879ab275449cadd8fe1e7d72ff03c53cfafca4e5L118-R133)
* [`libs/eo/transfers/src/lib/eo-transfers.service.ts`](diffhunk://#diff-af1cfe180bc0b8a300137194879ab275449cadd8fe1e7d72ff03c53cfafca4e5R115-R120): Introduced a new `getReceiverName` private method to determine the receiver name based on the transfer data and company names map.
* [`libs/eo/transfers/src/lib/eo-transfers.service.ts`](diffhunk://#diff-af1cfe180bc0b8a300137194879ab275449cadd8fe1e7d72ff03c53cfafca4e5L87-R105): Updated the `switchMap` logic to filter and map receiver TINs using a `Set` for unique values and to use the new `getReceiverName` method.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
