### PR TITLE
Add custom ESLint rule to disallow @if around watt-field-error components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "root": true,
   "ignorePatterns": ["**/*"],
-  "plugins": ["@nx", "import"],
+  "plugins": ["@nx", "import", "@energinet-datahub/custom"],
   "extends": ["plugin:storybook/recommended"],
   "overrides": [
     {
@@ -187,7 +187,8 @@
       "files": ["*.component.html"],
       "extends": ["plugin:@nx/angular-template"],
       "rules": {
-        "@angular-eslint/template/prefer-self-closing-tags": ["error"]
+        "@angular-eslint/template/prefer-self-closing-tags": ["error"],
+        "@energinet-datahub/custom/no-if-around-watt-field-error": ["error"]
       }
     },
     {

--- a/libs/watt/package/package.json
+++ b/libs/watt/package/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@energinet/watt",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/tools/eslint-rules/.eslintrc.json
+++ b/tools/eslint-rules/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"]
+}

--- a/tools/eslint-rules/README.md
+++ b/tools/eslint-rules/README.md
@@ -1,0 +1,1 @@
+# Custom eslint rules

--- a/tools/eslint-rules/package.json
+++ b/tools/eslint-rules/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@energinet-datahub/eslint-plugin-custom",
+  "version": "0.0.1",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@angular-eslint/eslint-plugin-template": "*",
+    "@typescript-eslint/utils": "*"
+  },
+  "devDependencies": {
+    "@angular-eslint/template-parser": "*",
+    "@types/eslint": "*",
+    "@types/node": "*",
+    "eslint": "*",
+    "typescript": "*",
+    "vitest": "*"
+  }
+}

--- a/tools/eslint-rules/project.json
+++ b/tools/eslint-rules/project.json
@@ -1,0 +1,25 @@
+{
+  "name": "eslint-rules",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "tools/eslint-rules/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/tools/eslint-rules",
+        "main": "tools/eslint-rules/src/index.ts",
+        "tsConfig": "tools/eslint-rules/tsconfig.json",
+        "assets": []
+      }
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "config": "tools/eslint-rules/vitest.config.mts"
+      }
+    }
+  }
+}

