### PR TITLE
chore: update HotChocolate to v15

### DIFF
--- a/.github/workflows/dh-ci-dotnet.yml
+++ b/.github/workflows/dh-ci-dotnet.yml
@@ -29,7 +29,6 @@ jobs:
     with:
       solution_file_path: apps/dh/api-dh/DataHub.WebApi.sln
       release_name_prefix: ui_dotnet
-      dotnet-version: '8.0.4xx'
 
   # Run tests in 'Tests.dll' except TelemetryTests
   dotnet_ci_test_except_telemetry:

--- a/.github/workflows/dh-ci-dotnet.yml
+++ b/.github/workflows/dh-ci-dotnet.yml
@@ -29,6 +29,7 @@ jobs:
     with:
       solution_file_path: apps/dh/api-dh/DataHub.WebApi.sln
       release_name_prefix: ui_dotnet
+      dotnet-version: '8.0.4xx'
 
   # Run tests in 'Tests.dll' except TelemetryTests
   dotnet_ci_test_except_telemetry:

--- a/.github/workflows/dh-ci-frontend.yml
+++ b/.github/workflows/dh-ci-frontend.yml
@@ -32,6 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+
       - name: Bun setup
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -213,6 +213,9 @@ jobs:
         if: ${{ env.is-pull-request == 'false' }}
         uses: actions/checkout@v4
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+
       - name: Bun setup
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -67,6 +67,9 @@ jobs:
         if: ${{ env.is-pull-request == 'false' }}
         uses: actions/checkout@v4
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+
       - name: Bun setup
         uses: oven-sh/setup-bun@v2
         with:
@@ -104,6 +107,9 @@ jobs:
       - name: "Merge: Check out source code"
         if: ${{ env.is-pull-request == 'false' }}
         uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
 
       - name: Bun setup
         uses: oven-sh/setup-bun@v2
@@ -257,6 +263,9 @@ jobs:
         if: ${{ env.is-pull-request == 'false' }}
         uses: actions/checkout@v4
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+
       - name: Bun setup
         uses: oven-sh/setup-bun@v2
         with:
@@ -294,6 +303,9 @@ jobs:
       - name: "Merge: Check out source code"
         if: ${{ env.is-pull-request == 'false' }}
         uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
 
       - name: Bun setup
         uses: oven-sh/setup-bun@v2

--- a/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -59,19 +59,20 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.ProcessManager.Client" Version="2.1.1" />
     <PackageReference Include="Energinet.DataHub.ProcessManager.Orchestrations.Abstractions" Version="1.11.2" />
     <PackageReference Include="Energinet.DataHub.RevisionLog.Integration" Version="1.1.5" />
-    <PackageReference Include="HotChocolate.AspNetCore" Version="14.2.0" />
-    <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="14.2.0" />
-    <PackageReference Include="HotChocolate.AspNetCore.CommandLine" Version="14.2.0" />
-    <PackageReference Include="HotChocolate.Data" Version="14.2.0" />
-    <PackageReference Include="HotChocolate.Diagnostics" Version="14.2.0" />
-    <PackageReference Include="HotChocolate.Types.Analyzers" Version="14.2.0">
+    <PackageReference Include="HotChocolate.AspNetCore" Version="15.1.3" />
+    <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="15.1.3" />
+    <PackageReference Include="HotChocolate.AspNetCore.CommandLine" Version="15.1.3" />
+    <PackageReference Include="HotChocolate.Data" Version="15.1.3" />
+    <PackageReference Include="HotChocolate.Diagnostics" Version="15.1.3" />
+    <PackageReference Include="HotChocolate.Types.Analyzers" Version="15.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="HotChocolate.Types.NodaTime" Version="15.1.3" />
+    <PackageReference Include="HotChocolate.Types.OffsetPagination" Version="15.1.3" />
     <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="14.0.1" />
     <PackageReference Include="Energinet.DataHub.MessageArchive.Client" Version="2.0.8" />
     <PackageReference Include="Energinet.DataHub.MessageArchive.Client.Abstractions" Version="2.0.8" />
-    <PackageReference Include="HotChocolate.Types.NodaTime" Version="14.2.0" />
     <PackageReference Include="Microsoft.FeatureManagement" Version="4.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">

--- a/apps/dh/api-dh/source/DataHub.WebApi/Registration/GraphQLRegistrationExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Registration/GraphQLRegistrationExtensions.cs
@@ -17,7 +17,6 @@ using Energinet.DataHub.WebApi.GraphQL.Query;
 using Energinet.DataHub.WebApi.GraphQL.Scalars;
 using Energinet.DataHub.WebApi.GraphQL.Subscription;
 using HotChocolate.Execution.Configuration;
-using HotChocolate.Types.NodaTime;
 using NodaTime;
 
 namespace Energinet.DataHub.WebApi.Registration;
@@ -39,7 +38,7 @@ public static class GraphQLRegistrationExtensions
             .AddTypes()
             .AddModules()
             .AddSorting()
-            .AddType<LocalDateType>()
+            .AddType<HotChocolate.Types.NodaTime.LocalDateType>()
             .BindRuntimeType<Interval, DateRangeType>()
             .ModifyOptions(options =>
             {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "8.0.407",
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "8.0.400",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
The update apparently required a later version of the dotnet sdk than was specified in the `global.json` file. So I updated it to the latest version (same as I was running on my own machine). But this wasn't enough, as I also had to the setup-dotnet actions to our frontend ci (since they rely on dotnet during the generate phase). It should have probably been there from the start, but since the runner comes with dotnet preinstalled (at version 8.0.1xx something), it didn't fail (until now).