### PR TITLE
feat: Add missing measurement to archived messages

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
@@ -992,16 +992,16 @@ type Query {
   permissionById(id: Int!): Permission!
   filteredPermissions(filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: [PermissionDtoSortInput!]): FilteredPermissionsConnection
   permissionsByEicFunction(eicFunction: EicFunction!): [PermissionDetailsDto!]!
-  userRolesByActorId(actorId: UUID!): [UserRoleDto!]!
-  userRolesByEicFunction(eicFunction: EicFunction!): [UserRoleDto!]!
-  filteredUserRoles(status: UserRoleStatus eicFunctions: [EicFunction!] filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: [UserRoleSortInput!]): FilteredUserRolesConnection
-  userRoles(actorId: UUID): [UserRoleDto!]!
-  userRoleById(id: UUID!): UserRoleWithPermissions!
   domainExists(email: String!): Boolean!
   knownEmails: [String!]!
   userById(id: UUID!): User!
   users(skip: Int take: Int actorId: UUID userRoleIds: [UUID!] userStatus: [UserStatus!] filter: String order: UsersSortInput): UsersCollectionSegment
   userProfile: UserProfile!
+  userRolesByActorId(actorId: UUID!): [UserRoleDto!]!
+  userRolesByEicFunction(eicFunction: EicFunction!): [UserRoleDto!]!
+  filteredUserRoles(status: UserRoleStatus eicFunctions: [EicFunction!] filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: [UserRoleSortInput!]): FilteredUserRolesConnection
+  userRoles(actorId: UUID): [UserRoleDto!]!
+  userRoleById(id: UUID!): UserRoleWithPermissions!
   measurementsReports: [MeasurementsReport!]!
   archivedMessagesForMeteringPoint(created: DateRange! meteringPointId: String! senderId: UUID receiverId: UUID documentType: MeteringPointDocumentType "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: ArchivedMessageSortInput): ArchivedMessagesForMeteringPointConnection
   archivedMessages(created: DateRange! senderId: UUID receiverId: UUID documentTypes: [SearchDocumentType!] businessReasons: [BusinessReason!] includeRelated: Boolean filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: ArchivedMessageSortInput): ArchivedMessagesConnection

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
@@ -979,16 +979,16 @@ type Query {
   permissionById(id: Int!): Permission!
   filteredPermissions(filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: [PermissionDtoSortInput!]): FilteredPermissionsConnection
   permissionsByEicFunction(eicFunction: EicFunction!): [PermissionDetailsDto!]!
-  domainExists(email: String!): Boolean!
-  knownEmails: [String!]!
-  userById(id: UUID!): User!
-  users(skip: Int take: Int actorId: UUID userRoleIds: [UUID!] userStatus: [UserStatus!] filter: String order: UsersSortInput): UsersCollectionSegment
-  userProfile: UserProfile!
   userRolesByActorId(actorId: UUID!): [UserRoleDto!]!
   userRolesByEicFunction(eicFunction: EicFunction!): [UserRoleDto!]!
   filteredUserRoles(status: UserRoleStatus eicFunctions: [EicFunction!] filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: [UserRoleSortInput!]): FilteredUserRolesConnection
   userRoles(actorId: UUID): [UserRoleDto!]!
   userRoleById(id: UUID!): UserRoleWithPermissions!
+  domainExists(email: String!): Boolean!
+  knownEmails: [String!]!
+  userById(id: UUID!): User!
+  users(skip: Int take: Int actorId: UUID userRoleIds: [UUID!] userStatus: [UserStatus!] filter: String order: UsersSortInput): UsersCollectionSegment
+  userProfile: UserProfile!
   measurementsReports: [MeasurementsReport!]!
   archivedMessagesForMeteringPoint(created: DateRange! meteringPointId: String! senderId: UUID receiverId: UUID documentType: MeteringPointDocumentType "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: ArchivedMessageSortInput): ArchivedMessagesForMeteringPointConnection
   archivedMessages(created: DateRange! senderId: UUID receiverId: UUID documentTypes: [SearchDocumentType!] businessReasons: [BusinessReason!] includeRelated: Boolean filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: ArchivedMessageSortInput): ArchivedMessagesConnection
@@ -1911,6 +1911,7 @@ enum DocumentType {
   REQUEST_WHOLESALE_SETTLEMENT
   B2C_REQUEST_WHOLESALE_SETTLEMENT
   NOTIFY_WHOLESALE_SERVICES
+  REMINDER_OF_MISSING_MEASUREMENTS
 }
 
 enum ESettStageComponent {
@@ -2208,6 +2209,7 @@ enum SearchDocumentType {
   REQUEST_AGGREGATED_MEASURE_DATA
   REQUEST_WHOLESALE_SETTLEMENT
   ACKNOWLEDGEMENT
+  REMINDER_OF_MISSING_MEASUREMENTS
 }
 
 enum SettlementMethod {

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/EDI/B2CWebApi/V3/EdiB2CWebAppClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/EDI/B2CWebApi/V3/EdiB2CWebAppClient.cs
@@ -238,7 +238,7 @@ namespace Energinet.DataHub.Edi.B2CWebApp.Clients.v3
                     var field = System.Reflection.IntrospectionExtensions.GetTypeInfo(value.GetType()).GetDeclaredField(name);
                     if (field != null)
                     {
-                        var attribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute(field, typeof(System.Runtime.Serialization.EnumMemberAttribute)) 
+                        var attribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute(field, typeof(System.Runtime.Serialization.EnumMemberAttribute))
                             as System.Runtime.Serialization.EnumMemberAttribute;
                         if (attribute != null)
                         {
@@ -250,7 +250,7 @@ namespace Energinet.DataHub.Edi.B2CWebApp.Clients.v3
                     return converted == null ? string.Empty : converted;
                 }
             }
-            else if (value is bool) 
+            else if (value is bool)
             {
                 return System.Convert.ToString((bool)value, cultureInfo).ToLowerInvariant();
             }
@@ -386,6 +386,8 @@ namespace Energinet.DataHub.Edi.B2CWebApp.Clients.v3
         B2CRequestWholesaleSettlement = 7,
 
         Acknowledgement = 8,
+
+        ReminderOfMissingMeasurements = 9,
 
     }
 

--- a/apps/dh/api-dh/source/DataHub.WebApi/Clients/EDI/B2CWebApi/V3/swagger.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Clients/EDI/B2CWebApi/V3/swagger.json
@@ -27,7 +27,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/SearchArchivedMessagesRequestV3"
+                    "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.SearchArchivedMessagesRequestV3"
                   }
                 ]
               }
@@ -36,7 +36,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/SearchArchivedMessagesRequestV3"
+                    "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.SearchArchivedMessagesRequestV3"
                   }
                 ]
               }
