### PR TITLE
feat(dh): create empty metering point search page

### DIFF
--- a/libs/dh/core/routing/src/dhPaths.ts
+++ b/libs/dh/core/routing/src/dhPaths.ts
@@ -41,7 +41,12 @@ const wholesaleSubPaths = {
   settlementReports: 'settlement-reports',
 } as const;
 
+const meteringPointSubPaths = {
+  search: 'search',
+} as const;
+
 const basePaths = {
+  meteringPointBasePath: 'metering-point',
   marketParticipantBasePath: 'market-participant',
   messageArchiveBasePath: 'message-archive',
   esettBasePath: 'esett',
@@ -62,9 +67,17 @@ export type ESettSubPaths = (typeof eSettSubPaths)[keyof typeof eSettSubPaths];
 
 export type WholesaleSubPaths = (typeof wholesaleSubPaths)[keyof typeof wholesaleSubPaths];
 
+export type MeteringPointSubPaths =
+  (typeof meteringPointSubPaths)[keyof typeof meteringPointSubPaths];
+
 export type AdminSubPaths = (typeof adminSubPaths)[keyof typeof adminSubPaths];
 
-type SubPaths = MarketParticipantSubPaths | ESettSubPaths | WholesaleSubPaths | AdminSubPaths;
+type SubPaths =
+  | MarketParticipantSubPaths
+  | ESettSubPaths
+  | WholesaleSubPaths
+  | AdminSubPaths
+  | MeteringPointSubPaths;
 
 export const getPath = <T extends BasePaths | SubPaths>(route: T) => route;
 

--- a/libs/dh/core/shell/src/lib/dh-core-shell.routes.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.routes.ts
@@ -40,6 +40,11 @@ export const dhCoreShellRoutes: Routes = [
         canActivate: [MsalGuard],
       },
       {
+        path: getPath<BasePaths>('metering-point'),
+        loadChildren: () => import('@energinet-datahub/dh/metering-point/feature-search'),
+        canActivate: [MsalGuard],
+      },
+      {
         path: getPath<BasePaths>('esett'),
         loadChildren: () => import('@energinet-datahub/dh/esett/shell'),
         canActivate: [MsalGuard],

--- a/libs/dh/core/shell/src/lib/dh-primary-navigation.component.html
+++ b/libs/dh/core/shell/src/lib/dh-primary-navigation.component.html
@@ -16,6 +16,12 @@ limitations under the License.
 -->
 <ng-container *transloco="let transloco; read: 'sidebar.navigation'">
   <watt-nav-list>
+    <ng-container *dhFeatureFlag="'metering-point'">
+      <watt-nav-list-item *dhPermissionRequired="['fas']" [link]="getLink('metering-point')">{{
+        transloco("meteringPoints")
+      }}</watt-nav-list-item>
+    </ng-container>
+
     <watt-nav-list-item [link]="getLink('message-archive')">{{
       transloco("messageArchive")
     }}</watt-nav-list-item>

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -162,6 +162,7 @@
   },
   "sidebar": {
     "navigation": {
+      "meteringPoints": "Målepunkter",
       "messageArchive": "Fremsøg forretningsbesked",
       "marketParticipantActors": "Aktører",
       "marketParticipantOrganizations": "Organisationer",
@@ -181,6 +182,9 @@
         "userManagement": "Brugeradministration"
       }
     }
+  },
+  "meteringPoint": {
+    "topBarTitle": "Målepunkter"
   },
   "messageArchive": {
     "topBarTitle": "Fremsøg forretningsbesked",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -162,6 +162,7 @@
   },
   "sidebar": {
     "navigation": {
+      "meteringPoints": "Metering Points",
       "messageArchive": "Request/Response messages",
       "marketParticipantActors": "Actors",
       "marketParticipantOrganizations": "Organisations",
@@ -181,6 +182,9 @@
         "userManagement": "User Management"
       }
     }
