### PR TITLE
feat: add step through buttons to year and month pickers

### DIFF
--- a/libs/dh/metering-point/feature-overview/src/components/measurement/dh-measurements-month.component.ts
+++ b/libs/dh/metering-point/feature-overview/src/components/measurement/dh-measurements-month.component.ts
@@ -74,7 +74,7 @@ import { dhFormatMeasurementNumber } from '../../utils/dh-format-measurement-num
     @use '@energinet-datahub/watt/utils' as watt;
     :host {
       watt-yearmonth-field {
-        width: 200px;
+        width: 280px;
       }
 
       .missing-values-text {
@@ -100,6 +100,7 @@ import { dhFormatMeasurementNumber } from '../../utils/dh-format-measurement-num
             <watt-yearmonth-field
               [formControl]="form.controls.yearMonth"
               [max]="maxDate.toDate()"
+              [canStepThroughMonths]="true"
             />
             <watt-slide-toggle [formControl]="form.controls.showOnlyChangedValues">
               {{ t('showOnlyChangedValues') }}

--- a/libs/dh/metering-point/feature-overview/src/components/measurement/dh-measurements-year.component.ts
+++ b/libs/dh/metering-point/feature-overview/src/components/measurement/dh-measurements-year.component.ts
@@ -83,7 +83,7 @@ import { DhCircleComponent } from './circle.component';
 
     dh-measurements-year {
       watt-year-field {
-        width: 200px;
+        width: 250px;
       }
 
       .capitalize {
@@ -110,7 +110,11 @@ import { DhCircleComponent } from './circle.component';
       <watt-data-filters *transloco="let t; read: 'meteringPoint.measurements.filters'">
         <form wattQueryParams [formGroup]="form">
           <vater-stack direction="row" gap="ml" align="baseline">
-            <watt-year-field [formControl]="form.controls.year" [max]="maxDate.toDate()" />
+            <watt-year-field
+              [formControl]="form.controls.year"
+              [max]="maxDate.toDate()"
+              [canStepThroughYears]="true"
+            />
             <watt-slide-toggle [formControl]="form.controls.showOnlyChangedValues">
               {{ t('showOnlyChangedValues') }}
             </watt-slide-toggle>

--- a/libs/watt/package/package.json
+++ b/libs/watt/package/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@energinet/watt",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/libs/watt/package/year-field/watt-year-field.stories.ts
+++ b/libs/watt/package/year-field/watt-year-field.stories.ts
@@ -19,6 +19,7 @@
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { DateAdapter, MAT_DATE_FORMATS, MAT_NATIVE_DATE_FORMATS } from '@angular/material/core';
 import { applicationConfig, Meta, moduleMetadata, StoryFn } from '@storybook/angular';
+
 import { WattYearField } from './watt-year-field.component';
 import { WattDateAdapter } from '../core/date/watt-date-adapter';
 
@@ -41,11 +42,16 @@ const meta: Meta<WattYearField> = {
 export default meta;
 
 export const Overview: StoryFn = () => ({
-  props: { yearOfEmployment: new FormControl<string | null>('2022') },
+  props: {
+    yearOfEmployment: new FormControl<string | null>('2022'),
+    minDate: new Date('2022'),
+  },
   template: `
     <watt-year-field
       label="Year of employment"
       [formControl]="yearOfEmployment"
+      [canStepThroughYears]="true"
+      [min]="minDate"
     />
   `,
 });

--- a/libs/watt/package/yearmonth-field/watt-yearmonth-field.component.ts
+++ b/libs/watt/package/yearmonth-field/watt-yearmonth-field.component.ts
@@ -33,10 +33,13 @@ import {
   ReactiveFormsModule,
 } from '@angular/forms';
 import { outputFromObservable, takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { MatCalendar } from '@angular/material/datepicker';
 import { map, share } from 'rxjs';
+import { MatCalendar } from '@angular/material/datepicker';
+
+import { dayjs } from '@energinet-datahub/watt/date';
 import { WattFieldComponent } from '@energinet/watt/field';
 import { WattButtonComponent } from '@energinet/watt/button';
+
 import { YearMonth } from './year-month';
 
 /* eslint-disable @angular-eslint/component-class-suffix */
@@ -57,8 +60,24 @@ import { YearMonth } from './year-month';
       watt-yearmonth-field {
         display: block;
         width: 100%;
+
         & input {
           text-transform: capitalize;
+        }
+
+        &:has(.watt-yearmonth-field__step-through) {
+          display: flex;
+          flex-align: flex-start;
+
+          .watt-yearmonth-field__step-through {
+            display: flex;
+          }
+        }
+
+        &:has(.watt-yearmonth-field__has-label) {
+          .watt-yearmonth-field__step-through {
+            margin-top: 28px;
+          }
         }
       }
 
@@ -106,6 +125,26 @@ import { YearMonth } from './year-month';
       <ng-content select="watt-field-error" ngProjectAs="watt-field-error" />
       <ng-content select="watt-field-hint" ngProjectAs="watt-field-hint" />
     </watt-field>
+
+    @if (canStepThroughMonths()) {
+      <span
+        class="watt-yearmonth-field__step-through"
+        [class.watt-yearmonth-field__has-label]="!!label()"
+      >
+        <watt-button
+          variant="icon"
+          icon="left"
+          (click)="prevMonth(field)"
+          [disabled]="control.disabled || isPrevMonthButtonDisabled()"
+        />
+        <watt-button
+          variant="icon"
+          icon="right"
+          (click)="nextMonth(field)"
+          [disabled]="control.disabled || isNextMonthButtonDisabled()"
+        />
+      </span>
+    }
   `,
 })
 export class WattYearMonthField implements ControlValueAccessor {
@@ -144,12 +183,18 @@ export class WattYearMonthField implements ControlValueAccessor {
   /** The maximum selectable date. */
   max = input<Date>();
 
+  /** Enable buttons to step through months. */
+  canStepThroughMonths = input(false);
+
   /** Emits when the selected month has changed. */
   monthChange = outputFromObservable(this.valueChanges);
 
   /** Emits when the field loses focus. */
   // eslint-disable-next-line @angular-eslint/no-output-native
   blur = output<FocusEvent>();
+
+  isPrevMonthButtonDisabled = computed(() => this.isPrevMonthBeforeOrEqualToMinDate());
+  isNextMonthButtonDisabled = computed(() => this.isNextMonthAfterOrEqualToMaxDate());
 
   protected handleFocus = (picker: HTMLElement) => {
     this.isOpen.set(true);
@@ -178,4 +223,61 @@ export class WattYearMonthField implements ControlValueAccessor {
   setDisabledState = (x: boolean) => (x ? this.control.disable() : this.control.enable());
   registerOnTouched = (fn: () => void) => this.blur.subscribe(fn);
   registerOnChange = (fn: (value: string | null) => void) => this.valueChanges.subscribe(fn);
+
+  /**
+   * @ignore
+   */
+  protected prevMonth(field: HTMLInputElement): void {
+    this.changeMonth(field, -1);
+  }
+  /**
+   * @ignore
+   */
+  protected nextMonth(field: HTMLInputElement): void {
+    this.changeMonth(field, 1);
+  }
+
+  /**
+   * @ignore
+   */
+  private changeMonth(field: HTMLInputElement, value: number): void {
+    const currentDate = YearMonth.fromView(field.value).toDate();
+
+    if (!currentDate) return;
+
+    const newDate = dayjs(currentDate).add(value, 'month');
+    this.handleSelectedChange(field, newDate.toDate());
+  }
+
+  /**
+   * @ignore
+   */
+  isPrevMonthBeforeOrEqualToMinDate(): boolean {
+    const min = this.min();
+
+    if (!min) return false;
+
+    const selectedDate = dayjs(this.selected());
+
+    const isBefore = selectedDate.isBefore(min, 'month');
+    const isSame = selectedDate.isSame(min, 'month');
+
+    return isSame || isBefore;
+  }
+
+  /**
+   * @ignore
+   */
+  isNextMonthAfterOrEqualToMaxDate(): boolean {
+    const max = this.max();
+
+    if (!max) return false;
+
+    const selectedDate = dayjs(this.selected());
+
+    const isAfter = selectedDate.isAfter(max, 'month');
+    const isSame = selectedDate.isSame(max, 'month');
+
+    return isSame || isAfter;
+  }
 }

--- a/libs/watt/package/yearmonth-field/watt-yearmonth-field.component.ts
+++ b/libs/watt/package/yearmonth-field/watt-yearmonth-field.component.ts
@@ -36,7 +36,7 @@ import { outputFromObservable, takeUntilDestroyed, toSignal } from '@angular/cor
 import { map, share } from 'rxjs';
 import { MatCalendar } from '@angular/material/datepicker';
 
-import { dayjs } from '@energinet-datahub/watt/date';
+import { dayjs } from '@energinet/watt/core/date';
 import { WattFieldComponent } from '@energinet/watt/field';
 import { WattButtonComponent } from '@energinet/watt/button';
 

--- a/libs/watt/package/yearmonth-field/watt-yearmonth-field.stories.ts
+++ b/libs/watt/package/yearmonth-field/watt-yearmonth-field.stories.ts
@@ -41,11 +41,16 @@ const meta: Meta<WattYearMonthField> = {
 export default meta;
 
 export const Overview: StoryFn = () => ({
-  props: { monthOfEmployment: new FormControl<string | null>('2022-05') },
+  props: {
+    monthOfEmployment: new FormControl<string | null>('2022-05'),
+    minDate: new Date('2022-05'),
+  },
   template: `
     <watt-yearmonth-field
       label="Month of employment"
       [formControl]="monthOfEmployment"
+      [min]="minDate"
+      [canStepThroughMonths]="true"
     />
   `,
 });


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

### Watt Design System
- add step through buttons to year picker
- add step through buttons to year-month picker

### DataHub
- enable step through buttons on year and year-month pickers in Measurements

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
