### PR TITLE
fix(watt): set end value in range date picker only when complete date is entered

### DIFF
--- a/libs/watt/src/lib/components/picker/datepicker/watt-datepicker.component.ts
+++ b/libs/watt/src/lib/components/picker/datepicker/watt-datepicker.component.ts
@@ -20,7 +20,6 @@ import { FormatWidth, getLocaleDateFormat } from '@angular/common';
 import {
   ChangeDetectorRef,
   Component,
-  DestroyRef,
   ElementRef,
   Input,
   LOCALE_ID,
@@ -92,7 +91,6 @@ export class WattDatepickerComponent extends WattPickerBase implements Validator
   protected override ngControl = inject(NgControl, { optional: true, self: true });
   private localeService = inject(WattLocaleService);
   private locale: WattSupportedLocales = inject(LOCALE_ID) as WattSupportedLocales;
-  private destroyRef = inject(DestroyRef);
 
   max = input<Date>();
   min = input<Date>();
@@ -289,16 +287,20 @@ export class WattDatepickerComponent extends WattPickerBase implements Validator
 
   rangeInputChanged(value: string) {
     const startDateString = value.slice(0, this.datePlaceholder.length);
+
     if (startDateString.length === 0) {
       this.control?.setValue(null);
       return;
     }
+
     if (startDateString.length !== this.datePlaceholder.length) {
       return;
     }
+
     const start = this.parseDateShortFormat(startDateString);
     const endDateString = value.slice(this.datePlaceholder.length + this.rangeSeparator.length);
     let end = this.setEndDateToDanishTimeZone(endDateString);
+
     if (end !== null) {
       end = this.setToEndOfDay(end);
       this.control?.setValue({ start, end });
@@ -381,13 +383,6 @@ export class WattDatepickerComponent extends WattPickerBase implements Validator
   /**
    * @ignore
    */
-  private parseISO8601Format(value: string): Date {
-    return dayjs(value).toDate();
-  }
-
-  /**
-   * @ignore
-   */
   private setValueToInput<D extends { value: Date | null }>(
     value: string | null | undefined,
     nativeInput: HTMLInputElement,
@@ -431,14 +426,11 @@ export class WattDatepickerComponent extends WattPickerBase implements Validator
    */
   private setEndDateToDanishTimeZone(value: string): Date | null {
     const dateBasedOnShortFormat = this.parseDateShortFormat(value);
-    const dateBasedOnISO8601Format = this.parseISO8601Format(value);
 
     let maybeDateInDanishTimeZone: Date | null = null;
 
     if (dayjs(dateBasedOnShortFormat).isValid()) {
       maybeDateInDanishTimeZone = this.toDanishTimeZone(dateBasedOnShortFormat);
-    } else if (dayjs(dateBasedOnISO8601Format).isValid()) {
-      maybeDateInDanishTimeZone = this.toDanishTimeZone(dateBasedOnISO8601Format);
     }
 
     return maybeDateInDanishTimeZone;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### Watt Design System
- when a datepicker was in "range" mode, the end date was set continiously during input. This was problematic because the component emitted multiple values - on each keystroke - which resulted in wrong end date. The change here ensures that the component emits only when the end date is fully typed.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