@@ -45,7 +45,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/SearchArchivedMessagesRequestV3"
+                    "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.SearchArchivedMessagesRequestV3"
                   }
                 ]
               }
@@ -58,17 +58,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ArchivedMessageSearchResponseV3"
+                  "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.ArchivedMessageSearchResponseV3"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ArchivedMessageSearchResponseV3"
+                  "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.ArchivedMessageSearchResponseV3"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ArchivedMessageSearchResponseV3"
+                  "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.ArchivedMessageSearchResponseV3"
                 }
               }
             }
@@ -79,7 +79,7 @@
   },
   "components": {
     "schemas": {
-      "ActorRole": {
+      "Energinet.DataHub.EDI.B2CWebApi.Models.ActorRole": {
         "type": "integer",
         "format": "int32",
         "x-enumNames": [
@@ -109,7 +109,7 @@
           10
         ]
       },
-      "ArchivedMessageResultV3": {
+      "Energinet.DataHub.EDI.B2CWebApi.Models.ArchivedMessageResultV3": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -134,11 +134,12 @@
               "B2CRequestAggregatedMeasureData",
               "RequestWholesaleSettlement",
               "B2CRequestWholesaleSettlement",
-              "Acknowledgement"
+              "Acknowledgement",
+              "ReminderOfMissingMeasurements"
             ],
             "allOf": [
               {
-                "$ref": "#/components/schemas/DocumentType"
+                "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.DocumentType"
               }
             ]
           },
@@ -149,7 +150,7 @@
             "nullable": true,
             "allOf": [
               {
-                "$ref": "#/components/schemas/ActorRole"
+                "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.ActorRole"
               }
             ]
           },
@@ -160,7 +161,7 @@
             "nullable": true,
             "allOf": [
               {
-                "$ref": "#/components/schemas/ActorRole"
+                "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.ActorRole"
               }
             ]
           },
@@ -174,14 +175,14 @@
           }
         }
       },
