### PR TITLE
fix: rename align input to alignment

### DIFF
--- a/libs/dh/esett/feature-outgoing-messages/src/lib/details.component.html
+++ b/libs/dh/esett/feature-outgoing-messages/src/lib/details.component.html
@@ -86,7 +86,7 @@ limitations under the License.
   <watt-drawer-content>
     <watt-tabs>
       <watt-tab [label]="t('tabs.message')">
-        <vater-stack align="end">
+        <vater-stack alignment="end">
           <watt-button variant="text" icon="download" (click)="downloadXML('message')">{{
             "shared.download" | transloco
           }}</watt-button>
@@ -97,7 +97,7 @@ limitations under the License.
 
       @if (responseDocument.value()) {
         <watt-tab [label]="t('tabs.receipt')">
-          <vater-stack align="end">
+          <vater-stack alignment="end">
             <watt-button variant="text" icon="download" (click)="downloadXML('receipt')">{{
               "shared.download" | transloco
             }}</watt-button>

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/create/steps/dh-choose-organization-step.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/create/steps/dh-choose-organization-step.component.ts
@@ -51,7 +51,7 @@ import { lazyQuery, query } from '@energinet-datahub/dh/shared/util-apollo';
     `,
   ],
   template: `<vater-stack
-    align="start"
+    alignment="start"
     fill="horizontal"
     *transloco="let t; read: 'marketParticipant.actor.create'"
   >

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/create/steps/dh-new-actor-step.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/create/steps/dh-new-actor-step.component.ts
@@ -65,12 +65,12 @@ import { dhMarketParticipantNameMaxLength } from '../../dh-market-participant-na
   ],
   template: `<vater-stack
     gap="xl"
-    align="start"
+    alignment="start"
     direction="row"
     class="container"
     *transloco="let t; read: 'marketParticipant.actor.create'"
   >
-    <vater-stack class="container__item" fill="horizontal" align="start" direction="column">
+    <vater-stack class="container__item" fill="horizontal" alignment="start" direction="column">
       <h4>{{ t('marketParty') }}</h4>
 
       <watt-text-field
@@ -113,7 +113,7 @@ import { dhMarketParticipantNameMaxLength } from '../../dh-market-participant-na
       }
     </vater-stack>
 
-    <vater-stack class="container__item" fill="horizontal" align="start" direction="column">
+    <vater-stack class="container__item" fill="horizontal" alignment="start" direction="column">
       <h4>{{ t('contact') }}</h4>
       <watt-text-field
         [formControl]="newActorForm().controls.contact.controls.departmentOrName"

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/create/steps/dh-new-organization-step.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/create/steps/dh-new-organization-step.component.ts
@@ -78,7 +78,7 @@ import { dhCompanyNameMaxLength } from '../../dh-company-name-max-length.validat
       }}</watt-button>
     </vater-stack>
 
-    <vater-stack gap="m" align="center" direction="row">
+    <vater-stack gap="m" alignment="center" direction="row">
       <watt-dropdown
         translateKey="marketParticipant.actor.create.countries"
         dhDropdownTranslator
@@ -102,7 +102,7 @@ import { dhCompanyNameMaxLength } from '../../dh-company-name-max-length.validat
       </watt-text-field>
     </vater-stack>
 
-    <vater-stack gap="m" align="start">
+    <vater-stack gap="m" alignment="start">
       <watt-text-field
         [formControl]="newOrganizationForm().controls.companyName"
         [label]="t('companyName')"

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/dh-actor-drawer.component.html
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/drawer/dh-actor-drawer.component.html
@@ -65,7 +65,7 @@ limitations under the License.
       <watt-drawer-content>
         <watt-tabs>
           <watt-tab [label]="t('tabs.masterData.tabLabel')">
-            <vater-stack direction="column" gap="ml" align="stretch" fill="horizontal">
+            <vater-stack direction="column" gap="ml" alignment="stretch" fill="horizontal">
               <watt-card variant="solid">
                 <watt-card-title>
                   <h3>{{ t("tabs.masterData.actor") }}</h3>

--- a/libs/dh/market-participant/actors/feature-actors/src/lib/merge/dh-merge-market-participants.component.ts
+++ b/libs/dh/market-participant/actors/feature-actors/src/lib/merge/dh-merge-market-participants.component.ts
@@ -77,7 +77,7 @@ type MarketParticipant = ResultOf<
           [formGroup]="form"
           vater-stack
           gap="m"
-          align="start"
+          alignment="start"
           (ngSubmit)="form.valid && save()"
         >
           @if (form.hasError('notUniqueMarketParticipants')) {

--- a/libs/dh/market-participant/actors/feature-delegation/src/lib/stop/dh-delegation-stop-modal.component.ts
+++ b/libs/dh/market-participant/actors/feature-delegation/src/lib/stop/dh-delegation-stop-modal.component.ts
@@ -22,9 +22,8 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-
+import { Component, inject, viewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Component, ViewEncapsulation, inject, viewChild } from '@angular/core';
 
 import { distinctUntilKeyChanged } from 'rxjs';
 import { TranslocoDirective, translate } from '@jsverse/transloco';
@@ -53,22 +52,13 @@ import { dhDateCannotBeOlderThanTodayValidator } from '../dh-delegation-validato
 
 @Component({
   selector: 'dh-delegation-stop-modal',
-  encapsulation: ViewEncapsulation.None,
   styles: `
