### PR TITLE
Add the auth header to reports api calls in local development

### DIFF
--- a/libs/eo/shared/assets/src/assets/configuration/eo-api-environment.local.json
+++ b/libs/eo/shared/assets/src/assets/configuration/eo-api-environment.local.json
@@ -7,7 +7,8 @@
     "transfer": "1",
     "claim-automation": "1",
     "measurements": "1",
-    "authorization": "1"
+    "authorization": "1",
+    "reports": "1"
   },
   "/* NOTE: Remember to add the URLs to the prerendered routes: /apps/eo/app-eo-landing-page/src/prerendered-routes.txt */": "ex. /en/documentation/<DOC-ID>",
   "documentation": [


### PR DESCRIPTION
## Description

Auth header not added when running locally, and calling /api/reports

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #4663
