### PR TITLE
fix(dh): add catch-all route

### DIFF
--- a/libs/dh/core/shell/src/lib/dh-core-shell.routes.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.routes.ts
@@ -100,4 +100,5 @@ export const dhCoreShellRoutes: Routes = [
     pathMatch: 'full',
     component: DhCoreLoginComponent,
   },
+  { path: '**', redirectTo: '/' },
 ];


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

### DataHub
- before the change navigating to non-existing route ended up in a blank page. Now the user is redirected to `/`

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