+  },
+  "meteringPoint": {
+    "topBarTitle": "Metering Points"
   },
   "messageArchive": {
     "topBarTitle": "Search in request and response messages",

--- a/libs/dh/metering-point/feature-search/src/index.ts
+++ b/libs/dh/metering-point/feature-search/src/index.ts
@@ -16,4 +16,4 @@
  * limitations under the License.
  */
 //#endregion
-export {};
+export { dhMeteringPointRoutes as default } from './lib/dh-metering-point.routes';

--- a/libs/dh/metering-point/feature-search/src/lib/dh-metering-point.routes.ts
+++ b/libs/dh/metering-point/feature-search/src/lib/dh-metering-point.routes.ts
@@ -1,0 +1,45 @@
+//#region License
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//#endregion
+import { Routes } from '@angular/router';
+
+import { PermissionGuard } from '@energinet-datahub/dh/shared/feature-authorization';
+import { getPath, MeteringPointSubPaths } from '@energinet-datahub/dh/core/routing';
+
+import { DhSearchComponent } from './dh-search.component';
+
+export const dhMeteringPointRoutes: Routes = [
+  {
+    path: '',
+    canActivate: [PermissionGuard(['fas'])],
+    data: {
+      titleTranslationKey: 'meteringPoint.topBarTitle',
+    },
+    children: [
+      {
+        path: '',
+        pathMatch: 'full',
+        redirectTo: getPath<MeteringPointSubPaths>('search'),
+      },
+      {
+        path: getPath<MeteringPointSubPaths>('search'),
+        component: DhSearchComponent,
+      },
+    ],
+  },
+];

--- a/libs/dh/metering-point/feature-search/src/lib/dh-metering-point.routes.ts
+++ b/libs/dh/metering-point/feature-search/src/lib/dh-metering-point.routes.ts
@@ -16,17 +16,23 @@
  * limitations under the License.
  */
 //#endregion
-import { Routes } from '@angular/router';
+import { Router, Routes } from '@angular/router';
+import { inject } from '@angular/core';
 
 import { PermissionGuard } from '@energinet-datahub/dh/shared/feature-authorization';
 import { getPath, MeteringPointSubPaths } from '@energinet-datahub/dh/core/routing';
+import { DhFeatureFlagsService } from '@energinet-datahub/dh/shared/feature-flags';
 
 import { DhSearchComponent } from './dh-search.component';
 
 export const dhMeteringPointRoutes: Routes = [
   {
     path: '',
-    canActivate: [PermissionGuard(['fas'])],
+    canActivate: [
+      PermissionGuard(['fas']),
+      () =>
+        inject(DhFeatureFlagsService).isEnabled('metering-point') || inject(Router).parseUrl('/'),
+    ],
     data: {
       titleTranslationKey: 'meteringPoint.topBarTitle',
     },

--- a/libs/dh/metering-point/feature-search/src/lib/dh-search.component.ts
+++ b/libs/dh/metering-point/feature-search/src/lib/dh-search.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'dh-search',
+  template: '',
+})
+export class DhSearchComponent {}

--- a/libs/dh/metering-point/feature-search/src/lib/dh-search.component.ts
+++ b/libs/dh/metering-point/feature-search/src/lib/dh-search.component.ts
@@ -1,3 +1,21 @@
+//#region License
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//#endregion
 import { Component } from '@angular/core';
 
 @Component({

--- a/libs/dh/shared/feature-flags/src/lib/dh-feature-flags.ts
+++ b/libs/dh/shared/feature-flags/src/lib/dh-feature-flags.ts
@@ -25,7 +25,7 @@ export type DhFeatureFlag = {
 
 export type FeatureFlagConfig = Record<string, DhFeatureFlag>;
 
-const latestBump = '20-11-2024';
+const latestBump = '21-01-2025';
 
 /**
  * Feature flag example:

--- a/libs/dh/shared/feature-flags/src/lib/dh-feature-flags.ts
+++ b/libs/dh/shared/feature-flags/src/lib/dh-feature-flags.ts
@@ -66,6 +66,10 @@ export const dhFeatureFlagsConfig = {
       DhAppEnvironment.prod,
     ],
   },
+  'metering-point': {
+    created: latestBump,
+    disabledEnvironments: [DhAppEnvironment.preprod, DhAppEnvironment.prod],
+  },
 } satisfies FeatureFlagConfig;
 
 export type DhFeatureFlags = keyof typeof dhFeatureFlagsConfig;


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### DataHub
- empty metering point search page
- routing setup
- add metering point feature flag
- bump feature flag date

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
