### PR TITLE
fix(metering-point): disable sorting for documentType column in messages table

### DIFF
--- a/libs/dh/metering-point/feature-overview/src/components/dh-metering-point-messages.component.ts
+++ b/libs/dh/metering-point/feature-overview/src/components/dh-metering-point-messages.component.ts
@@ -160,7 +160,7 @@ export class DhMeteringPointMessagesComponent {
 
   columns: WattTableColumnDef<ArchivedMessage> = {
     createdAt: { accessor: 'createdAt' },
-    documentType: { accessor: 'documentType' },
+    documentType: { accessor: 'documentType', sort: false },
     sender: { accessor: (m) => m.sender?.displayName },
     receiver: { accessor: (m) => m.receiver?.displayName },
   };


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Disable sorting for documentType column in messages table
<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#890](https://github.com/Energinet-DataHub/team-mosaic/issues/890)