--- a/tools/eslint-rules/src/index.ts
+++ b/tools/eslint-rules/src/index.ts
@@ -1,3 +1,21 @@
+//#region License
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//#endregion
 import noIfAroundWattFieldError from './rules/no-if-around-watt-field-error';
 
 export const rules = {

--- a/tools/eslint-rules/src/index.ts
+++ b/tools/eslint-rules/src/index.ts
@@ -1,0 +1,5 @@
+import noIfAroundWattFieldError from './rules/no-if-around-watt-field-error';
+
+export const rules = {
+  'no-if-around-watt-field-error': noIfAroundWattFieldError,
+};

--- a/tools/eslint-rules/src/rules/no-if-around-watt-field-error.spec.ts
+++ b/tools/eslint-rules/src/rules/no-if-around-watt-field-error.spec.ts
@@ -1,0 +1,245 @@
+import { RuleTester } from 'eslint';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import rule from './no-if-around-watt-field-error';
+
+// Create a custom rule tester that simulates Angular template parsing
+class AngularTemplateTester extends RuleTester {
+  constructor(config?: any) {
+    super({
+      ...config,
+      parser: require.resolve('@angular-eslint/template-parser'),
+    });
+  }
+}
+
+const ruleTester = new AngularTemplateTester({
+  parserOptions: {
+    ecmaVersion: 2020,
+  },
+});
+
+describe('no-if-around-watt-field-error', () => {
+  ruleTester.run('no-if-around-watt-field-error', rule, {
+    valid: [
+      // Valid: watt-field-error without @if
+      {
+        code: `
+          <watt-field-error>
+            This is an error message
+          </watt-field-error>
+        `,
+        filename: 'test.component.html',
+      },
+      // Valid: @if inside watt-field-error
+      {
+        code: `
+          <watt-field-error>
+            @if (hasError) {
+              This is an error message
+            }
+          </watt-field-error>
+        `,
+        filename: 'test.component.html',
+      },
+      // Valid: Multiple watt-field-error without @if
+      {
+        code: `
+          <div>
+            <watt-field-error>Error 1</watt-field-error>
+            <watt-field-error>Error 2</watt-field-error>
+          </div>
+        `,
+        filename: 'test.component.html',
+      },
+      // Valid: @if around other elements, not watt-field-error
+      {
+        code: `
+          @if (condition) {
+            <div>Some content</div>
+          }
+          <watt-field-error>Error message</watt-field-error>
+        `,
+        filename: 'test.component.html',
+      },
+    ],
+
+    invalid: [
+      // Invalid: Basic @if around watt-field-error
+      {
+        code: `
+          @if (hasError) {
+            <watt-field-error>
+              This is an error message
+            </watt-field-error>
+          }
+        `,
+        filename: 'test.component.html',
+        errors: [
+          {
+            messageId: 'noIfAroundWattFieldError',
+            type: 'Element',
+          },
+        ],
+      },
+      // Invalid: @if with complex condition
+      {
+        code: `
+          @if (form.get('email')?.hasError('required')) {
+            <watt-field-error>
+              Email is required
+            </watt-field-error>
+          }
+        `,
+        filename: 'test.component.html',
+        errors: [
+          {
+            messageId: 'noIfAroundWattFieldError',
+            type: 'Element',
+          },
+        ],
+      },
+      // Invalid: Nested @if blocks
+      {
+        code: `
+          <div>
+            @if (showErrors) {
+              <watt-field-error>
+                Error message
+              </watt-field-error>
+            }
+          </div>
+        `,
+        filename: 'test.component.html',
+        errors: [
+          {
+            messageId: 'noIfAroundWattFieldError',
+            type: 'Element',
+          },
+        ],
+      },
+      // Invalid: Multiple @if blocks with watt-field-error
+      {
+        code: `
+          @if (error1) {
+            <watt-field-error>Error 1</watt-field-error>
+          }
+
+          @if (error2) {
+            <watt-field-error>Error 2</watt-field-error>
+          }
+        `,
+        filename: 'test.component.html',
+        errors: [
+          {
+            messageId: 'noIfAroundWattFieldError',
+            type: 'Element',
+          },
+          {
+            messageId: 'noIfAroundWattFieldError',
+            type: 'Element',
+          },
+        ],
+      },
+      // Invalid: @if with inline template (simulating inline template)
+      {
+        code: `
+          <div>
+            @if (hasValidationError) {
+              <watt-field-error>
+                Validation failed
+              </watt-field-error>
+            }
+          </div>
+        `,
+        filename: 'test.component.ts',
+        errors: [
+          {
+            messageId: 'noIfAroundWattFieldError',
+            type: 'Element',
+          },
+        ],
+      },
+      // Invalid: ng-container with @if around watt-field-error (spacing issue)
+      {
+        code: `
+          <ng-container>
+            @if (hasError) {
+              <watt-field-error>
+                This is an error message
+              </watt-field-error>
+            }
+          </ng-container>
+        `,
+        filename: 'test.component.html',
+        errors: [
+          {
+            messageId: 'noIfAroundWattFieldError',
+            type: 'Element',
+          },
+        ],
+      },
+    ],
+  });
+});
+
+// Additional unit tests for edge cases
+describe('no-if-around-watt-field-error edge cases', () => {
+  const mockReport = vi.fn();
+  const context: any = {
+    getSourceCode: () => ({
+      text: '',
+      getText: () => '',
+    }),
+    report: mockReport,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should handle nodes without location info gracefully', () => {
+    const node = {
+      type: 'Element',
+      name: 'watt-field-error',
+      loc: null,
+    };
+
+    const visitor = rule.create(context) as any;
+    visitor.Element(node);
+
+    expect(mockReport).not.toHaveBeenCalled();
+  });
+
+  it('should handle errors in rule execution gracefully', () => {
+    const node = {
+      type: 'Element',
+      name: 'watt-field-error',
+      loc: { start: { line: 1 } },
+    };
+
+    const errorContext = {
+      getSourceCode: () => {
+        throw new Error('Source code error');
+      },
+      report: vi.fn(),
+    } as any;
+
+    const visitor = rule.create(errorContext) as any;
+
+    // Should not throw
+    expect(() => visitor.Element(node)).not.toThrow();
+  });
+
+  it('should not report on elements that are not watt-field-error', () => {
+    const node = {
+      type: 'Element',
+      name: 'div',
+      loc: { start: { line: 1 } },
+    };
+
+    const visitor = rule.create(context) as any;
+    visitor.Element(node);
+
+    expect(mockReport).not.toHaveBeenCalled();
+  });
+});