-      "ArchivedMessageSearchResponseV3": {
+      "Energinet.DataHub.EDI.B2CWebApi.Models.ArchivedMessageSearchResponseV3": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
           "messages": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ArchivedMessageResultV3"
+              "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.ArchivedMessageResultV3"
             }
           },
           "totalCount": {
@@ -190,7 +191,7 @@
           }
         }
       },
-      "DirectionToSortBy": {
+      "Energinet.DataHub.EDI.B2CWebApi.Models.DirectionToSortBy": {
         "type": "integer",
         "description": "Represents the direction to sort by when searching for archived messages.",
         "format": "int32",
@@ -203,7 +204,7 @@
           1
         ]
       },
-      "DocumentType": {
+      "Energinet.DataHub.EDI.B2CWebApi.Models.DocumentType": {
         "type": "integer",
         "format": "int32",
         "x-enumNames": [
@@ -215,7 +216,8 @@
           "B2CRequestAggregatedMeasureData",
           "RequestWholesaleSettlement",
           "B2CRequestWholesaleSettlement",
-          "Acknowledgement"
+          "Acknowledgement",
+          "ReminderOfMissingMeasurements"
         ],
         "enum": [
           0,
@@ -226,10 +228,11 @@
           5,
           6,
           7,
-          8
+          8,
+          9
         ]
       },
-      "FieldToSortBy": {
+      "Energinet.DataHub.EDI.B2CWebApi.Models.FieldToSortBy": {
         "type": "integer",
         "description": "Represents the fields that can be sorted on when searching for archived messages.",
         "format": "int32",
@@ -248,7 +251,7 @@
           4
         ]
       },
-      "MessageCreationPeriod": {
+      "Energinet.DataHub.EDI.B2CWebApi.Models.MessageCreationPeriod": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -262,7 +265,7 @@
           }
         }
       },
-      "SearchArchivedMessagesCriteriaV3": {
+      "Energinet.DataHub.EDI.B2CWebApi.Models.SearchArchivedMessagesCriteriaV3": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -270,7 +273,7 @@
             "nullable": true,
             "allOf": [
               {
-                "$ref": "#/components/schemas/MessageCreationPeriod"
+                "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.MessageCreationPeriod"
               }
             ]
           },
@@ -286,7 +289,7 @@
             "nullable": true,
             "allOf": [
               {
-                "$ref": "#/components/schemas/ActorRole"
+                "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.ActorRole"
               }
             ]
           },
@@ -298,7 +301,7 @@
             "nullable": true,
             "allOf": [
               {
-                "$ref": "#/components/schemas/ActorRole"
+                "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.ActorRole"
               }
             ]
           },
@@ -306,7 +309,7 @@
             "type": "array",
             "nullable": true,
             "items": {
-              "$ref": "#/components/schemas/DocumentType"
+              "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.DocumentType"
             }
           },
           "businessReasons": {
@@ -321,7 +324,7 @@
           }
         }
       },
-      "SearchArchivedMessagesCursor": {
+      "Energinet.DataHub.EDI.B2CWebApi.Models.SearchArchivedMessagesCursor": {
         "type": "object",
         "description": "Pagination cursor for the search of archived messages.\r\nPointing to the field being sorted by and the record id.\r\nWhen navigating forward, the cursor points to the last record of the current page.\r\nand when navigating backward, the cursor points to the first record of the current page.",
         "additionalProperties": false,
@@ -338,7 +341,7 @@
           }
         }
       },
-      "SearchArchivedMessagesPagination": {
+      "Energinet.DataHub.EDI.B2CWebApi.Models.SearchArchivedMessagesPagination": {
         "type": "object",
         "description": "Pagination when searching for archived messages that supports sorting on a specific field.",
         "additionalProperties": false,
@@ -348,7 +351,7 @@
             "nullable": true,
             "allOf": [
               {
-                "$ref": "#/components/schemas/SearchArchivedMessagesCursor"
+                "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.SearchArchivedMessagesCursor"
               }
             ]
           },
@@ -356,7 +359,7 @@
             "nullable": true,
             "allOf": [
               {
-                "$ref": "#/components/schemas/FieldToSortBy"
+                "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.FieldToSortBy"
               }
             ]
           },
@@ -364,7 +367,7 @@
             "nullable": true,
             "allOf": [
               {
-                "$ref": "#/components/schemas/DirectionToSortBy"
+                "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.DirectionToSortBy"
               }
             ]
           },
@@ -377,14 +380,14 @@
           }
         }
       },
