### PR TITLE
fix: Use metering point for grid loss notification

### DIFF
--- a/libs/dh/core/feature-notifications/src/lib/dh-get-route-by-type.ts
+++ b/libs/dh/core/feature-notifications/src/lib/dh-get-route-by-type.ts
@@ -28,7 +28,7 @@ import {
 
 import { DhNotification } from './dh-notification';
 
-export function dhGetRouteByType({ notificationType }: DhNotification): string[] {
+export function dhGetRouteByType({ notificationType, relatedToId }: DhNotification): string[] {
   const rootPath = '/';
 
   switch (notificationType) {
@@ -58,11 +58,13 @@ export function dhGetRouteByType({ notificationType }: DhNotification): string[]
         getPath<MarketParticipantSubPaths>('actors'),
       ];
     case NotificationType.GridLossValidationError:
-      return [
-        rootPath,
-        getPath<BasePaths>('metering-point'),
-        getPath<MeteringPointSubPaths>('master-data'),
-      ]
+      if (relatedToId)
+        return [
+          rootPath,
+          getPath<BasePaths>('metering-point'),
+          relatedToId
+        ];
+      return [rootPath];
     default:
       return [rootPath];
   }

--- a/libs/dh/core/feature-notifications/src/lib/dh-get-route-by-type.ts
+++ b/libs/dh/core/feature-notifications/src/lib/dh-get-route-by-type.ts
@@ -22,6 +22,7 @@ import {
   ESettSubPaths,
   getPath,
   MarketParticipantSubPaths,
+  MeteringPointSubPaths,
   ReportsSubPaths,
 } from '@energinet-datahub/dh/core/routing';
 
@@ -56,6 +57,12 @@ export function dhGetRouteByType({ notificationType }: DhNotification): string[]
         getPath<BasePaths>('market-participant'),
         getPath<MarketParticipantSubPaths>('actors'),
       ];
+    case NotificationType.GridLossValidationError:
+      return [
+        rootPath,
+        getPath<BasePaths>('metering-point'),
+        getPath<MeteringPointSubPaths>('master-data'),
+      ]
     default:
       return [rootPath];
   }

--- a/libs/dh/core/feature-notifications/src/lib/dh-get-route-by-type.ts
+++ b/libs/dh/core/feature-notifications/src/lib/dh-get-route-by-type.ts
@@ -58,12 +58,13 @@ export function dhGetRouteByType({ notificationType, relatedToId }: DhNotificati
         getPath<MarketParticipantSubPaths>('actors'),
       ];
     case NotificationType.GridLossValidationError:
-      if (relatedToId)
+      if (relatedToId) {
         return [
           rootPath,
           getPath<BasePaths>('metering-point'),
           relatedToId
         ];
+      }
       return [rootPath];
     default:
       return [rootPath];

--- a/libs/dh/core/feature-notifications/src/lib/dh-get-route-by-type.ts
+++ b/libs/dh/core/feature-notifications/src/lib/dh-get-route-by-type.ts
@@ -22,7 +22,6 @@ import {
   ESettSubPaths,
   getPath,
   MarketParticipantSubPaths,
-  MeteringPointSubPaths,
   ReportsSubPaths,
 } from '@energinet-datahub/dh/core/routing';
 

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -60,7 +60,7 @@
       },
       "GridLossValidationError": {
         "headline": "Nettab's process fejlet",
-        "message": "Proces for beregning af nettab og systemkorrektion for netområde \"{{ relatedToId }}\" er fejlet"
+        "message": "Proces for beregning af nettab og systemkorrektion for målepunkt \"{{ relatedToId }}\" er fejlet"
       }
     }
   },

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -60,7 +60,7 @@
       },
       "GridLossValidationError": {
         "headline": "Grid loss process failed",
-        "message": "Process for calculating grid loss and system correction for grid area \"{{ relatedToId }}\" failed"
+        "message": "Process for calculating grid loss and system correction for metering point \"{{ relatedToId }}\" failed"
       }
     }
   },

--- a/libs/dh/shared/data-access-mocks/src/lib/notifications.mocks.ts
+++ b/libs/dh/shared/data-access-mocks/src/lib/notifications.mocks.ts
@@ -90,7 +90,7 @@ function getNotifications() {
             __typename: 'NotificationDto',
             id: 8,
             notificationType: NotificationType.GridLossValidationError,
-            relatedToId: '123456789012345678',
+            relatedToId: '222222222222222222',
             occurredAt: new Date('2025-08-07'),
           },
         ],

--- a/libs/dh/shared/data-access-mocks/src/lib/notifications.mocks.ts
+++ b/libs/dh/shared/data-access-mocks/src/lib/notifications.mocks.ts
@@ -90,7 +90,7 @@ function getNotifications() {
             __typename: 'NotificationDto',
             id: 8,
             notificationType: NotificationType.GridLossValidationError,
-            relatedToId: '123',
+            relatedToId: '123456789012345678',
             occurredAt: new Date('2025-08-07'),
           },
         ],


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

- Update grid loss notification to use metering point id.
- Deep link to metering point when clicking the notification.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
