### PR TITLE
fix(dh): remove router-outlet from layout

### DIFF
--- a/apps/dh/app-dh/src/styles.scss
+++ b/apps/dh/app-dh/src/styles.scss
@@ -43,6 +43,10 @@ canvas {
   pointer-events: none;
 }
 
+router-outlet {
+  display: none;
+}
+
 #cookie-information-template-wrapper #Coi-Renew {
   right: 0px;
   left: initial;


### PR DESCRIPTION
I just realized that Angular does not replace `<router-outlet />` in the DOM, but instead places the matched component underneath it, as a sibling. It is empty and normally has a "zero-size", but if it happens to be part of fx. a VaterFlex component, it actually flexes along with other components, causing weird layout issues. This change just hides all `router-outlet` components as I see no reason why it should be visible.