### PR TITLE
refac: remove importProvidersFrom for MatDialog and MatSnackBar

### DIFF
--- a/docs/dh/testing.md
+++ b/docs/dh/testing.md
@@ -50,20 +50,6 @@ async function setup() {
 };
 ```
 
-#### When the feature under test uses toast(s)
-
-In this case import `MatSnackBarModule` function in the testing setup. This will make sure that the base API is configured correctly. For example:
-
-```ts
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-
-async function setup() {
-  await render(MyComponent.name, {
-    providers: [importProvidersFrom(MatSnackBarModule)],
-  }
-};
-```
-
 #### When the feature under test sends requests to the BFF
 
 In this case import `HttpClientModule` in the test setup. This will make sure that the base API is configured correctly. For example:

--- a/libs/dh/core/shell/src/lib/dh-core-shell.component.spec.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.component.spec.ts
@@ -21,8 +21,6 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { HttpClientModule } from '@angular/common/http';
 import { render, RenderResult } from '@testing-library/angular';
 import { ApolloModule } from 'apollo-angular';
-import { importProvidersFrom } from '@angular/core';
-import { MatDialogModule } from '@angular/material/dialog';
 
 import { graphQLProviders } from '@energinet-datahub/dh/shared/data-access-graphql';
 
@@ -43,7 +41,6 @@ describe(DhCoreShellComponent, () => {
         WattModalService,
         provideHttpClientTesting(),
         graphQLProviders,
-        importProvidersFrom([MatDialogModule]),
       ],
     });
   });

--- a/libs/dh/core/shell/src/lib/dh-core-shell.providers.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.providers.ts
@@ -18,7 +18,6 @@
 //#endregion
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { importProvidersFrom } from '@angular/core';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import {
   MsalInterceptor,
   MsalService,
@@ -28,7 +27,6 @@ import {
   MsalGuard,
   MsalBroadcastService,
 } from '@azure/msal-angular';
-import { MatDialogModule } from '@angular/material/dialog';
 import { FormGroupDirective } from '@angular/forms';
 import { IPublicClientApplication } from '@azure/msal-browser';
 import { of } from 'rxjs';
@@ -109,7 +107,7 @@ const msalProviders = [
 ];
 
 export const dhCoreShellProviders = [
-  importProvidersFrom([MatDialogModule, MatSnackBarModule, ApolloModule]),
+  importProvidersFrom([ApolloModule]),
   FormGroupDirective,
   environment.production ? applicationInsightsProviders : [],
   dhWattTranslationsProviders,

--- a/libs/dh/wholesale/feature-calculations/src/lib/calculations.cy.ts
+++ b/libs/dh/wholesale/feature-calculations/src/lib/calculations.cy.ts
@@ -18,14 +18,12 @@
 //#endregion
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
-import { importProvidersFrom } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ApolloModule } from 'apollo-angular';
 import { FormGroupDirective } from '@angular/forms';
 
 import { danishDatetimeProviders } from '@energinet-datahub/watt/danish-date-time';
 import { da as daTranslations } from '@energinet-datahub/dh/globalization/assets-localization';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { graphQLProviders } from '@energinet-datahub/dh/shared/data-access-graphql';
 import { translocoProviders } from '@energinet-datahub/dh/globalization/configuration-localization';
 import { MsalServiceMock } from '@energinet-datahub/dh/shared/test-util';
@@ -37,7 +35,6 @@ const { calculations } = daTranslations.wholesale;
 it.skip('mounts', () => {
   cy.mount(DhCalculationsComponent, {
     providers: [
-      importProvidersFrom(MatSnackBarModule),
       graphQLProviders,
       translocoProviders,
       danishDatetimeProviders,

--- a/libs/eo/core/shell/src/lib/eo-core-shell.providers.ts
+++ b/libs/eo/core/shell/src/lib/eo-core-shell.providers.ts
@@ -16,9 +16,6 @@
  * limitations under the License.
  */
 //#endregion
-import { importProvidersFrom } from '@angular/core';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { TitleStrategy } from '@angular/router';
 
 import { translocoProviders } from '@energinet-datahub/eo/globalization/configuration-localization';
@@ -42,7 +39,6 @@ export const eoCoreShellProviders = [
   browserConfigurationProviders,
   danishLocalProviders,
   danishDatetimeProviders,
-  importProvidersFrom(MatDialogModule, MatSnackBarModule),
   eoAuthorizationInterceptorProvider,
   eoOrganizationIdInterceptorProvider,
   eoApiVersioningInterceptorProvider,

--- a/libs/watt/package/clipboard/+storybook/watt-clipboard.stories.ts
+++ b/libs/watt/package/clipboard/+storybook/watt-clipboard.stories.ts
@@ -18,8 +18,6 @@
 //#endregion
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { moduleMetadata, StoryFn, Meta, applicationConfig } from '@storybook/angular';
-import { importProvidersFrom } from '@angular/core';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { WattCopyToClipboardDirective } from '../watt-copy-to-clipboard.directive';
 import { WattStorybookClipboardComponent } from './storybook-clipboard.component';
@@ -28,7 +26,7 @@ const meta: Meta<WattCopyToClipboardDirective> = {
   title: 'Components/Clipboard',
   decorators: [
     applicationConfig({
-      providers: [importProvidersFrom(MatSnackBarModule), provideAnimations()],
+      providers: [provideAnimations()],
     }),
     moduleMetadata({
       imports: [WattStorybookClipboardComponent],

--- a/libs/watt/package/clipboard/watt-copy-to-clipboard.directive.spec.ts
+++ b/libs/watt/package/clipboard/watt-copy-to-clipboard.directive.spec.ts
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 //#endregion
-import { importProvidersFrom } from '@angular/core';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
@@ -26,7 +24,6 @@ import { WattCopyToClipboardDirective } from './watt-copy-to-clipboard.directive
 describe(WattCopyToClipboardDirective, () => {
   it('shows toast on click', async () => {
     await render(`<span wattCopyToClipboard>Text</span>`, {
-      providers: [importProvidersFrom(MatSnackBarModule)],
       imports: [WattCopyToClipboardDirective],
     });
 

--- a/libs/watt/package/toast/+storybook/watt-toast.stories.ts
+++ b/libs/watt/package/toast/+storybook/watt-toast.stories.ts
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 //#endregion
-import { importProvidersFrom } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { moduleMetadata, StoryFn, Meta, applicationConfig } from '@storybook/angular';
 
 import { WattToastConfig } from '../watt-toast.component';
@@ -28,7 +26,7 @@ const meta: Meta<StorybookToastComponent> = {
   title: 'Components/Toast',
   decorators: [
     applicationConfig({
-      providers: [importProvidersFrom(MatSnackBarModule), provideAnimations()],
+      providers: [provideAnimations()],
     }),
     moduleMetadata({
       imports: [StorybookToastComponent],


### PR DESCRIPTION
https://dev.to/this-is-angular/you-dont-need-importprovidersfrom-with-angular-material-3nih