### PR TITLE
INC0462912 - Use watt-date-range-chip instead of two individual watt-chip

### DIFF
--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -596,8 +596,7 @@
       "businessReason": "Forretningsårsag",
       "sender": "Afsender",
       "receiver": "Modtager",
-      "start": "Starttidspunkt",
-      "end": "Sluttidspunkt",
+      "dateRange": "Datointerval",
       "reset": "Nulstil",
       "confirm": "Søg"
     },
@@ -606,8 +605,7 @@
       "businessReason": "Forretningsårsag",
       "sender": "Afsender",
       "receiver": "Modtager",
-      "start": "Start",
-      "end": "Slut",
+      "dateRange": "Datointerval",
       "includeRelated": "Inkluder relaterede",
       "created": "Tidspunkt"
     },

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -596,8 +596,7 @@
       "businessReason": "Business reason",
       "sender": "Sender",
       "receiver": "Receiver",
-      "start": "Start time",
-      "end": "End time",
+      "dateRange": "Date range",
       "reset": "Reset",
       "confirm": "Search"
     },
@@ -606,8 +605,7 @@
       "businessReason": "Business reason",
       "sender": "Sender",
       "receiver": "Receiver",
-      "start": "Start",
-      "end": "End",
+      "dateRange": "Date range",
       "includeRelated": "Include related",
       "created": "Created"
     },

--- a/libs/dh/message-archive/feature-search/src/lib/filters.component.ts
+++ b/libs/dh/message-archive/feature-search/src/lib/filters.component.ts
@@ -21,7 +21,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { TranslocoDirective } from '@jsverse/transloco';
 
 import { WattFilterChipComponent } from '@energinet-datahub/watt/chip';
-import { WattDateChipComponent, WattFormChipDirective } from '@energinet-datahub/watt/chip';
+import { WattDateRangeChipComponent, WattFormChipDirective } from '@energinet-datahub/watt/chip';
 import { WattDropdownComponent } from '@energinet-datahub/watt/dropdown';
 import { VaterStackComponent } from '@energinet-datahub/watt/vater';
 
@@ -39,7 +39,7 @@ import { getDocumentTypeIdentifier } from '@energinet-datahub/dh/message-archive
     ReactiveFormsModule,
     TranslocoDirective,
     VaterStackComponent,
-    WattDateChipComponent,
+    WattDateRangeChipComponent,
     WattDropdownComponent,
     WattFilterChipComponent,
     WattFormChipDirective,
@@ -60,9 +60,9 @@ import { getDocumentTypeIdentifier } from '@energinet-datahub/dh/message-archive
           {{ t('includeRelated') }}
         </watt-filter-chip>
       } @else {
-        <watt-date-chip [formControl]="form.controls.start" [placeholder]="t('start')" />
-
-        <watt-date-chip [formControl]="form.controls.end" [placeholder]="t('end')" />
+        <watt-date-range-chip [formControl]="form.controls.dateRange!">
+          {{ t('dateRange') }}
+        </watt-date-range-chip>
 
         <watt-dropdown
           [formControl]="form.controls.documentTypes"

--- a/libs/dh/message-archive/feature-search/src/lib/form.service.ts
+++ b/libs/dh/message-archive/feature-search/src/lib/form.service.ts
@@ -18,7 +18,7 @@
 //#endregion
 import { computed, Injectable, inject } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { dayjs } from '@energinet-datahub/watt/date';
+import { dayjs, WattRange } from '@energinet-datahub/watt/date';
 import {
   BusinessReason,
   GetArchivedMessagesQueryVariables,
@@ -50,8 +50,10 @@ export class DhMessageArchiveSearchFormService {
     businessReasons: dhMakeFormControl<BusinessReason[]>(),
     senderId: dhMakeFormControl<string>(),
     receiverId: dhMakeFormControl<string>(),
-    start: dhMakeFormControl(dayjs().startOf('day').toDate()),
-    end: dhMakeFormControl(dayjs().endOf('day').toDate()),
+    dateRange: dhMakeFormControl<WattRange<Date>>({
+      start: dayjs().startOf('day').toDate(),
+      end: dayjs().endOf('day').toDate(),
+    }),
   });
 
   root = this.form;
@@ -78,8 +80,11 @@ export class DhMessageArchiveSearchFormService {
       startWith(null),
       map(() => this.form.getRawValue()),
       exists(),
-      keyExists('start'),
-      map(({ start, end, ...variables }) => ({ ...variables, created: { start, end } }))
+      keyExists('dateRange'),
+      map(({ dateRange, ...variables }) => ({
+        ...variables,
+        created: { start: dateRange.start, end: dateRange.end }
+      }))
     ),
     { requireSync: true }
   );

--- a/libs/dh/message-archive/feature-search/src/lib/start.component.ts
+++ b/libs/dh/message-archive/feature-search/src/lib/start.component.ts
@@ -22,7 +22,7 @@ import { TranslocoDirective } from '@jsverse/transloco';
 
 import { VaterFlexComponent } from '@energinet-datahub/watt/vater';
 import { WattButtonComponent } from '@energinet-datahub/watt/button';
-import { WattDateTimeField } from '@energinet-datahub/watt/datetime-field';
+import { WattDatepickerComponent } from '@energinet-datahub/watt/datepicker';
 import { WattDropdownComponent } from '@energinet-datahub/watt/dropdown';
 import { WattModalActionsComponent, WattModalComponent } from '@energinet-datahub/watt/modal';
 
@@ -37,7 +37,7 @@ import { DhMessageArchiveSearchFormService } from './form.service';
     TranslocoDirective,
     VaterFlexComponent,
     WattButtonComponent,
-    WattDateTimeField,
+    WattDatepickerComponent,
     WattDropdownComponent,
     WattModalActionsComponent,
     WattModalComponent,
@@ -58,12 +58,10 @@ import { DhMessageArchiveSearchFormService } from './form.service';
         [formGroup]="form.root"
         (ngSubmit)="searchChanged.emit(form.values())"
       >
-        <watt-datetime-field [label]="t('start')" [formControl]="form.controls.start" />
-
-        <watt-datetime-field
-          [label]="t('end')"
-          [formControl]="form.controls.end"
-          [inclusive]="true"
+        <watt-datepicker 
+          [label]="t('dateRange')" 
+          [formControl]="form.controls.dateRange" 
+          [range]="true" 
         />
 
         <watt-dropdown


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Changes to `message-archive` to solve inconsistent behaviour when starting and filtering dates: 
- Use `watt-date-range-chip` instead of two individual `watt-chip`
- Use a single `watt-datepicker` with `[range]="true"` in `start.component.ts` instead of having two individual `watt-datepicker`

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