-      "SearchArchivedMessagesRequestV3": {
+      "Energinet.DataHub.EDI.B2CWebApi.Models.SearchArchivedMessagesRequestV3": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
           "searchCriteria": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/SearchArchivedMessagesCriteriaV3"
+                "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.SearchArchivedMessagesCriteriaV3"
               }
             ]
           },
@@ -392,7 +395,7 @@
             "description": "Pagination when searching for archived messages that supports sorting on a specific field.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/SearchArchivedMessagesPagination"
+                "$ref": "#/components/schemas/Energinet.DataHub.EDI.B2CWebApi.Models.SearchArchivedMessagesPagination"
               }
             ]
           }

--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/MessageArchive/Enums/DocumentType.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/MessageArchive/Enums/DocumentType.cs
@@ -28,4 +28,5 @@ public enum DocumentType
     [GraphQLName("B2C_REQUEST_WHOLESALE_SETTLEMENT")]
     B2CRequestWholesaleSettlement,
     NotifyWholesaleServices,
+    ReminderOfMissingMeasurements,
 }

--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/MessageArchive/Extensions/SearchDocumentTypeExtensions.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/MessageArchive/Extensions/SearchDocumentTypeExtensions.cs
@@ -31,5 +31,6 @@ public static class SearchDocumentTypeExtensions
             SearchDocumentType.RejectRequestWholesaleSettlement => DocumentType.RejectRequestWholesaleSettlement,
             SearchDocumentType.RequestAggregatedMeasureData => DocumentType.RequestAggregatedMeasureData,
             SearchDocumentType.RequestWholesaleSettlement => DocumentType.RequestWholesaleSettlement,
+            SearchDocumentType.ReminderOfMissingMeasurements => DocumentType.ReminderOfMissingMeasurements,
         };
 }

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -582,7 +582,8 @@
       "REJECT_REQUEST_WHOLESALE_SETTLEMENT": "Afvis anmod om engrosydelser (RSM-017)",
       "REQUEST_WHOLESALE_SETTLEMENT": "Anmod om engrosydelser (RSM-017)",
       "B2C_REQUEST_WHOLESALE_SETTLEMENT": "B2C: Anmod om engrosydelser (RSM-017)",
-      "NOTIFY_WHOLESALE_SERVICES": "Notifikation om beregnede engrosydelser (RSM-019)"
+      "NOTIFY_WHOLESALE_SERVICES": "Notifikation om beregnede engrosydelser (RSM-019)",
+      "REMINDER_OF_MISSING_MEASUREMENTS": "Påmindelse om manglende måledata (RSM-018)"
     },
     "businessReason": {
       "D03": "Aggregering (D03)",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -583,7 +583,7 @@
       "REQUEST_WHOLESALE_SETTLEMENT": "Anmod om engrosydelser (RSM-017)",
       "B2C_REQUEST_WHOLESALE_SETTLEMENT": "B2C: Anmod om engrosydelser (RSM-017)",
       "NOTIFY_WHOLESALE_SERVICES": "Notifikation om beregnede engrosydelser (RSM-019)",
-      "REMINDER_OF_MISSING_MEASUREMENTS": "Påmindelse om manglende måledata (RSM-018)"
+      "REMINDER_OF_MISSING_MEASUREMENTS": "Hullerlog (RSM-018)"
     },
     "businessReason": {
       "D03": "Aggregering (D03)",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -583,7 +583,7 @@
       "REQUEST_WHOLESALE_SETTLEMENT": "Request for wholesale services (RSM-017)",
       "B2C_REQUEST_WHOLESALE_SETTLEMENT": "B2C: Request for wholesale services (RSM-017)",
       "NOTIFY_WHOLESALE_SERVICES": "Notification of calculated wholesale services (RSM-019)",
-      "REMINDER_OF_MISSING_MEASUREMENTS": "Reminder of missing measurements (RSM-018)"
+      "REMINDER_OF_MISSING_MEASUREMENTS": "Reminders (RSM-018)"
     },
     "businessReason": {
       "D03": "Aggregation (D03)",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -582,7 +582,8 @@
       "REJECT_REQUEST_WHOLESALE_SETTLEMENT": "Reject request for wholesale services (RSM-017)",
       "REQUEST_WHOLESALE_SETTLEMENT": "Request for wholesale services (RSM-017)",
       "B2C_REQUEST_WHOLESALE_SETTLEMENT": "B2C: Request for wholesale services (RSM-017)",
-      "NOTIFY_WHOLESALE_SERVICES": "Notification of calculated wholesale services (RSM-019)"
+      "NOTIFY_WHOLESALE_SERVICES": "Notification of calculated wholesale services (RSM-019)",
+      "REMINDER_OF_MISSING_MEASUREMENTS": "Reminder of missing measurements (RSM-018)"
     },
     "businessReason": {
       "D03": "Aggregation (D03)",

--- a/libs/dh/message-archive/domain/src/lib/documentType.ts
+++ b/libs/dh/message-archive/domain/src/lib/documentType.ts
@@ -40,5 +40,7 @@ export const getDocumentTypeIdentifier = (documentType: DocumentType) => {
       return 'RSM-017';
     case DocumentType.NotifyWholesaleServices:
       return 'RSM-019';
+    case DocumentType.ReminderOfMissingMeasurements:
+      return 'RSM-018'
   }
 };

