### PR TITLE
chore: monorepo = monoencoding

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,8 +19,5 @@
   },
   "prettier.prettierPath": "./node_modules/prettier/index.cjs",
   "eslint.validate": ["json", "graphql"],
-  "dotnet.defaultSolution": "apps/dh/api-dh/DataHub.WebApi.sln",
-  "[csharp]": {
-    "files.encoding": "utf8bom"
-  }
+  "dotnet.defaultSolution": "apps/dh/api-dh/DataHub.WebApi.sln"
 }

--- a/apps/dh/api-dh/.editorconfig
+++ b/apps/dh/api-dh/.editorconfig
@@ -32,7 +32,7 @@ indent_style = space
 [*.{cs,csx,vb,vbx}]
 indent_size = 4
 insert_final_newline = true
-charset = utf-8-bom
+charset = utf-8
 # Currently does not work in VS 2019, but works in VS Code.
 trim_trailing_whitespace = true
 
@@ -455,7 +455,7 @@ dotnet_diagnostic.SA1407.severity = error
 dotnet_diagnostic.SA1408.severity = error
 dotnet_diagnostic.SA1410.severity = error
 dotnet_diagnostic.SA1411.severity = error
-dotnet_diagnostic.SA1412.severity = error
+dotnet_diagnostic.SA1412.severity = none
 dotnet_diagnostic.SA1413.severity = error
 dotnet_diagnostic.SA1500.severity = error
 dotnet_diagnostic.SA1501.severity = none