-    dh-delegation-stop-modal {
+    :host {
       display: block;
+    }
 
-      vater-stack[align='flex-start'] {
-        margin-top: var(--watt-space-m);
-      }
-
-      watt-datepicker {
-        watt-field {
-          span.label {
-            display: none;
-          }
-        }
-      }
+    #stop-delegation-form {
+      margin-top: var(--watt-space-m);
     }
   `,
   imports: [
@@ -90,14 +80,14 @@ import { dhDateCannotBeOlderThanTodayValidator } from '../dh-delegation-validato
       [formGroup]="stopDelegationForm"
       (ngSubmit)="stopSelectedDelegations()"
     >
-      <vater-stack align="start" gap="m">
+      <vater-stack alignment="start" gap="m">
         <watt-radio
           group="stopDate"
           [formControl]="stopDelegationForm.controls.selectedOption"
           value="stopNow"
           >{{ t('stopNow') }}</watt-radio
         >
-        <vater-stack direction="row" align="baseline" gap="m">
+        <vater-stack direction="row" alignment="baseline" gap="m">
           <watt-radio
             group="stopDate"
             [formControl]="stopDelegationForm.controls.selectedOption"

--- a/libs/dh/market-participant/grid-areas/src/table.component.html
+++ b/libs/dh/market-participant/grid-areas/src/table.component.html
@@ -29,7 +29,7 @@ limitations under the License.
       }}</watt-button>
     </vater-stack>
 
-    <vater-stack direction="row" align="start" gap="m">
+    <vater-stack direction="row" alignment="start" gap="m">
       <watt-dropdown
         sortDirection="asc"
         dhDropdownTranslator

--- a/libs/dh/metering-point/feature-debug/src/debug-metering-points/metering-points.component.ts
+++ b/libs/dh/metering-point/feature-debug/src/debug-metering-points/metering-points.component.ts
@@ -65,7 +65,7 @@ import { MeteringPointsGroupComponent } from './metering-points-group.component'
             [placeholder]="t('gridArea')"
           />
 
-          <vater-stack scrollable fill="vertical" align="stretch">
+          <vater-stack scrollable fill="vertical" alignment="stretch">
             @if (loading()) {
               <watt-spinner vater center [diameter]="22" />
             }

--- a/libs/dh/metering-point/feature-measurements/src/components/day-filter.component.ts
+++ b/libs/dh/metering-point/feature-measurements/src/components/day-filter.component.ts
@@ -54,7 +54,7 @@ import { MeasurementsQueryVariables } from '../types';
       <vater-stack
         direction="row"
         gap="ml"
-        align="baseline"
+        alignment="baseline"
         *transloco="let t; read: 'meteringPoint.measurements.filters'"
       >
         <watt-datepicker [formControl]="form.controls.date" canStepThroughDays />

--- a/libs/dh/metering-point/feature-measurements/src/components/month.component.ts
+++ b/libs/dh/metering-point/feature-measurements/src/components/month.component.ts
@@ -93,7 +93,7 @@ import { dhFormatMeasurementNumber } from '../utils/dh-format-measurement-number
     >
       <watt-data-filters *transloco="let t; read: 'meteringPoint.measurements.filters'">
         <form wattQueryParams [formGroup]="form">
-          <vater-stack direction="row" gap="ml" align="baseline">
+          <vater-stack direction="row" gap="ml" alignment="baseline">
             <watt-yearmonth-field [formControl]="form.controls.yearMonth" canStepThroughMonths />
             <watt-slide-toggle [formControl]="form.controls.showOnlyChangedValues">
               {{ t('showOnlyChangedValues') }}

--- a/libs/dh/metering-point/feature-measurements/src/components/upload.component.ts
+++ b/libs/dh/metering-point/feature-measurements/src/components/upload.component.ts
@@ -148,7 +148,7 @@ import { CommonModule } from '@angular/common';
           }
         </vater-stack>
       </watt-card-title>
-      <vater-flex wrap direction="row" gap="xl" align="baseline">
+      <vater-flex wrap direction="row" gap="xl" alignment="baseline">
         <watt-description-list variant="compact" *transloco="let tCommon">
           <watt-description-list-item [label]="t('upload.quality')">
             {{ csv()?.quality && t('quality.' + csv()?.quality) | dhEmDashFallback }}
@@ -174,7 +174,7 @@ import { CommonModule } from '@angular/common';
             }
           </watt-dropzone>
         } @else {
-          <vater-stack align="start" gap="m">
+          <vater-stack alignment="start" gap="m">
             <!-- Hack for updating the value of the datepicker -->
             @if (date.value) {
               <watt-datepicker [label]="t('upload.datepicker')" [formControl]="date" />

--- a/libs/dh/metering-point/feature-measurements/src/components/year.component.ts
+++ b/libs/dh/metering-point/feature-measurements/src/components/year.component.ts
@@ -98,7 +98,7 @@ import {
     >
       <watt-data-filters *transloco="let t; read: 'meteringPoint.measurements.filters'">
         <form wattQueryParams [formGroup]="form">
-          <vater-stack direction="row" gap="ml" align="baseline">
+          <vater-stack direction="row" gap="ml" alignment="baseline">
             <watt-year-field [formControl]="form.controls.year" canStepThroughYears />
           </vater-stack>
         </form>

--- a/libs/dh/metering-point/feature-overview/src/components/customer/dh-customer-contact-details.component.ts
+++ b/libs/dh/metering-point/feature-overview/src/components/customer/dh-customer-contact-details.component.ts
@@ -49,7 +49,7 @@ import { DhCustomerContactComponent } from './dh-customer-contact.component';
       size="large"
       #modal
     >
-      <vater-stack direction="column" align="start">
+      <vater-stack direction="column" alignment="start">
         <h3>{{ t('legalContact') }}</h3>
         @if (this.legalContact) {
           <dh-customer-contact [contact]="legalContact" />

--- a/libs/dh/metering-point/feature-overview/src/components/related/dh-related-metering-point.component.ts
+++ b/libs/dh/metering-point/feature-overview/src/components/related/dh-related-metering-point.component.ts
@@ -75,13 +75,13 @@ import { DhMeteringPointStatusComponent } from '../dh-metering-point-status.comp
     <li
       vater-stack
       direction="row"
-      align="center"
+      alignment="center"
       justify="space-between"
       class="metering-point"
       [class.metering-point--selected]="isHighlighted()"
       [routerLink]="getLink('master-data', meteringPoint().identification)"
     >
-      <vater-stack align="start">
+      <vater-stack alignment="start">
         {{ 'meteringPointType.' + meteringPoint().type | transloco }}
 
         <span class="metering-point__metadata">

--- a/libs/dh/metering-point/feature-overview/src/components/related/dh-related-metering-points.component.ts
+++ b/libs/dh/metering-point/feature-overview/src/components/related/dh-related-metering-points.component.ts
@@ -59,7 +59,7 @@ import { RelatedMeteringPoints } from '../../types';
         <h3>{{ 'meteringPoint.relatedMeteringPointsTitle' | transloco }}</h3>
       </watt-card-title>
 
-      <ul vater-stack align="stretch">
+      <ul vater-stack alignment="stretch">
         @let parent = relatedMeteringPoints()?.parent;
         @let current = relatedMeteringPoints()?.current;
 

--- a/libs/dh/profile/feature-profile-modal/src/lib/dh-profile-modal/dh-profile-modal.component.html
+++ b/libs/dh/profile/feature-profile-modal/src/lib/dh-profile-modal/dh-profile-modal.component.html
@@ -21,9 +21,9 @@ limitations under the License.
 >
   <form [formGroup]="userPreferencesForm" id="userPreferencesForm" (ngSubmit)="save()">
     <vater-flex fill="vertical" gap="m">
-      <vater-stack class="names" align="start" direction="column" gap="s">
+      <vater-stack class="names" alignment="start" direction="column" gap="s">
         <h4 class="watt-headline-4">{{ t("myInformation") }}</h4>
-        <vater-stack align="start" direction="row" gap="s">
+        <vater-stack alignment="start" direction="row" gap="s">
           <watt-text-field
             [label]="t('name')"
             [formControl]="userPreferencesForm.controls.firstName"

--- a/libs/dh/reports/feature-measurements-reports/src/components/request-report/request-as-modal.component.html
+++ b/libs/dh/reports/feature-measurements-reports/src/components/request-report/request-as-modal.component.html
@@ -20,7 +20,7 @@ limitations under the License.
   *transloco="let t; read: 'reports.measurementsReports.requestReportModal'"
 >
   <form id="request-as-measurements-report-form" [formGroup]="form" (ngSubmit)="submit()">
-    <vater-stack align="stretch" direction="column" gap="l">
+    <vater-stack alignment="stretch" direction="column" gap="l">
       <watt-dropdown
         [label]="t('requestAs')"
         [showResetOption]="false"

--- a/libs/dh/reports/feature-settlement-reports/src/components/details/details.component.html
+++ b/libs/dh/reports/feature-settlement-reports/src/components/details/details.component.html
@@ -83,7 +83,7 @@ limitations under the License.
       </watt-card>
 
       <watt-card variant="solid" class="card-grid-areas">
-        <vater-stack direction="row" gap="s" align="center">
+        <vater-stack direction="row" gap="s" alignment="center">
           <h4>{{ t("drawer.gridAreas") }}</h4>
           <span class="watt-chip-label">{{ tableSource.data.length }}</span>
         </vater-stack>

--- a/libs/dh/reports/feature-settlement-reports/src/components/request-report/request-as-modal.component.html
+++ b/libs/dh/reports/feature-settlement-reports/src/components/request-report/request-as-modal.component.html
@@ -20,7 +20,7 @@ limitations under the License.
   *transloco="let t; read: 'reports.settlementReports.requestReportModal'"
 >
   <form id="request-as-settlement-report-form" [formGroup]="form" (ngSubmit)="submit()">
-    <vater-stack align="stretch" direction="column" gap="l">
+    <vater-stack alignment="stretch" direction="column" gap="l">
       <watt-dropdown
         [label]="t('requestAs')"
         [showResetOption]="false"

--- a/libs/dh/reports/feature-settlement-reports/src/components/request-report/select-calculation-modal.component.ts
+++ b/libs/dh/reports/feature-settlement-reports/src/components/request-report/select-calculation-modal.component.ts
@@ -58,7 +58,7 @@ import { KeyValuePairOfStringAndListOfSettlementReportApplicableCalculation } fr
       >
         @for (group of modalData.rawData; track group) {
           @if (group.value.length > 1) {
-            <vater-stack align="start" gap="s" class="watt-space-stack-l">
+            <vater-stack alignment="start" gap="s" class="watt-space-stack-l">
               <span class="watt-label">{{ group.value[0].gridAreaWithName?.displayName }}</span>
 
               @for (calculation of group.value; track calculation; let first = $first) {

--- a/libs/dh/shared/ui-util/src/lib/dh-result.component.ts
+++ b/libs/dh/shared/ui-util/src/lib/dh-result.component.ts
@@ -43,7 +43,7 @@ import { WattEmptyStateComponent } from '@energinet-datahub/watt/empty-state';
     @if (!loading() && !hasError() && !empty()) {
       <ng-content />
     } @else {
-      <vater-stack direction="row" offset="m" fill="vertical" justify="center" align="center">
+      <vater-stack direction="row" offset="m" fill="vertical" justify="center" alignment="center">
         @if (loading()) {
           <watt-spinner />
         }

--- a/libs/dh/wholesale/feature-calculations/src/lib/create/fields/schedule-field.ts
+++ b/libs/dh/wholesale/feature-calculations/src/lib/create/fields/schedule-field.ts
@@ -56,7 +56,7 @@ import { TranslocoDirective } from '@jsverse/transloco';
       >
         {{ t('now') }}
       </watt-radio>
-      <vater-stack direction="row" gap="ml" align="start">
+      <vater-stack direction="row" gap="ml" alignment="start">
         <watt-radio
           group="scheduled"
           class="scheduled"

--- a/libs/dh/wholesale/feature-calculations/src/lib/details/details.component.html
+++ b/libs/dh/wholesale/feature-calculations/src/lib/details/details.component.html
@@ -99,7 +99,7 @@ limitations under the License.
         </watt-progress-tracker>
       }
 
-      <vater-stack scrollable fill="vertical" align="stretch">
+      <vater-stack scrollable fill="vertical" alignment="stretch">
         @if (wholesaleAndEnergyCalculation && wholesaleAndEnergyCalculation?.gridAreas) {
           <dh-calculations-grid-areas-table [data]="wholesaleAndEnergyCalculation.gridAreas" />
         } @else if (query.error()) {

--- a/libs/eo/transfers/src/lib/form/eo-transfers-form.component.ts
+++ b/libs/eo/transfers/src/lib/form/eo-transfers-form.component.ts
@@ -301,7 +301,7 @@ type FormField = 'senderTin' | 'receiverTin' | 'startDate' | 'endDate' | 'transf
               (entering)="createTransferAgreementProposal()"
             >
               <div class="content-min-height">
-                <vater-stack direction="column" gap="l" align="start">
+                <vater-stack direction="column" gap="l" alignment="start">
                   @if (!generateProposalFailed()) {
                     <h2>
                       {{

--- a/libs/watt/package/code/watt-code.component.ts
+++ b/libs/watt/package/code/watt-code.component.ts
@@ -37,7 +37,7 @@ import { WATT_CODE_HIGHLIGHT_WORKER_FACTORY } from './watt-code.worker.token';
   selector: 'watt-code',
   template: `
     @if (loading()) {
-      <vater-stack [fill]="'horizontal'" [align]="'center'"><watt-spinner /></vater-stack>
+      <vater-stack fill="horizontal" alignment="center"><watt-spinner /></vater-stack>
     } @else {
       <pre>
         <code class="watt-code-content" [innerHTML]="formattedCode()"></code>

--- a/libs/watt/package/dropzone/watt-dropzone.ts
+++ b/libs/watt/package/dropzone/watt-dropzone.ts
@@ -91,7 +91,7 @@ export type MimeType = `${string}/${string}`;
           (dragleave)="dragOver.set(false)"
         >
           @if (progress() < 100) {
-            <vater-stack center gap="s" fill="horizontal" align="start">
+            <vater-stack center gap="s" fill="horizontal" alignment="start">
               <span>{{ intl.loadingMessage }} ( {{ progress() + '%' }} )</span>
               <mat-progress-bar mode="determinate" [value]="progress()" />
             </vater-stack>

--- a/libs/watt/package/field/watt-field.component.ts
+++ b/libs/watt/package/field/watt-field.component.ts
@@ -73,7 +73,7 @@ import { NgTemplateOutlet } from '@angular/common';
           }
         </span>
       }
