### PR TITLE
fix(calculations): filter out scheduled calculations when querying for pending state

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/Processes/Calculations/Client/CalculationsClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/Processes/Calculations/Client/CalculationsClient.cs
@@ -57,7 +57,15 @@ public class CalculationsClient(
             ScheduledAtOrLater = input.State == ProcessState.Scheduled ? DateTime.UtcNow : null,
         };
 
-        return await client.SearchOrchestrationInstancesByCustomQueryAsync(query, ct);
+        var results = await client.SearchOrchestrationInstancesByCustomQueryAsync(query, ct);
+
+        // Filter out scheduled calculations when querying for pending state
+        if (input.State == ProcessState.Pending)
+        {
+            return results.Where(r => r.GetLifecycle().ToProcessState() == ProcessState.Pending);
+        }
+
+        return results;
     }
 
     public async Task<ICalculationsQueryResultV1?> GetLatestCalculationAsync(


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

- Filter out scheduled calculations when querying for pending state

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#561](https://github.com/Energinet-DataHub/team-mosaic/issues/561)
