### PR TITLE
EO: Add license executor to run after generating translation keys

### DIFF
--- a/workspace-tools/src/executors/generate-translation-keys/executor.ts
+++ b/workspace-tools/src/executors/generate-translation-keys/executor.ts
@@ -25,6 +25,7 @@ import {
   PropertySignature,
 } from 'ts-morph';
 import { format } from 'prettier';
+import { execSync } from 'child_process';
 
 import { GenerateTranslationKeysExecutorSchema } from './schema';
 
@@ -53,6 +54,11 @@ export default async function runExecutor(options: GenerateTranslationKeysExecut
   const code = outputSourceFile.print();
   const formatted = format(code, { parser: 'typescript' });
   outputSourceFile.replaceWithText(await formatted);
+
+  await outputSourceFile.save();
+
+  // Run license executor after generating translation keys
+  execSync('bun run nx run tools:add-license', { stdio: 'inherit' });
 
   await project.save();
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
 - Add license executor to run after generating translation keys

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