-      <vater-flex direction="row" gap="s" align="center">
+      <vater-flex direction="row" gap="s" alignment="center">
         <div
           vater
           fill="horizontal"

--- a/libs/watt/package/vater/vater-flex.component.ts
+++ b/libs/watt/package/vater/vater-flex.component.ts
@@ -26,7 +26,7 @@ import { VaterLayoutDirective } from './vater-layout.directive';
   hostDirectives: [
     {
       directive: VaterLayoutDirective,
-      inputs: ['align', 'direction', 'justify', 'wrap', 'gap', 'offset'],
+      inputs: ['alignment', 'direction', 'justify', 'wrap', 'gap', 'offset'],
     },
     {
       directive: VaterUtilityDirective,

--- a/libs/watt/package/vater/vater-layout.directive.ts
+++ b/libs/watt/package/vater/vater-layout.directive.ts
@@ -27,7 +27,7 @@ import { Align, Direction, Justify, Spacing } from './types';
 })
 export class VaterLayoutDirective {
   /** Cross axis alignment of the flex items. */
-  align = input<Align>();
+  alignment = input<Align>();
 
   /** Direction of the flex items. Defaults to `column`. */
   direction = input<Direction>('column');
@@ -45,7 +45,7 @@ export class VaterLayoutDirective {
   wrap = input(false, { transform: booleanAttribute });
 
   // Computed class names
-  protected alignClass = computed(() => this.align() && `vater-align-${this.align()}`);
+  protected alignClass = computed(() => this.alignment() && `vater-align-${this.alignment()}`);
   protected directionClass = computed(() => this.direction() && `vater-${this.direction()}`);
   protected gapClass = computed(() => this.gap() && `vater-gap-${this.gap()}`);
   protected justifyClass = computed(() => this.justify() && `vater-justify-${this.justify()}`);

--- a/libs/watt/package/vater/vater-stack.component.ts
+++ b/libs/watt/package/vater/vater-stack.component.ts
@@ -26,7 +26,7 @@ import { VaterLayoutDirective } from './vater-layout.directive';
   hostDirectives: [
     {
       directive: VaterLayoutDirective,
-      inputs: ['align', 'direction', 'justify', 'wrap', 'gap', 'offset'],
+      inputs: ['alignment', 'direction', 'justify', 'wrap', 'gap', 'offset'],
     },
     {
       directive: VaterUtilityDirective,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

### Watt Design System
- rename `align` property to `alignment`. The `align` property is a native attribute that is deprecated. Using it causes issues in Edge, possibly also Chrome.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