--- a/tools/eslint-rules/src/rules/no-if-around-watt-field-error.ts
+++ b/tools/eslint-rules/src/rules/no-if-around-watt-field-error.ts
@@ -17,6 +17,7 @@
  */
 //#endregion
 import { Rule } from 'eslint';
+import { TemplateElementNode } from '../types/angular-template-ast';
 
 interface IfStatementInfo {
   found: boolean;
@@ -72,7 +73,7 @@ const rule: Rule.RuleModule = {
       return closingBraceIndex > closingErrorIndex;
     }
 
-    function checkWattFieldError(node: any): void {
+    function checkWattFieldError(node: TemplateElementNode): void {
       if (node.name !== 'watt-field-error' || !node.loc?.start) {
         return;
       }
@@ -88,14 +89,16 @@ const rule: Rule.RuleModule = {
 
       if (isIfWrappingElement(lines, ifInfo.lineNumber, elementStartLine)) {
         context.report({
-          node,
+          // ESLint expects ESTree nodes, but we have Angular template nodes
+          node: node as unknown as Rule.Node,
           messageId: 'noIfAroundWattFieldError',
         });
       }
     }
 
     return {
-      Element(node: any): void {
+      // Angular ESLint uses 'Element' for HTML elements in templates
+      Element(node: TemplateElementNode): void {
         try {
           checkWattFieldError(node);
         } catch (e) {
@@ -105,7 +108,9 @@ const rule: Rule.RuleModule = {
           }
         }
       },
-    };
+      // Type assertion needed because ESLint types expect ESTree nodes,
+      // but we're working with Angular template nodes
+    } as unknown as Rule.RuleListener;
   },
 };
 

--- a/tools/eslint-rules/src/rules/no-if-around-watt-field-error.ts
+++ b/tools/eslint-rules/src/rules/no-if-around-watt-field-error.ts
@@ -1,0 +1,94 @@
+import { Rule } from 'eslint';
+
+interface IfStatementInfo {
+  found: boolean;
+  lineNumber: number;
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow @if control flow around watt-field-error components',
+      recommended: true,
+    },
+    messages: {
+      noIfAroundWattFieldError:
+        'Do not wrap <watt-field-error> in an @if statement. This causes layout shifts when errors appear/disappear. Place the condition inside the component instead.',
+    },
+    schema: [],
+  },
+  create(context: Rule.RuleContext): Rule.RuleListener {
+    function findIfStatement(lines: string[], elementStartLine: number): IfStatementInfo {
+      const startLine = Math.max(0, elementStartLine - 10);
+      const endLine = elementStartLine - 2;
+
+      for (let i = endLine; i >= startLine; i--) {
+        const line = lines[i];
+        if (line?.includes('@if') && line?.includes('(')) {
+          return { found: true, lineNumber: i };
+        }
+      }
+
+      return { found: false, lineNumber: -1 };
+    }
+
+    function isIfWrappingElement(
+      lines: string[],
+      ifLine: number,
+      elementStartLine: number
+    ): boolean {
+      const contextLines = lines.slice(ifLine, elementStartLine + 5).join('\n');
+
+      const hasOpenBrace = contextLines.includes('{');
+      const hasWattFieldError = contextLines.includes('<watt-field-error');
+      const hasClosingWattFieldError = contextLines.includes('</watt-field-error>');
+
+      if (!hasOpenBrace || !hasWattFieldError || !hasClosingWattFieldError) {
+        return false;
+      }
+
+      const closingBraceIndex = contextLines.lastIndexOf('}');
+      const closingErrorIndex = contextLines.lastIndexOf('</watt-field-error>');
+
+      return closingBraceIndex > closingErrorIndex;
+    }
+
+    function checkWattFieldError(node: any): void {
+      if (node.name !== 'watt-field-error' || !node.loc?.start) {
+        return;
+      }
+
+      const sourceCode = context.sourceCode;
+      const lines = sourceCode.text.split('\n');
+      const elementStartLine = node.loc.start.line;
+      const ifInfo = findIfStatement(lines, elementStartLine);
+
+      if (!ifInfo.found) {
+        return;
+      }
+
+      if (isIfWrappingElement(lines, ifInfo.lineNumber, elementStartLine)) {
+        context.report({
+          node,
+          messageId: 'noIfAroundWattFieldError',
+        });
+      }
+    }
+
+    return {
+      Element(node: any): void {
+        try {
+          checkWattFieldError(node);
+        } catch (e) {
+          // Handle any errors gracefully - don't re-throw
+          if (process.env.NODE_ENV !== 'test') {
+            console.error('Error in no-if-around-watt-field-error rule:', e);
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tools/eslint-rules/src/rules/no-if-around-watt-field-error.ts
+++ b/tools/eslint-rules/src/rules/no-if-around-watt-field-error.ts
@@ -1,3 +1,21 @@
+//#region License
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//#endregion
 import { Rule } from 'eslint';
 
 interface IfStatementInfo {

--- a/tools/eslint-rules/src/types/angular-template-ast.ts
+++ b/tools/eslint-rules/src/types/angular-template-ast.ts
@@ -1,3 +1,21 @@
+//#region License
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//#endregion
 /**
  * @license
  * Copyright 2020 Energinet DataHub A/S

--- a/tools/eslint-rules/src/types/angular-template-ast.ts
+++ b/tools/eslint-rules/src/types/angular-template-ast.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Type definitions for Angular template AST nodes.
+ *
+ * The Angular ESLint template parser doesn't export strongly typed AST nodes,
+ * so we define our own interfaces based on the runtime structure.
+ * These types represent the actual structure we receive from the parser.
+ */
+
+/**
+ * Represents the location information for an AST node
+ */
+export interface TemplateNodeLocation {
+  start: {
+    line: number;
+    column: number;
+  };
+  end: {
+    line: number;
+    column: number;
+  };
+}
+
+/**
+ * Represents an HTML element node in an Angular template AST
+ */
+export interface TemplateElementNode {
+  /** The tag name of the element (e.g., 'div', 'watt-field-error') */
+  name: string;
+  /** Location information for the element in the source code */
+  loc?: TemplateNodeLocation;
+  /** Other properties exist but are not typed here */
+  [key: string]: unknown;
+}

--- a/tools/eslint-rules/tsconfig.json
+++ b/tools/eslint-rules/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2018",
+    "lib": ["es2018"],
+    "outDir": "../../dist/tools/eslint-rules",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
+}

--- a/tools/eslint-rules/tsconfig.spec.json
+++ b/tools/eslint-rules/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.spec.ts", "vitest.config.mts"]
+}

--- a/tools/eslint-rules/vitest.config.mts
+++ b/tools/eslint-rules/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+  },
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -344,6 +344,7 @@
         "libs/eo/core/globalization/assets-localization/translations.ts"
       ],
       "@energinet-datahub/eo/wallet/data-access-api": ["libs/eo/wallet/data-access-api/index.ts"],
+      "@energinet-datahub/eslint-plugin-custom": ["tools/eslint-rules/src/index.ts"],
       "@energinet-datahub/gf/e2e-util-msw": ["libs/gf/msw/e2e-util-msw/index.ts"],
       "@energinet-datahub/gf/globalization/configuration-danish-locale": [
         "libs/gf/globalization/configuration-danish-locale/src/index.ts"


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

- Add library for custom ESLint rules
- Add custom ESLint rule to disallow @if around watt-field-error components

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
