### PR TITLE
Minor UI adjustments

### DIFF
--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -576,6 +576,7 @@
     "new": "Ny søgning",
     "results": "Resultater",
     "searchById": "Søg på ID",
+    "refetching": "Henter forretningsbeskeder...",
     "drawer": {
       "message": "Besked",
       "sender": "Afsender",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -576,6 +576,7 @@
     "new": "New search",
     "results": "Results",
     "searchById": "Search by ID",
+    "refetching": "Fetching request and response messages...",
     "drawer": {
       "message": "Message",
       "receiver": "Receiver",

--- a/libs/dh/grid-areas/src/components/grid-areas.component.html
+++ b/libs/dh/grid-areas/src/components/grid-areas.component.html
@@ -22,7 +22,7 @@ limitations under the License.
 
       <vater-spacer />
 
-      <watt-search [label]="'shared.search' | transloco" (search)="search($event)" [trim]="true" />
+      <watt-search [label]="'shared.search' | transloco" (search)="search($event)" />
 
       <watt-button icon="download" variant="text" (click)="download()">{{
         "shared.download" | transloco

--- a/libs/dh/grid-areas/src/components/grid-areas.component.html
+++ b/libs/dh/grid-areas/src/components/grid-areas.component.html
@@ -22,7 +22,7 @@ limitations under the License.
 
       <vater-spacer />
 
-      <watt-search [label]="'shared.search' | transloco" (search)="search($event)" />
+      <watt-search [label]="'shared.search' | transloco" (search)="search($event)" [trim]="true" />
 
       <watt-button icon="download" variant="text" (click)="download()">{{
         "shared.download" | transloco

--- a/libs/dh/message-archive/feature-search/src/lib/table.component.ts
+++ b/libs/dh/message-archive/feature-search/src/lib/table.component.ts
@@ -49,7 +49,7 @@ import { GetArchivedMessagesDataSource } from '@energinet-datahub/dh/shared/doma
 
 import { DhMessageArchiveSearchFiltersComponent } from './filters.component';
 import { WattToastService } from '@energinet-datahub/watt/toast';
-import { delay, filter } from 'rxjs';
+import { delay, filter, first } from 'rxjs';
 
 type Variables = Partial<GetArchivedMessagesQueryVariables>;
 
@@ -172,7 +172,8 @@ export class DhMessageArchiveSearchTableComponent {
         .connect()
         .pipe(
           delay(300),
-          filter(() => !this.dataSource.loading)
+          filter(() => !this.dataSource.loading),
+          first()
         )
         .subscribe(() => {
           this.toast.dismiss();

--- a/libs/dh/message-archive/feature-search/src/lib/table.component.ts
+++ b/libs/dh/message-archive/feature-search/src/lib/table.component.ts
@@ -17,15 +17,7 @@
  */
 //#endregion
 import { ReactiveFormsModule } from '@angular/forms';
-import {
-  Component,
-  computed,
-  effect,
-  inject,
-  output,
-  signal,
-  viewChild,
-} from '@angular/core';
+import { Component, computed, effect, inject, output, signal, viewChild } from '@angular/core';
 
 import { TranslocoDirective, TranslocoService } from '@jsverse/transloco';
 
@@ -170,8 +162,7 @@ export class DhMessageArchiveSearchTableComponent {
   };
 
   private readonly shouldShowLoading = computed(() => {
-    return this.dataSource.loading &&
-           this.dataSource.data.length > 0;
+    return this.dataSource.loading && this.dataSource.data.length > 0;
   });
 
   constructor() {

--- a/libs/dh/message-archive/feature-search/src/lib/table.component.ts
+++ b/libs/dh/message-archive/feature-search/src/lib/table.component.ts
@@ -159,7 +159,7 @@ export class DhMessageArchiveSearchTableComponent {
     this.showRefetchingIndicator();
   };
 
-  showRefetchingIndicator = () => {
+  private showRefetchingIndicator = () => {
     if (this.dataSource.data.length === 0) return;
 
     this.toast.open({

--- a/libs/dh/wholesale/feature-requests/src/lib/table.ts
+++ b/libs/dh/wholesale/feature-requests/src/lib/table.ts
@@ -97,7 +97,7 @@ type Request = ExtractNodeType<GetRequestsDataSource>;
         </ng-container>
 
         <ng-container *wattTableCell="columns['period']; let row">
-          {{ row.period | wattDate }}
+          {{row.period?.start | wattDate}} ― <span style="white-space: nowrap;">{{ row.period?.end | wattDate }}</span>
         </ng-container>
 
         <ng-container *wattTableCell="columns['meteringPointTypeOrPriceType']; let row">

--- a/libs/dh/wholesale/feature-requests/src/lib/table.ts
+++ b/libs/dh/wholesale/feature-requests/src/lib/table.ts
@@ -97,7 +97,8 @@ type Request = ExtractNodeType<GetRequestsDataSource>;
         </ng-container>
 
         <ng-container *wattTableCell="columns['period']; let row">
-          {{row.period?.start | wattDate}} ― <span style="white-space: nowrap;">{{ row.period?.end | wattDate }}</span>
+          {{ row.period?.start | wattDate }} ―
+          <span style="white-space: nowrap;">{{ row.period?.end | wattDate }}</span>
         </ng-container>
 
         <ng-container *wattTableCell="columns['meteringPointTypeOrPriceType']; let row">

--- a/libs/watt/package/data/watt-data-table.component.ts
+++ b/libs/watt/package/data/watt-data-table.component.ts
@@ -97,7 +97,11 @@ import { WattDataIntlService } from './watt-data-intl.service';
           <ng-content />
           <vater-spacer />
           @if (enableSearch()) {
-            <watt-search [label]="searchLabel() ?? intl.search" [trim]="trimSearch()" (search)="onSearch($event)" />
+            <watt-search
+              [label]="searchLabel() ?? intl.search"
+              [trim]="trimSearch()"
+              (search)="onSearch($event)"
+            />
           }
           <ng-content select="watt-data-actions" />
           <ng-content select="watt-button" />

--- a/libs/watt/package/data/watt-data-table.component.ts
+++ b/libs/watt/package/data/watt-data-table.component.ts
@@ -148,7 +148,7 @@ export class WattDataTableComponent {
   error = input<unknown>();
   ready = input(true);
   enableSearch = input(true);
-  trimSearch = input<boolean>(true);
+  trimSearch = input(true);
   enableRetry = input(false);
   enableCount = input(true);
   enableEmptyState = input(true);

--- a/libs/watt/package/data/watt-data-table.component.ts
+++ b/libs/watt/package/data/watt-data-table.component.ts
@@ -97,7 +97,7 @@ import { WattDataIntlService } from './watt-data-intl.service';
           <ng-content />
           <vater-spacer />
           @if (enableSearch()) {
-            <watt-search [label]="searchLabel() ?? intl.search" (search)="onSearch($event)" />
+            <watt-search [label]="searchLabel() ?? intl.search" [trim]="trimSearch()" (search)="onSearch($event)" />
           }
           <ng-content select="watt-data-actions" />
           <ng-content select="watt-button" />
@@ -144,6 +144,7 @@ export class WattDataTableComponent {
   error = input<unknown>();
   ready = input(true);
   enableSearch = input(true);
+  trimSearch = input<boolean>(true);
   enableRetry = input(false);
   enableCount = input(true);
   enableEmptyState = input(true);

--- a/libs/watt/package/package.json
+++ b/libs/watt/package/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@energinet/watt",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/libs/watt/package/search/watt-search.component.ts
+++ b/libs/watt/package/search/watt-search.component.ts
@@ -67,7 +67,7 @@ export class WattSearchComponent {
   /**
    * If true, trims whitespace from the search value before emitting.
    */
-  trim = input<boolean>(true);
+  trim = input(true);
 
   /**
    * @ignore

--- a/libs/watt/package/search/watt-search.component.ts
+++ b/libs/watt/package/search/watt-search.component.ts
@@ -34,7 +34,7 @@ import { WattIconComponent } from '@energinet/watt/icon';
         type="text"
         role="searchbox"
         [placeholder]="label()"
-        (input)="search$.next(input.value)"
+        (input)="onInput(input.value)"
       />
       <span class="wrapper">
         <span class="button">
@@ -65,6 +65,11 @@ export class WattSearchComponent {
   debounceTime = input<number>(300);
 
   /**
+   * If true, trims whitespace from the search value before emitting.
+   */
+  trim = input<boolean>(true);
+
+  /**
    * @ignore
    */
   search$ = new BehaviorSubject<string>('');
@@ -75,6 +80,14 @@ export class WattSearchComponent {
   search = outputFromObservable(this.search$.pipe(skip(1), debounceTime(this.debounceTime())));
 
   /**
+   * Handles input event, optionally trimming the value.
+   */
+  onInput(value: string): void {
+    const processed = this.trim() ? value.trim() : value;
+    this.search$.next(processed);
+  }
+
+  /**
    * @ignore
    */
   clear(): void {
@@ -82,7 +95,6 @@ export class WattSearchComponent {
     if (element.value === '') return;
 
     element.value = '';
-
-    this.search$.next(element.value);
+    this.onInput(element.value);
   }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This pull request introduces several updates across multiple components, focusing on enhancing search functionality, and adding user feedback during data fetching. Below is a summary of the most significant changes, grouped by theme:

### Search Functionality Improvements
- Updated the `WattSearchComponent` to include a `trim` input property, allowing search values to be trimmed of whitespace before being emitted **(This is now default behaviour).** 
- Updated `watt-data-table` to trim search fields as default

### Data Fetching and User Feedback
- Enhanced the `DhMessageArchiveSearchTableComponent` to display a loading toast message during data refetching. 

### Date "responsiveness"
- Updated the display format for date ranges in the `wholesale/feature-requests`, ensuring dates are not splitten.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#760](https://app.zenhub.com/workspaces/mosaic-60a6105157304f00119be86e/issues/gh/energinet-datahub/team-mosaic/760)
