### PR TITLE
fix(watt): move watt-tooltip to left side

### DIFF
--- a/libs/watt/package/package.json
+++ b/libs/watt/package/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@energinet/watt",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/libs/watt/package/tooltip/watt-tooltip.component.scss
+++ b/libs/watt/package/tooltip/watt-tooltip.component.scss
@@ -19,6 +19,7 @@ $offset: 6px;
 
 :host {
   position: absolute;
+  left: 0; /* Prevent overflow on right side */
   pointer-events: none;
   z-index: 1000;
   display: inline-block;


### PR DESCRIPTION
This PR fixes an issue where a hidden tooltip could overflow the parent, causing a scrollbar. By positioning it on the left side, this is much less likely to occur. Once the tooltip is shown, it will automatically position itself properly, so it should have no effect otherwise.