### PR TITLE
Fixes issue with autocomplete text fields

### DIFF
--- a/libs/watt/package/field/watt-field.component.ts
+++ b/libs/watt/package/field/watt-field.component.ts
@@ -105,6 +105,7 @@ import { NgTemplateOutlet } from '@angular/common';
 })
 export class WattFieldComponent {
   intl = inject(WattFieldIntlService);
+  elementRef = inject<ElementRef>(ElementRef);
 
   control = input<FormControl | null>(null);
   label = input<string>();

--- a/libs/watt/package/field/watt-field.component.ts
+++ b/libs/watt/package/field/watt-field.component.ts
@@ -125,7 +125,7 @@ export class WattFieldComponent {
   isEmpty = computed(() => this.errors()?.['required'] || this.errors()?.['rangeRequired']);
 
   // Used for text fields with autocomplete
-  wrapper = viewChild.required<ElementRef>('wrapper');
+  wrapper = viewChild<ElementRef>('wrapper');
 
   constructor() {
     const control$ = toObservable(this.control).pipe(filter((control) => control !== null));

--- a/libs/watt/package/package.json
+++ b/libs/watt/package/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@energinet/watt",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/libs/watt/package/text-field/watt-text-field.component.ts
+++ b/libs/watt/package/text-field/watt-text-field.component.ts
@@ -55,7 +55,7 @@ export type WattInputTypes = 'text' | 'password' | 'email' | 'number' | 'tel' | 
     },
   ],
   template: `<watt-field
-    #wattField
+    #wattField="matAutocompleteOrigin"
     [control]="formControl"
     [label]="label"
     [tooltip]="tooltip"
@@ -88,7 +88,7 @@ export type WattInputTypes = 'text' | 'password' | 'email' | 'number' | 'tel' | 
         (input)="onChanged($event)"
         [maxlength]="maxLength"
         [matAutocomplete]="auto"
-        [matAutocompleteConnectedTo]="{ elementRef: wattField.wrapper() }"
+        [matAutocompleteConnectedTo]="wattField"
         #inputField
       />
 

--- a/libs/watt/package/text-field/watt-text-field.component.ts
+++ b/libs/watt/package/text-field/watt-text-field.component.ts
@@ -55,7 +55,7 @@ export type WattInputTypes = 'text' | 'password' | 'email' | 'number' | 'tel' | 
     },
   ],
   template: `<watt-field
-    #wattField="matAutocompleteOrigin"
+    #wattField
     [control]="formControl"
     [label]="label"
     [tooltip]="tooltip"
@@ -88,7 +88,7 @@ export type WattInputTypes = 'text' | 'password' | 'email' | 'number' | 'tel' | 
         (input)="onChanged($event)"
         [maxlength]="maxLength"
         [matAutocomplete]="auto"
-        [matAutocompleteConnectedTo]="wattField"
+        [matAutocompleteConnectedTo]="{ elementRef: wattField.wrapper() ?? wattField.elementRef }"
         #inputField
       />
 


### PR DESCRIPTION
Quick fix - Perhaps we should, as @dzhavat mentioned, stop using both ng-template and viewchild at the same time.
But this gets ETT Going again 🙂 
