### PR TITLE
fix(dh): enable metering point page only for users with right permission

### DIFF
--- a/libs/dh/core/shell/src/lib/dh-primary-navigation.component.html
+++ b/libs/dh/core/shell/src/lib/dh-primary-navigation.component.html
@@ -25,7 +25,7 @@ limitations under the License.
   <watt-nav-list>
     <ng-container *dhFeatureFlag="'metering-point'">
       <watt-nav-list-item
-        *dhPermissionRequired="['fas', 'metering-point:search']"
+        *dhPermissionRequired="['metering-point:search']"
         [link]="getLink('metering-point')"
         >{{ transloco("meteringPoints") }}</watt-nav-list-item
       >

--- a/libs/dh/metering-point/feature-search/src/lib/dh-metering-point.routes.ts
+++ b/libs/dh/metering-point/feature-search/src/lib/dh-metering-point.routes.ts
@@ -31,7 +31,7 @@ export const dhMeteringPointRoutes: Routes = [
   {
     path: '',
     canActivate: [
-      PermissionGuard(['fas', 'metering-point:search']),
+      PermissionGuard(['metering-point:search']),
       () =>
         inject(DhFeatureFlagsService).isEnabled('metering-point') || inject(Router).parseUrl('/'),
     ],


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
