### PR TITLE
Minor UI adjustments

### DIFF
--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -576,6 +576,7 @@
     "new": "Ny søgning",
     "results": "Resultater",
     "searchById": "Søg på ID",
+    "refetching": "Henter forretningsbeskeder...",
     "drawer": {
       "message": "Besked",
       "sender": "Afsender",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -576,6 +576,7 @@
     "new": "New search",
     "results": "Results",
     "searchById": "Search by ID",
+    "refetching": "Fetching request and response messages...",
     "drawer": {
       "message": "Message",
       "receiver": "Receiver",

--- a/libs/dh/grid-areas/src/components/grid-areas.component.html
+++ b/libs/dh/grid-areas/src/components/grid-areas.component.html
@@ -22,7 +22,7 @@ limitations under the License.
 
       <vater-spacer />
 
-      <watt-search [label]="'shared.search' | transloco" (search)="search($event)" />
+      <watt-search [label]="'shared.search' | transloco" (search)="search($event)" [trim]="true" />
 
       <watt-button icon="download" variant="text" (click)="download()">{{
         "shared.download" | transloco

--- a/libs/dh/wholesale/feature-requests/src/lib/table.ts
+++ b/libs/dh/wholesale/feature-requests/src/lib/table.ts
@@ -97,7 +97,7 @@ type Request = ExtractNodeType<GetRequestsDataSource>;
         </ng-container>
 
         <ng-container *wattTableCell="columns['period']; let row">
-          {{ row.period | wattDate }}
+          {{row.period?.start | wattDate}} ― <span style="white-space: nowrap;">{{ row.period?.end | wattDate }}</span>
         </ng-container>
 
         <ng-container *wattTableCell="columns['meteringPointTypeOrPriceType']; let row">

--- a/libs/watt/package/data/watt-data-table.component.ts
+++ b/libs/watt/package/data/watt-data-table.component.ts
@@ -97,7 +97,7 @@ import { WattDataIntlService } from './watt-data-intl.service';
           <ng-content />
           <vater-spacer />
           @if (enableSearch()) {
-            <watt-search [label]="searchLabel() ?? intl.search" (search)="onSearch($event)" />
+            <watt-search [label]="searchLabel() ?? intl.search" [trim]="trimSearch()" (search)="onSearch($event)" />
           }
           <ng-content select="watt-data-actions" />
           <ng-content select="watt-button" />
@@ -144,6 +144,7 @@ export class WattDataTableComponent {
   error = input<unknown>();
   ready = input(true);
   enableSearch = input(true);
+  trimSearch = input<boolean>(true);
   enableRetry = input(false);
   enableCount = input(true);
   enableEmptyState = input(true);

--- a/libs/watt/package/search/watt-search.component.ts
+++ b/libs/watt/package/search/watt-search.component.ts
@@ -34,7 +34,7 @@ import { WattIconComponent } from '@energinet/watt/icon';
         type="text"
         role="searchbox"
         [placeholder]="label()"
-        (input)="search$.next(input.value)"
+        (input)="onInput(input.value)"
       />
       <span class="wrapper">
         <span class="button">
@@ -65,6 +65,11 @@ export class WattSearchComponent {
   debounceTime = input<number>(300);
 
   /**
+   * If true, trims whitespace from the search value before emitting.
+   */
+  trim = input<boolean>(true);
+
+  /**
    * @ignore
    */
   search$ = new BehaviorSubject<string>('');
@@ -75,6 +80,14 @@ export class WattSearchComponent {
   search = outputFromObservable(this.search$.pipe(skip(1), debounceTime(this.debounceTime())));
 
   /**
+   * Handles input event, optionally trimming the value.
+   */
+  onInput(value: string): void {
+    const processed = this.trim() ? value.trim() : value;
+    this.search$.next(processed);
+  }
+
+  /**
    * @ignore
    */
   clear(): void {
@@ -82,7 +95,6 @@ export class WattSearchComponent {
     if (element.value === '') return;
 
     element.value = '';
-
-    this.search$.next(element.value);
+    this.onInput(element.value);
   }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This pull request introduces several updates across multiple components, focusing on enhancing search functionality, and adding user feedback during data fetching. Below is a summary of the most significant changes, grouped by theme:

### Localization Enhancements
- Added a new key, `"refetching"`, to the Danish (`da.json`) and English (`en.json`) localization files for displaying messages during data refetching. [[1]](diffhunk://#diff-a4cdf4675cf1ad53e9c21e6fd8d49738d00f390edd576928617311bb1f20fffbR579) [[2]](diffhunk://#diff-2ee872ddaedf583df773027393d9d4697485118b078472c78291f95afcc0a08cR579)

### Search Functionality Improvements
- Updated the `WattSearchComponent` to include a `trim` input property, allowing search values to be trimmed of whitespace before being emitted **(This is now default behaviour).** 
- Updated `watt-data-table` to trim search fields as default

### Data Fetching and User Feedback
- Enhanced the `DhMessageArchiveSearchTableComponent` to display a loading toast message during data refetching. This includes a new `showRefetchingIndicator` method that uses `WattToastService` and `TranslocoService` for localized feedback. The toast is dismissed once the refetching process completes.

### Miscellaneous
- Updated the display format for date ranges in the `wholesale/feature-requests` table to include both start and end dates, ensuring better "responsiveness".

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#760](https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/760)
