### PR TITLE
#2571 - Configure Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,17 @@ updates:
     directory: /source/hello-world
     schedule:
       interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    groups:
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
# Description
This PR configures Dependabot to automatically check for updates to GitHub Actions used in this repository.

Highlights:
- Runs daily to detect new versions.
- Groups updates into:
  - Security updates (e.g., CVE fixes)
  - Version updates (e.g., new features, minor bumps)

## References
[Use dependabot to update actions usages of .github repo #2571](https://app.zenhub.com/workspaces/team-fusion-6193fe815d79fc0011e741b1/issues/gh/energinet-datahub/team-the-outlaws/2571)