### PR TITLE
fix(watt): make YearField and YearMonthField close popover correctly in chromium browsers

### DIFF
--- a/libs/watt/package/package.json
+++ b/libs/watt/package/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@energinet/watt",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/libs/watt/package/year-field/watt-year-field.component.ts
+++ b/libs/watt/package/year-field/watt-year-field.component.ts
@@ -170,7 +170,7 @@ export class WattYearField implements ControlValueAccessor {
   protected handleSelectedChange = (field: HTMLInputElement, date: Date) => {
     field.value = dayjs(date).format(YEAR_FORMAT);
     field.dispatchEvent(new Event('input', { bubbles: true }));
-    field.blur();
+    setTimeout(() => field.blur());
   };
 
   // Implementation for ControlValueAccessor

--- a/libs/watt/package/yearmonth-field/watt-yearmonth-field.component.ts
+++ b/libs/watt/package/yearmonth-field/watt-yearmonth-field.component.ts
@@ -170,7 +170,7 @@ export class WattYearMonthField implements ControlValueAccessor {
   protected handleSelectedChange = (field: HTMLInputElement, date: Date) => {
     field.value = YearMonth.fromDate(date).toView();
     field.dispatchEvent(new Event('input', { bubbles: true }));
-    field.blur();
+    setTimeout(() => field.blur());
   };
 
   // Implementation for ControlValueAccessor


### PR DESCRIPTION
This is what happens when all developers use Firefox 😄