### PR TITLE
feat(dh): loading indicators for create calculation

### DIFF
--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -1560,12 +1560,13 @@
         },
         "period": {
           "label": "Beregningsperiode",
-          "invalid": "Ugyldig periode"
+          "invalid": "Ugyldig periode",
+          "pending": "Validerer periode"
         },
         "gridArea": {
           "label": "Netområder",
           "hint": "{{shared.selectedValues}}",
-          "loading": "Henter netområder..."
+          "loading": "Henter netområder"
         },
         "scheduledAt": {
           "label": "Beregningstidspunkt",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -1560,12 +1560,13 @@
         },
         "period": {
           "label": "Calculation period",
-          "invalid": "Invalid period"
+          "invalid": "Invalid period",
+          "pending": "Validating period"
         },
         "gridArea": {
           "label": "Grid areas",
           "hint": "{{shared.selectedValues}}",
-          "loading": "Loading grid areas..."
+          "loading": "Loading grid areas"
         },
         "scheduledAt": {
           "label": "Calculation time",

--- a/libs/dh/wholesale/feature-calculations/src/lib/create/create-form.ts
+++ b/libs/dh/wholesale/feature-calculations/src/lib/create/create-form.ts
@@ -104,6 +104,7 @@ import { assertIsDefined } from '@energinet-datahub/dh/shared/util-assert';
       <dh-calculations-period-field
         [formControl]="form.controls.period"
         [calculationType]="calculationType()"
+        [pending]="form.controls.period.status === 'PENDING'"
         [min]="minDate"
         [max]="maxDate()"
       >

--- a/libs/dh/wholesale/shared/src/gridareas-dropdown.ts
+++ b/libs/dh/wholesale/shared/src/gridareas-dropdown.ts
@@ -41,9 +41,7 @@ import { TranslocoDirective } from '@jsverse/transloco';
       [multiple]="multiple()"
     >
       @if (isLoading()) {
-        <watt-field-hint>
-          {{ t('create.gridArea.loading') }}
-        </watt-field-hint>
+        <watt-field-hint class="watt-dots">{{ t('create.gridArea.loading') }}</watt-field-hint>
       } @else if (isResolved() && multiple()) {
         <watt-field-hint>
           {{ t('create.gridArea.hint', { count: control().value?.length }) }}

--- a/libs/watt/package/core/styles/@energinet-datahub/watt/_index.scss
+++ b/libs/watt/package/core/styles/@energinet-datahub/watt/_index.scss
@@ -15,6 +15,7 @@
 @use "./theme/material-overwrites/datepicker";
 @use "./theme/material-overwrites/snack-bar";
 
+@use "../../animations";
 @use "../../box-sizing";
 @use "../../chips";
 @use "../../elevation";

--- a/libs/watt/package/core/styles/_animations.scss
+++ b/libs/watt/package/core/styles/_animations.scss
@@ -1,0 +1,36 @@
+// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.watt-dots::after {
+  animation: 3s dots 1.5s linear infinite;
+  content: "...";
+}
+
+@keyframes dots {
+  0% {
+    content: "";
+  }
+  25% {
+    content: ".";
+  }
+  50% {
+    content: "..";
+  }
+  75% {
+    content: "...";
+  }
+  100% {
+    content: "";
+  }
+}

--- a/libs/watt/package/package.json
+++ b/libs/watt/package/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@energinet/watt",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "license": "Apache-2.0",
   "exports": {
     ".": {


### PR DESCRIPTION
Some of the asynchronous fields in create calculation can be slow at times. This change adds a hint with some animating dots to the period and grid areas fields to indicate that stuff is happening in the background.