### PR TITLE
fix(watt): do not touch cross-axis min sizing for vater-stack

### DIFF
--- a/libs/dh/metering-point/feature-measurements/src/components/upload.component.ts
+++ b/libs/dh/metering-point/feature-measurements/src/components/upload.component.ts
@@ -96,6 +96,10 @@ import { CommonModule } from '@angular/common';
       min-width: min(100%, 674px);
     }
 
+    watt-datepicker {
+      min-width: max-content;
+    }
+
     .summary-table {
       width: 100%;
       border-collapse: collapse;

--- a/libs/watt/package/core/styles/_vater.scss
+++ b/libs/watt/package/core/styles/_vater.scss
@@ -21,9 +21,12 @@
   [vater-stack] {
     align-items: center;
 
-    & > * {
-      min-height: max-content;
+    &.vater-row > * {
       min-width: max-content;
+    }
+
+    &.vater-column > * {
+      min-height: max-content;
     }
   }
 
@@ -58,7 +61,7 @@
     height: 100%;
   }
 
-  :not(vater-stack, vater-flex) {
+  :not(vater-stack, [vater-stack], vater-flex, [vater-flex]) {
     &.vater-fill-vertical,
     &.vater-fill-horizontal,
     &.vater-fill-both {


### PR DESCRIPTION
Undo this change to `vater-stack` that fx. caused dropdowns to overflow when selecting many items. I believe it was a mistake to add and has more downsides than upsides. I don't think it should break anything.