### PR TITLE
feat(api-dh): Add DocumentFormatter for JSON/XML formatting

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Utilities/DocumentFormatterTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Utilities/DocumentFormatterTests.cs
@@ -1,0 +1,246 @@
+// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.WebApi.Utilities;
+using Xunit;
+
+namespace Energinet.DataHub.WebApi.Tests.Utilities;
+
+public class DocumentFormatterTests
+{
+    [Fact]
+    public void FormatDocumentIfNeeded_WithValidJson_ReturnsFormattedJson()
+    {
+        // Arrange
+        var unformattedJson = """{"name":"test","value":123,"nested":{"key":"value"}}""";
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(unformattedJson);
+
+        // Assert
+        Assert.Contains("  \"name\": \"test\"", result);
+        Assert.Contains("  \"value\": 123", result);
+        Assert.Contains("  \"nested\": {", result);
+        Assert.Contains("    \"key\": \"value\"", result);
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_WithValidJsonArray_ReturnsFormattedJson()
+    {
+        // Arrange
+        var unformattedJson = """[{"id":1,"name":"first"},{"id":2,"name":"second"}]""";
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(unformattedJson);
+
+        // Assert
+        Assert.Contains("  {", result);
+        Assert.Contains("    \"id\": 1", result);
+        Assert.Contains("    \"name\": \"first\"", result);
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_WithValidXml_ReturnsFormattedXml()
+    {
+        // Arrange
+        var unformattedXml = "<root><item id=\"1\"><name>test</name></item></root>";
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(unformattedXml);
+
+        // Assert
+        Assert.Contains("<root>", result);
+        Assert.Contains("  <item id=\"1\">", result);
+        Assert.Contains("    <name>test</name>", result);
+        Assert.Contains("  </item>", result);
+        Assert.Contains("</root>", result);
+    }
+
+    [Theory]
+    [InlineData("{\"name\":\"test\",invalid}")]
+    [InlineData("<root><unclosed>")]
+    [InlineData("This is just plain text, not JSON or XML")]
+    [InlineData("123.45")]
+    [InlineData("true")]
+    public void FormatDocumentIfNeeded_WithNonFormattableContent_ReturnsOriginal(string input)
+    {
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(input);
+
+        // Assert
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_WithEmptyString_ReturnsEmptyString()
+    {
+        // Arrange
+        var empty = string.Empty;
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(empty);
+
+        // Assert
+        Assert.Equal(empty, result);
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_WithNull_ReturnsNull()
+    {
+        // Arrange
+        string? nullDocument = null;
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(nullDocument!);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_WithWhitespace_ReturnsWhitespace()
+    {
+        // Arrange
+        var whitespace = "   ";
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(whitespace);
+
+        // Assert
+        Assert.Equal(whitespace, result);
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_WithAlreadyFormattedJson_ReturnsAsIs()
+    {
+        // Arrange
+        var alreadyFormatted = """
+            {
+              "name": "test",
+              "value": 123
+            }
+            """;
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(alreadyFormatted);
+
+        // Assert
+        Assert.Equal(alreadyFormatted, result); // Should return as-is, not re-formatted
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_WithAlreadyFormattedXml_ReturnsAsIs()
+    {
+        // Arrange
+        var alreadyFormatted = """
+            <root>
+              <item id="1">
+                <name>test</name>
+              </item>
+            </root>
+            """;
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(alreadyFormatted);
+
+        // Assert
+        Assert.Equal(alreadyFormatted, result); // Should return as-is, not re-formatted
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_WithXmlDeclaration_PreservesDeclaration()
+    {
+        // Arrange
+        var xmlWithDeclaration = """<?xml version="1.0" encoding="utf-8"?><root><item>test</item></root>""";
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(xmlWithDeclaration);
+
+        // Assert
+        Assert.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>", result);
+        Assert.Contains("<root>", result);
+        Assert.Contains("  <item>test</item>", result);
+        Assert.Contains("</root>", result);
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_WithJsonStartingWithWhitespace_FormatsCorrectly()
+    {
+        // Arrange
+        var jsonWithLeadingSpace = "   {\"key\":\"value\"}";
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(jsonWithLeadingSpace);
+
+        // Assert
+        Assert.Contains("{\n  \"key\": \"value\"\n}", result);
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_WithXmlStartingWithWhitespace_FormatsCorrectly()
+    {
+        // Arrange
+        var xmlWithLeadingSpace = "   <root><item>test</item></root>";
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(xmlWithLeadingSpace);
+
+        // Assert
+        Assert.Contains("<root>", result);
+        Assert.Contains("  <item>test</item>", result);
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_WithVeryLargeDocument_ReturnsOriginalWithoutFormatting()
+    {
+        // Arrange
+        // Create a JSON string larger than 100MB (the new limit)
+        var largeJson = "{\"data\":\"" + new string('x', 101 * 1024 * 1024) + "\"}";
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(largeJson);
+
+        // Assert
+        Assert.Equal(largeJson, result);
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_With50MBDocument_FormatsSuccessfully()
+    {
+        // Arrange
+        // Create a JSON string of 50MB (which should be formatted)
+        var json50MB = "{\"data\":\"" + new string('x', 50 * 1024 * 1024) + "\"}";
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(json50MB);
+
+        // Assert
+        Assert.NotEqual(json50MB, result);
+        Assert.Contains("{\n  \"data\":", result);
+    }
+
+    [Fact]
+    public void FormatDocumentIfNeeded_WithUnformattedJsonButContainsNewline_StillFormats()
+    {
+        // Arrange
+        var jsonWithNewlineInValue = "{\"message\":\"Hello\\nWorld\",\"value\":123}";
+
+        // Act
+        var result = DocumentFormatter.FormatDocumentIfNeeded(jsonWithNewlineInValue);
+
+        // Assert
+        Assert.NotEqual(jsonWithNewlineInValue, result);
+        Assert.Contains("{\n  \"message\":", result);
+    }
+}

--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MessageArchiveController.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/MessageArchiveController.cs
@@ -14,6 +14,7 @@
 
 using System.Net.Mime;
 using Energinet.DataHub.Edi.B2CWebApp.Clients.v1;
+using Energinet.DataHub.WebApi.Utilities;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Energinet.DataHub.WebApi.Controllers;
@@ -34,11 +35,18 @@ public class MessageArchiveController : ControllerBase
     [Produces(MediaTypeNames.Text.Plain)]
     public async Task<ActionResult<string>> GetDocumentByIdAsync(string id, CancellationToken cancellationToken)
     {
+        if (!Guid.TryParse(id, out var documentId))
+        {
+            return BadRequest("Invalid document ID format");
+        }
+
         var document = await _client.ArchivedMessageGetDocumentAsync(
-            Guid.Parse(id),
+            documentId,
             "1.0",
             cancellationToken);
 
-        return Ok(document);
+        var formattedDocument = DocumentFormatter.FormatDocumentIfNeeded(document);
+
+        return Ok(formattedDocument);
     }
 }

--- a/apps/dh/api-dh/source/DataHub.WebApi/Utilities/DocumentFormatter.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Utilities/DocumentFormatter.cs
@@ -1,0 +1,120 @@
+// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace Energinet.DataHub.WebApi.Utilities;
+
+public static class DocumentFormatter
+{
+    private const int MaxDocumentSizeForFormatting = 100 * 1024 * 1024; // 100 MB - safely handles 50MB documents
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        WriteIndented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never,
+        PropertyNamingPolicy = null,
+    };
+
+    public static string FormatDocumentIfNeeded(string document)
+    {
+        if (string.IsNullOrWhiteSpace(document))
+        {
+            return document;
+        }
+
+        if (document.Length > MaxDocumentSizeForFormatting)
+        {
+            return document;
+        }
+
+        if (TryFormatJson(document, out var formattedJson))
+        {
+            return formattedJson;
+        }
+
+        if (TryFormatXml(document, out var formattedXml))
+        {
+            return formattedXml;
+        }
+
+        return document;
+    }
+
+    private static bool TryFormatJson(string input, out string formattedJson)
+    {
+        formattedJson = input;
+        try
+        {
+            var trimmed = input.TrimStart();
+            if (!trimmed.StartsWith('{') && !trimmed.StartsWith('['))
+            {
+                return false;
+            }
+
+            if (input.Contains('\n') && (input.Contains("\n  ") || input.Contains("\n\t")))
+            {
+                using var validationDoc = JsonDocument.Parse(input);
+                return true;
+            }
+
+            using var doc = JsonDocument.Parse(input);
+            formattedJson = JsonSerializer.Serialize(doc.RootElement, _jsonOptions);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryFormatXml(string input, out string formattedXml)
+    {
+        formattedXml = input;
+        try
+        {
+            var trimmed = input.TrimStart();
+            if (!trimmed.StartsWith('<'))
+            {
+                return false;
+            }
+
+            if (input.Contains('\n') && (input.Contains("\n  ") || input.Contains("\n\t")))
+            {
+                _ = XDocument.Parse(input);
+                return true;
+            }
+
+            var doc = XDocument.Parse(input);
+            formattedXml = doc.Declaration != null
+                ? doc.Declaration.ToString() + Environment.NewLine + doc.ToString()
+                : doc.ToString();
+            return true;
+        }
+        catch (System.Xml.XmlException)
+        {
+            return false;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

This pull request introduces a new utility for formatting document content (JSON and XML) before returning it from the API, and adds comprehensive unit tests to ensure correct formatting behavior. The main change is that documents returned by the `MessageArchiveController` are now automatically formatted for readability if they are valid JSON or XML and not already formatted, with safeguards for very large documents.

**Document formatting feature:**

* Added a new static utility class `DocumentFormatter` in `DocumentFormatter.cs` that detects and formats JSON and XML documents, preserving already formatted content and handling edge cases like empty, null, or oversized documents.
* Updated `MessageArchiveController` so that documents returned by `GetDocumentByIdAsync` are passed through `DocumentFormatter.FormatDocumentIfNeeded` before being returned, improving readability for clients. Also added validation for the document ID format. [[1]](diffhunk://#diff-d126084c81791b5684fc50dc4823523abd81a9e29e6bfcd00a4e37c1b308a2f3R17) [[2]](diffhunk://#diff-d126084c81791b5684fc50dc4823523abd81a9e29e6bfcd00a4e37c1b308a2f3R38-R50)

**Testing and validation:**

* Added a comprehensive set of unit tests in `DocumentFormatterTests.cs` to cover various scenarios, including valid/invalid JSON/XML, empty/null/whitespace input, already formatted content, XML declarations, documents with leading whitespace, very large documents, and edge cases.

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#965](https://github.com/Energinet-DataHub/team-mosaic/issues/964)
- [#965](https://github.com/Energinet-DataHub/team-mosaic/issues/965)
