### PR TITLE
fix(dh): spammy calculation subscription

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/ProcessManager/Calculations/CalculationOperations.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/ProcessManager/Calculations/CalculationOperations.cs
@@ -19,7 +19,6 @@ using Energinet.DataHub.WebApi.Modules.Common;
 using Energinet.DataHub.WebApi.Modules.ProcessManager.Calculations.Client;
 using Energinet.DataHub.WebApi.Modules.ProcessManager.Calculations.Enums;
 using Energinet.DataHub.WebApi.Modules.ProcessManager.Calculations.Models;
-using Energinet.DataHub.WebApi.Modules.ProcessManager.Calculations.Types;
 using Energinet.DataHub.WebApi.Modules.ProcessManager.Types;
 using HotChocolate.Authorization;
 using HotChocolate.Subscriptions;
@@ -130,10 +129,8 @@ public static partial class CalculationOperations
         ICalculationsClient client,
         CancellationToken ct)
     {
-        // TODO: This needs to only search for calculations that are in progress
-        var input = new CalculationsQueryInput() { };
         return Observable
-            .FromAsync(() => client.QueryCalculationsAsync(input))
+            .FromAsync(() => client.GetNonTerminatedCalculationsAsync(ct))
             .SelectMany(calculations => calculations)
             .Select(calculation => calculation.Id)
             .Merge(eventReceiver.Observe<Guid>(nameof(CreateCalculationAsync), ct))

--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/ProcessManager/Calculations/Client/ICalculationsClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/ProcessManager/Calculations/Client/ICalculationsClient.cs
@@ -51,4 +51,10 @@ public interface ICalculationsClient
     Task<bool> CancelScheduledCalculationAsync(
         Guid calculationId,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Get all non-terminated calculations in the Process Manager.
+    /// </summary>
+    Task<IEnumerable<IOrchestrationInstanceTypedDto<ICalculation>>> GetNonTerminatedCalculationsAsync(
+        CancellationToken ct = default);
 }


### PR DESCRIPTION
The subscription for calculation was fetching all calculations upon initial subscription, causing a metric buttload of requests to the process manager. This change should remedy the spamming of "getById" requests.