--- a/libs/dh/message-archive/domain/src/lib/documentType.ts
+++ b/libs/dh/message-archive/domain/src/lib/documentType.ts
@@ -41,6 +41,6 @@ export const getDocumentTypeIdentifier = (documentType: DocumentType) => {
     case DocumentType.NotifyWholesaleServices:
       return 'RSM-019';
     case DocumentType.ReminderOfMissingMeasurements:
-      return 'RSM-018'
+      return 'RSM-018';
   }
 };

--- a/libs/dh/message-archive/feature-search/src/lib/form.service.ts
+++ b/libs/dh/message-archive/feature-search/src/lib/form.service.ts
@@ -57,9 +57,7 @@ export class DhMessageArchiveSearchFormService {
   root = this.form;
   controls = this.form.controls;
   documentTypeOptions = dhEnumToWattDropdownOptions(SearchDocumentType, [
-    !this.featureFlagsService.isEnabled('acknowledgement-archived-messages')
-      ? SearchDocumentType.Acknowledgement
-      : '',
+    SearchDocumentType.Acknowledgement, // This should never be shown in the UI, since the corresponding messages does not exist via this api
     !this.featureFlagsService.isEnabled('missing-measurements-log')
       ? SearchDocumentType.ReminderOfMissingMeasurements
       : '',

--- a/libs/dh/message-archive/feature-search/src/lib/form.service.ts
+++ b/libs/dh/message-archive/feature-search/src/lib/form.service.ts
@@ -56,7 +56,12 @@ export class DhMessageArchiveSearchFormService {
 
   root = this.form;
   controls = this.form.controls;
-  documentTypeOptions = dhEnumToWattDropdownOptions(SearchDocumentType);
+  documentTypeOptions = dhEnumToWattDropdownOptions(
+    SearchDocumentType,
+    [
+      !this.featureFlagsService.isEnabled('acknowledgement-archived-messages') ? SearchDocumentType.Acknowledgement : "",
+      !this.featureFlagsService.isEnabled('missing-measurements-log') ? SearchDocumentType.ReminderOfMissingMeasurements : "",
+    ])
   businessReasonOptions = dhEnumToWattDropdownOptions(BusinessReason);
   actorOptions = computed(() =>
     this.actors().map((actor) => ({

--- a/libs/dh/message-archive/feature-search/src/lib/form.service.ts
+++ b/libs/dh/message-archive/feature-search/src/lib/form.service.ts
@@ -56,12 +56,14 @@ export class DhMessageArchiveSearchFormService {
 
   root = this.form;
   controls = this.form.controls;
-  documentTypeOptions = dhEnumToWattDropdownOptions(
-    SearchDocumentType,
-    [
-      !this.featureFlagsService.isEnabled('acknowledgement-archived-messages') ? SearchDocumentType.Acknowledgement : "",
-      !this.featureFlagsService.isEnabled('missing-measurements-log') ? SearchDocumentType.ReminderOfMissingMeasurements : "",
-    ])
+  documentTypeOptions = dhEnumToWattDropdownOptions(SearchDocumentType, [
+    !this.featureFlagsService.isEnabled('acknowledgement-archived-messages')
+      ? SearchDocumentType.Acknowledgement
+      : '',
+    !this.featureFlagsService.isEnabled('missing-measurements-log')
+      ? SearchDocumentType.ReminderOfMissingMeasurements
+      : '',
+  ]);
   businessReasonOptions = dhEnumToWattDropdownOptions(BusinessReason);
   actorOptions = computed(() =>
     this.actors().map((actor) => ({


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

It should be possible to search for missing measurement in the archived messages tab.
This should not be possible on production

https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/749

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