--- a/apps/dh/api-dh/DataHub.WebApi.sln.DotSettings
+++ b/apps/dh/api-dh/DataHub.WebApi.sln.DotSettings
@@ -1,2 +1,2 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Energinet/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/DataHub.WebApi.Tests.csproj
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/DataHub.WebApi.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 @license
 Copyright 2020 Energinet DataHub A/S
 

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Extensions/SnapshotExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Extensions/SnapshotExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Fixtures/OrchestrationInstanceDtoFactory.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Fixtures/OrchestrationInstanceDtoFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Fixtures/WebApiFactory.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Fixtures/WebApiFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Fixtures/WebApiTestBase.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Fixtures/WebApiTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/EndpointTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/EndpointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/Actor/ActorGridAreasQueryTest.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/Actor/ActorGridAreasQueryTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/Actor/FilteredActorsQueryTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/Actor/FilteredActorsQueryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/BalanceResponsibilityAgreement/BalanceResponsibilityAgreementStatusTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/BalanceResponsibilityAgreement/BalanceResponsibilityAgreementStatusTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/Calculation/CalculationGridAreasQueryTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/Calculation/CalculationGridAreasQueryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/Calculation/CalculationProgressQueryTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/Calculation/CalculationProgressQueryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/Calculation/CalculationStatusTypeQueryTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/Calculation/CalculationStatusTypeQueryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/GridArea/CalculateGridAreaStatusTest.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/GridArea/CalculateGridAreaStatusTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/MessageDelegation/MessageDelegationStatusTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/MessageDelegation/MessageDelegationStatusTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/SchemaTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/SchemaTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/HealthCheck/HealthCheckFixture.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/HealthCheck/HealthCheckFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/HealthCheck/HealthCheckTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/HealthCheck/HealthCheckTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/Telemetry/GraphQLTelemetryTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/Telemetry/GraphQLTelemetryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/Telemetry/TelemetryFixture.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/Telemetry/TelemetryFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/ModuleInitializer.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/ModuleInitializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/ServiceMocks/JwtAuthenticationServiceMock.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/ServiceMocks/JwtAuthenticationServiceMock.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/ActorGridAreasQueryTests.GetActorGridAreasAsync.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/ActorGridAreasQueryTests.GetActorGridAreasAsync.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "actorById": {
       "gridAreas": [

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/BalanceResponsibilityAgreementStatusTests.Active with enddate.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/BalanceResponsibilityAgreementStatusTests.Active with enddate.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "actorById": {
       "id": "9d1b5e2a-3c4e-4f8b-9a6e-7f2b6c8d9e1f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/BalanceResponsibilityAgreementStatusTests.Active without enddate.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/BalanceResponsibilityAgreementStatusTests.Active without enddate.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "actorById": {
       "id": "9d1b5e2a-3c4e-4f8b-9a6e-7f2b6c8d9e1f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/BalanceResponsibilityAgreementStatusTests.Awaiting.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/BalanceResponsibilityAgreementStatusTests.Awaiting.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "actorById": {
       "id": "9d1b5e2a-3c4e-4f8b-9a6e-7f2b6c8d9e1f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/BalanceResponsibilityAgreementStatusTests.Expired.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/BalanceResponsibilityAgreementStatusTests.Expired.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "actorById": {
       "id": "9d1b5e2a-3c4e-4f8b-9a6e-7f2b6c8d9e1f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/BalanceResponsibilityAgreementStatusTests.SoonToExpire.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/BalanceResponsibilityAgreementStatusTests.SoonToExpire.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "actorById": {
       "id": "9d1b5e2a-3c4e-4f8b-9a6e-7f2b6c8d9e1f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculateGridAreaStatusTest.GetGridAreasWithStatus.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculateGridAreaStatusTest.GetGridAreasWithStatus.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "gridAreas": [
       {

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationGridAreasQueryTests.GetCalculationGridAreasAsync.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationGridAreasQueryTests.GetCalculationGridAreasAsync.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "gridAreas": [

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationGridAreasQueryTests.GetCalculationGridAreasAsync_UseProcessManagerFeature.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationGridAreasQueryTests.GetCalculationGridAreasAsync_UseProcessManagerFeature.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "gridAreas": [

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.ActorMessagesEnqueued.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.ActorMessagesEnqueued.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.ActorMessagesEnqueued_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.ActorMessagesEnqueued_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.ActorMessagesEnqueuing.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.ActorMessagesEnqueuing.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.ActorMessagesEnqueuingFailed.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.ActorMessagesEnqueuingFailed.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.ActorMessagesEnqueuingFailed_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.ActorMessagesEnqueuingFailed_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.ActorMessagesEnqueuing_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.ActorMessagesEnqueuing_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Calculated.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Calculated.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Calculated_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Calculated_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Calculating.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Calculating.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Calculating_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Calculating_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.CalculationFailed.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.CalculationFailed.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.CalculationFailed_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.CalculationFailed_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Completed.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Completed.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Completed_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Completed_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Scheduled.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Scheduled.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Scheduled_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationProgressQueryTests.Scheduled_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "14098365-3231-40e3-8c1b-5a73dbab31c0",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.ActorMessagesEnqueued.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.ActorMessagesEnqueued.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.ActorMessagesEnqueued_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.ActorMessagesEnqueued_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.ActorMessagesEnqueuing.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.ActorMessagesEnqueuing.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.ActorMessagesEnqueuingFailed.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.ActorMessagesEnqueuingFailed.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.ActorMessagesEnqueuingFailed_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.ActorMessagesEnqueuingFailed_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.ActorMessagesEnqueuing_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.ActorMessagesEnqueuing_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Calculated.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Calculated.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Calculated_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Calculated_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Calculating.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Calculating.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Calculating_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Calculating_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.CalculationFailed.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.CalculationFailed.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.CalculationFailed_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.CalculationFailed_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Completed.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Completed.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Completed_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Completed_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Scheduled.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Scheduled.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Scheduled_processmanager.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/CalculationStatusTypeQueryTests.Scheduled_processmanager.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "calculationById": {
       "id": "9cce3e8f-b56d-49f8-a6af-42cc6dc3246f",

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/FilteredActorsQueryTests.GetFilteredActorsAsync-isFas-False.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/FilteredActorsQueryTests.GetFilteredActorsAsync-isFas-False.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "filteredActors": [
       {

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/FilteredActorsQueryTests.GetFilteredActorsAsync-isFas-True.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/FilteredActorsQueryTests.GetFilteredActorsAsync-isFas-True.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "filteredActors": [
       {

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/MessageDelegationStatusTests.Active with end.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/MessageDelegationStatusTests.Active with end.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "delegationsForActor": [
       {

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/MessageDelegationStatusTests.Active without end.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/MessageDelegationStatusTests.Active without end.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "delegationsForActor": [
       {

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/MessageDelegationStatusTests.Cancelled same date.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/MessageDelegationStatusTests.Cancelled same date.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "delegationsForActor": [
       {

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/MessageDelegationStatusTests.Cancelled.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/MessageDelegationStatusTests.Cancelled.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "delegationsForActor": [
       {

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/MessageDelegationStatusTests.Expired.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/MessageDelegationStatusTests.Expired.verified.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "data": {
     "delegationsForActor": [
       {

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
@@ -1,4 +1,4 @@
-﻿schema {
+schema {
   query: Query
   mutation: Mutation
 }

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/TestServices/GraphQLTestService.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/TestServices/GraphQLTestService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Unit/Clients/Wholesale/ProcessManager/OrchestrationInstanceMapperExtensionsTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Unit/Clients/Wholesale/ProcessManager/OrchestrationInstanceMapperExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Unit/Clients/Wholesale/SettlementReports/SettlementReportsClientTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Unit/Clients/Wholesale/SettlementReports/SettlementReportsClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/integrationtest.local.settings.sample.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/integrationtest.local.settings.sample.json
@@ -1,3 +1,3 @@
-﻿{
+{
   "AZURE_KEYVAULT_URL": "<Integration test key vault url>",
 }

--- a/apps/dh/api-dh/source/DataHub.WebApi/ApiClientSettings.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/ApiClientSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/AuthorizedHttpClientFactory.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/AuthorizedHttpClientFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/MarketParticipant/V1/ApiErrorDescriptor.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/MarketParticipant/V1/ApiErrorDescriptor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/MarketParticipant/V1/ApiErrorResponse.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/MarketParticipant/V1/ApiErrorResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/MarketParticipant/V1/ApiException.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/MarketParticipant/V1/ApiException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Notifications/Dto/NotificationDto.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Notifications/Dto/NotificationDto.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Notifications/INotificationsClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Notifications/INotificationsClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Notifications/NotificationsClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Notifications/NotificationsClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/Dto/CancelScheduledCalculationRequestDto.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/Dto/CancelScheduledCalculationRequestDto.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/Dto/StartCalculationRequestDto.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/Dto/StartCalculationRequestDto.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/IWholesaleOrchestrationsClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/IWholesaleOrchestrationsClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/WholesaleOrchestrationsClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/Orchestrations/WholesaleOrchestrationsClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/ProcessManager/IProcessManagerClientAdapter.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/ProcessManager/IProcessManagerClientAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/ProcessManager/OrchestrationInstanceMapperExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/ProcessManager/OrchestrationInstanceMapperExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/ProcessManager/ProcessManagerClientAdapter.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/ProcessManager/ProcessManagerClientAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/CalculationId.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/CalculationId.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/RequestedSettlementReportDto.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/RequestedSettlementReportDto.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/SettlementReportJobId.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/SettlementReportJobId.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/SettlementReportMarketRole.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/SettlementReportMarketRole.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/SettlementReportRequestDto.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/SettlementReportRequestDto.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/SettlementReportRequestFilterDto.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/SettlementReportRequestFilterDto.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/SettlementReportRequestId.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/SettlementReportRequestId.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/SettlementReportStatus.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/Dto/SettlementReportStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/ISettlementReportsClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/ISettlementReportsClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/SettlementReportsClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/Wholesale/SettlementReports/SettlementReportsClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Common/FeatureFlags.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Common/FeatureFlags.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/EsettExchangeController.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/EsettExchangeController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/ImbalancePricesController.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/ImbalancePricesController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MarketParticipantActorController.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MarketParticipantActorController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MarketParticipantBalanceResponsibleController.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MarketParticipantBalanceResponsibleController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MarketParticipantControllerBase.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MarketParticipantControllerBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MarketParticipantPermissionController.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MarketParticipantPermissionController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MarketParticipantUserController.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MarketParticipantUserController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MessageArchiveController.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MessageArchiveController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/TokenController.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/TokenController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/WholesaleSettlementReportController.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/WholesaleSettlementReportController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 @license
 Copyright 2020 Energinet DataHub A/S
 

--- a/apps/dh/api-dh/source/DataHub.WebApi/Extensions/HttpContextAccessorExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Extensions/HttpContextAccessorExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Extensions/HttpContextUserExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Extensions/HttpContextUserExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Attribute/PreserveParentAsAttribute.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Attribute/PreserveParentAsAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ActorByIdBatchDataLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ActorByIdBatchDataLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ActorByNumberAndRoleBatchDataLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ActorByNumberAndRoleBatchDataLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ActorByOrganizationBatchDataLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ActorByOrganizationBatchDataLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ActorNameByIdBatchDataLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ActorNameByIdBatchDataLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ActorNameByMarketRoleDataLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ActorNameByMarketRoleDataLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ActorPublicContactByActorId.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ActorPublicContactByActorId.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/AuditIdentityCacheDataLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/AuditIdentityCacheDataLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ConsolidationByActorFromIdBatchLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ConsolidationByActorFromIdBatchLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ConsolidationByGridAreaIdBatchDataLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/ConsolidationByGridAreaIdBatchDataLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/GridAreaByCodeBatchDataLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/GridAreaByCodeBatchDataLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/GridAreaByIdBatchDataLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/GridAreaByIdBatchDataLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/UserBatchDataLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/UserBatchDataLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/UserCacheDataLoader.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/DataLoaders/UserCacheDataLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/ActorDelegationStatus.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/ActorDelegationStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/ActorStatus.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/ActorStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/BalanceResponsibilityAgreementStatus.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/BalanceResponsibilityAgreementStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/BusinessReason.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/BusinessReason.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/CalculationExecutionType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/CalculationExecutionType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/CalculationProgressStep.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/CalculationProgressStep.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/GridAreaStatus.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/GridAreaStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/ImbalancePriceStatus.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/ImbalancePriceStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/NotificationType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/NotificationType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/PriceAreaCode.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/PriceAreaCode.cs
@@ -1,4 +1,4 @@
-﻿ // Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/ProcessStatus.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/ProcessStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/ProgressStatus.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/ProgressStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/RequestCalculationDataType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/RequestCalculationDataType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/SettlementReportStatusType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/SettlementReportStatusType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/SortDirection.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Enums/SortDirection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/CalculationTypeExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/CalculationTypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/EnumTypeExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/EnumTypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/MarketParticipantClientExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/MarketParticipantClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/MarketRoleExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/MarketRoleExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/TaskExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/TaskExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/TopicEventReceiverExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/TopicEventReceiverExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/WholesaleClientExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Extensions/WholesaleClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/ActorMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/ActorMutation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/CalculationMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/CalculationMutation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/EdiB2CMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/EdiB2CMutation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/EsettExchangeMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/EsettExchangeMutation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/MergeMarketParticipantsMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/MergeMarketParticipantsMutation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/NotificationMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/NotificationMutation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/OrganizationMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/OrganizationMutation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/PermissionMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/PermissionMutation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/SettlementReportMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/SettlementReportMutation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/TokenMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/TokenMutation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/UserMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/UserMutation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/UserRoleMutation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Mutation/UserRoleMutation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Operations/RequestOperations.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Operations/RequestOperations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/ActorQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/ActorQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/BalanceResponsibleQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/BalanceResponsibleQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/CalculationQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/CalculationQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/EsettExchangeQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/EsettExchangeQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/GridAreaQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/GridAreaQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/ImbalancePriceQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/ImbalancePriceQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/MessageArchiveQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/MessageArchiveQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/NotificationQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/NotificationQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/OrganizationQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/OrganizationQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/PermissionQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/PermissionQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/SettlementReportsQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/SettlementReportsQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/UserQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/UserQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/UserRoleQuery.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Query/UserRoleQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Resolvers/EsettExchangeResolvers.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Resolvers/EsettExchangeResolvers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Resolvers/GridAreaResolver.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Resolvers/GridAreaResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Resolvers/MarketParticipantResolvers.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Resolvers/MarketParticipantResolvers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Resolvers/MessageArchiveResolvers.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Resolvers/MessageArchiveResolvers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Resolvers/WholesaleResolvers.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Resolvers/WholesaleResolvers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Scalars/DateRangeType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Scalars/DateRangeType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Subscription/CalculationSubscription.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Subscription/CalculationSubscription.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Subscription/NotificationSubscription.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Subscription/NotificationSubscription.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorAuditLogType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorAuditLogType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorConsolidationActorAndDate.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorConsolidationActorAndDate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorConsolidationAuditLog.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorConsolidationAuditLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorCredentialsDtoType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorCredentialsDtoType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorDelegationAuditLog.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorDelegationAuditLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorNameWithId.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorNameWithId.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorPublicMail.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorPublicMail.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorStatusType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorStatusType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorUserRole.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/ActorUserRole.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/AssociatedActors.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/AssociatedActors.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/CreateActorGridAreaInput.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/CreateActorGridAreaInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/CreateActorInput.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/CreateActorInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/CreateActorMarketRoleInput.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/CreateActorMarketRoleInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/StopDelegationPeriodInput.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Actor/StopDelegationPeriodInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Balance/BalanceResponsibilityAgreement.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Balance/BalanceResponsibilityAgreement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Balance/BalanceResponsibilityMeteringPointType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Balance/BalanceResponsibilityMeteringPointType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Balance/BalanceResponsibleImport.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Balance/BalanceResponsibleImport.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Balance/BalanceResponsibleImportType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Balance/BalanceResponsibleImportType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Balance/BalanceResponsiblePageResultType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Balance/BalanceResponsiblePageResultType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Balance/BalanceResponsibleType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Balance/BalanceResponsibleType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/CVROrganizationResult.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/CVROrganizationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationProgress.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationProgress.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationQueryInput.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationQueryInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationSortType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationSortType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Calculation/CalculationType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/CreateMarketParticipantInput.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/CreateMarketParticipantInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/EicFunctionType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/EicFunctionType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ExchangeEvent/EsettExchangeEventType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ExchangeEvent/EsettExchangeEventType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ExchangeEvent/EsettTimeSeriesType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ExchangeEvent/EsettTimeSeriesType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ExchangeEvent/ExchangeEventCalculationType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ExchangeEvent/ExchangeEventCalculationType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ExchangeEvent/ExchangeEventSearchResultType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ExchangeEvent/ExchangeEventSearchResultType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ExchangeEvent/ManuallyHandledExchangeEventMetaDataType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ExchangeEvent/ManuallyHandledExchangeEventMetaDataType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaAuditedChangeAuditLogDtoType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaAuditedChangeAuditLogDtoType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaDto.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaDto.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaDtoType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaDtoType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaEnumType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaEnumType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaOverviewItemDto.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaOverviewItemDto.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaOverviewItemDtoType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaOverviewItemDtoType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaStatusType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/GridAreaStatusType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/IGridArea.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/GridArea/IGridArea.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ImbalancePrice/ImbalancePrice.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ImbalancePrice/ImbalancePrice.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ImbalancePrice/ImbalancePriceDaily.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ImbalancePrice/ImbalancePriceDaily.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ImbalancePrice/ImbalancePricePeriod.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ImbalancePrice/ImbalancePricePeriod.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ImbalancePrice/ImbalancePricesOverview.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ImbalancePrice/ImbalancePricesOverview.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ImbalancePrice/ImbalancePricesOverviewType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ImbalancePrice/ImbalancePricesOverviewType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/MessageArchive/ArchivedMessageSortInput.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/MessageArchive/ArchivedMessageSortInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/MessageArchive/ArchivedMessageSortInputType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/MessageArchive/ArchivedMessageSortInputType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/MessageArchive/ArchivedMessageType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/MessageArchive/ArchivedMessageType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/MessageArchive/DocumentTypeType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/MessageArchive/DocumentTypeType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/MessageDelegationType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/MessageDelegationType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Metering/MeteringGridAreaImbalanceSearchResultType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Metering/MeteringGridAreaImbalanceSearchResultType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Metering/MeteringPointType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Metering/MeteringPointType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Notification/NotificationDtoType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Notification/NotificationDtoType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Notification/NotificationEnumType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Notification/NotificationEnumType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Option/Option.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Option/Option.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Orchestration/IOrchestration.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Orchestration/IOrchestration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Orchestration/OrchestrationInstance.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Orchestration/OrchestrationInstance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Orchestration/OrchestrationLifeCycleType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Orchestration/OrchestrationLifeCycleType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Orchestration/OrchestrationType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Orchestration/OrchestrationType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Organization/OrganizationAuditedChangeAuditLogDtoType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Organization/OrganizationAuditedChangeAuditLogDtoType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Organization/OrganizationType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Organization/OrganizationType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Permission/FilteredPermissionsExtension.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Permission/FilteredPermissionsExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Permission/PermissionAuditedChangeAuditLogDtoType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Permission/PermissionAuditedChangeAuditLogDtoType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Permission/PermissionType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Permission/PermissionType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Permission/PermissionsDto.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Permission/PermissionsDto.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Permission/PermissionsType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Permission/PermissionsType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Permission/UserRoleWithPermissionsDtoType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Permission/UserRoleWithPermissionsDtoType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Process/CreateProcessDelegationsInput.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Process/CreateProcessDelegationsInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Process/ProcessDelegation.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Process/ProcessDelegation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Process/ProcessStatusType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Process/ProcessStatusType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ProgressStatusType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/ProgressStatusType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Request/IRequest.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Request/IRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Request/RequestAggregatedMeasureData.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Request/RequestAggregatedMeasureData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Request/RequestAggregatedMeasureDataType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Request/RequestAggregatedMeasureDataType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Request/RequestSortType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Request/RequestSortType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Request/RequestWholesaleSettlement.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Request/RequestWholesaleSettlement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Request/RequestWholesaleSettlementType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/Request/RequestWholesaleSettlementType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/CancelSettlementReportInput.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/CancelSettlementReportInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/RequestSettlementReportGridAreaCalculations.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/RequestSettlementReportGridAreaCalculations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/RequestSettlementReportGridAreaCalculationsType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/RequestSettlementReportGridAreaCalculationsType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/RequestSettlementReportGridAreaInput.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/RequestSettlementReportGridAreaInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/RequestSettlementReportInput.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/RequestSettlementReportInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/SettlementReport.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/SettlementReport.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/SettlementReportType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/SettlementReports/SettlementReportType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/GetUserResponse.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/GetUserResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/GetUserResponseType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/GetUserResponseType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/IUser.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/IUser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/SortDirectionType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/SortDirectionType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/UserOverviewItemDto.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/UserOverviewItemDto.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/UserOverviewItemDtoType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/UserOverviewItemDtoType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/UserOverviewSortPropertyType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/UserOverviewSortPropertyType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/UsersSortInput.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/UsersSortInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/UsersSortInputType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/User/UsersSortInputType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/UserAudit/UserAuditedChangeAuditLogDtoType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/UserAudit/UserAuditedChangeAuditLogDtoType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/UserAudit/UserRoleAuditedChangeAuditLogDtoType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/UserAudit/UserRoleAuditedChangeAuditLogDtoType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/UserRole/UpdateActorUserRoles.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/UserRole/UpdateActorUserRoles.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/UserRole/UserRoleSortType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/GraphQL/Types/UserRole/UserRoleSortType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Program.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Properties/ModuleInfo.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Properties/ModuleInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Properties/launchSettings.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,

--- a/apps/dh/api-dh/source/DataHub.WebApi/Registration/DomainRegistrationExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Registration/DomainRegistrationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Registration/GraphQLRegistrationExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Registration/GraphQLRegistrationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Registration/HealthEndpointRegistrationExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Registration/HealthEndpointRegistrationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/Registration/SwaggerRegistrationExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Registration/SwaggerRegistrationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/DataHub.WebApi/RequireNonNullablePropertiesSchemaFilter.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/RequireNonNullablePropertiesSchemaFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Energinet DataHub A/S
+// Copyright 2020 Energinet DataHub A/S
 //
 // Licensed under the Apache License, Version 2.0 (the "License2");
 // you may not use this file except in compliance with the License.

--- a/apps/dh/api-dh/source/stylecop.json
+++ b/apps/dh/api-dh/source/stylecop.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "orderingRules": {


### PR DESCRIPTION
Having multiple forms of encoding in the same repo is weird and causes issues with editors that are not owned by M$ 😄 The `utf8-bom` rule is outdated and basically all editors default to utf8 (without bom). Yes, even Visual Studio. Also, the aspnetcore repository doesn't even use `utf8-bom` in their [`.editorconfig`](https://github.com/dotnet/aspnetcore/blob/49df2e6c7207f6845b671b29e17d58d91edd6e93/.editorconfig#L18).

Also [this](https://stackoverflow.com/questions/2223882/whats-the-difference-between-utf-8-and-utf-8-with-bom/2223926#2223926).

And [this](https://www.rfc-editor.org/rfc/rfc7159#section-8.1).