### PR TITLE
refac: Send user "roles" as part of OperatingIdentity

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi/Extensions/HttpContextAccessorExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Extensions/HttpContextAccessorExtensions.cs
@@ -29,11 +29,13 @@ public static class HttpContextAccessorExtensions
         var userId = httpContextAccessor.HttpContext.User.GetUserId();
         var actorNumber = httpContextAccessor.HttpContext.User.GetActorNumber();
         var actorRole = httpContextAccessor.HttpContext.User.GetActorMarketRole();
+        var roles = httpContextAccessor.HttpContext.User.GetRoles();
 
         return new UserIdentityDto(
             UserId: userId,
             ActorNumber: ActorNumber.Create(actorNumber),
-            ActorRole: ActorRole.FromName(actorRole));
+            ActorRole: ActorRole.FromName(actorRole),
+            UserPermissions: roles);
     }
 
     public static Guid GetAssociatedActorId(this IHttpContextAccessor httpContextAccessor)

--- a/apps/dh/api-dh/source/DataHub.WebApi/Extensions/HttpContextUserExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Extensions/HttpContextUserExtensions.cs
@@ -49,6 +49,14 @@ public static class HttpContextUserExtensions
         return user.Claims.Any(c => c.Type == ClaimTypes.Role && c.Value == role);
     }
 
+    public static IReadOnlyCollection<string> GetRoles(this ClaimsPrincipal user)
+    {
+        return user.Claims
+            .Where(c => c.Type == ClaimTypes.Role)
+            .Select(c => c.Value)
+            .ToList();
+    }
+
     public static string GetActorNumber(this ClaimsPrincipal user)
     {
         return user.Claims.First(c => c is { Type: ClaimNames.ActorNumber }).Value;

--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/ProcessManager/Requests/Client/RequestsClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/ProcessManager/Requests/Client/RequestsClient.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using Energinet.DataHub.ProcessManager.Client;
-using Energinet.DataHub.ProcessManager.Components.Abstractions.ValueObjects;
 using Energinet.DataHub.ProcessManager.Orchestrations.Abstractions.Processes.BRS_026_028.CustomQueries;
 using Energinet.DataHub.WebApi.Extensions;
 


### PR DESCRIPTION
## Description

- [x] Extract roles from token and send as part of `OperatingIdentity` (`UserIdentityDto`)

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
