### PR TITLE
fix(eo, signin-callback): update isMitIDErhverv logic

### DIFF
--- a/libs/eo/onboarding/shell/signin-callback.component.ts
+++ b/libs/eo/onboarding/shell/signin-callback.component.ts
@@ -65,7 +65,9 @@ export class EoSigninCallbackComponent implements OnInit {
   private readonly transloco = inject(TranslocoService);
 
   errorDescription = input<string>('', { alias: 'error_description' });
-  protected readonly isMitIDErhverv = computed(() => !this.errorDescription().startsWith('AADB2C90273'));
+  protected readonly isMitIDErhverv = computed(
+    () => !this.errorDescription().startsWith('AADB2C90273')
+  );
 
   protected readonly translations = translations;
 

--- a/libs/eo/onboarding/shell/signin-callback.component.ts
+++ b/libs/eo/onboarding/shell/signin-callback.component.ts
@@ -65,7 +65,7 @@ export class EoSigninCallbackComponent implements OnInit {
   private readonly transloco = inject(TranslocoService);
 
   errorDescription = input<string>('', { alias: 'error_description' });
-  protected readonly isMitIDErhverv = computed(() => this.errorDescription() !== 'AADB2C90273');
+  protected readonly isMitIDErhverv = computed(() => !this.errorDescription().startsWith('AADB2C90273'));
 
   protected readonly translations = translations;
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This pull request includes a small but important change to the `EoSigninCallbackComponent` class in the `libs/eo/onboarding/shell/signin-callback.component.ts` file. The change modifies the logic used to determine if an error description indicates a MitID Erhverv error.

* [`libs/eo/onboarding/shell/signin-callback.component.ts`](diffhunk://#diff-00e15509bc7bcaf80f056d54a2a8d93efc5eedc6dc717f69644f3437d808b554L68-R68): Updated the `isMitIDErhverv` computed property to use `startsWith` instead of a strict comparison for detecting the 'AADB2C90273' error code.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#3599](https://github.com/Energinet-DataHub/energy-origin-issues/issues/3599)
