### PR TITLE
Enable node SBOM generation

### DIFF
--- a/.github/workflows/dh-ci-frontend.yml
+++ b/.github/workflows/dh-ci-frontend.yml
@@ -63,6 +63,14 @@ jobs:
           cp -R ${{ github.workspace }}/dist/apps/dh/${{ env.APP_NAME }}/browser/* ${{ github.workspace }}/${{ steps.get_releaseversion_strings.outputs.release_version }}/${{ env.APP_NAME }}
           cp -R ${{ github.workspace }}/apps/dh/e2e-dh ${{ github.workspace }}/${{ steps.get_releaseversion_strings.outputs.release_version }}
 
+      - name: Generate SBOM for node_modules
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./node_modules
+          format: cyclonedx-json
+          output-file: ${{ github.workspace }}/${{ steps.get_releaseversion_strings.outputs.release_version }}/sbom.cyclonedx.json
+          dependency-snapshot: true
+
       - name: Zip artifact
         uses: thedoctor0/zip-release@master
         with:

--- a/.github/workflows/dh-ci-frontend.yml
+++ b/.github/workflows/dh-ci-frontend.yml
@@ -41,7 +41,7 @@ jobs:
           bun-version-file: package.json
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --yarn
 
       - name: Production build
         run: bun run nx build ${{ env.APP_NAME }}
@@ -66,9 +66,9 @@ jobs:
       - name: Generate SBOM for node_modules
         uses: anchore/sbom-action@v0
         with:
-          path: ./node_modules
-          format: cyclonedx-json
-          output-file: ${{ github.workspace }}/${{ steps.get_releaseversion_strings.outputs.release_version }}/sbom.cyclonedx.json
+          path: ./yarn.lock
+          format: spdx-json
+          output-file: ${{ github.workspace }}/${{ steps.get_releaseversion_strings.outputs.release_version }}/sbom.spdx.json
           dependency-snapshot: true
 
       - name: Zip artifact

--- a/.github/workflows/dh-ci-frontend.yml
+++ b/.github/workflows/dh-ci-frontend.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Generate SBOM for node_modules
         uses: anchore/sbom-action@v0
         with:
-          path: ./yarn.lock
+          file: ./yarn.lock
           format: spdx-json
           output-file: ${{ github.workspace }}/${{ steps.get_releaseversion_strings.outputs.release_version }}/sbom.spdx.json
           dependency-snapshot: true

--- a/.github/workflows/dh-ci-frontend.yml
+++ b/.github/workflows/dh-ci-frontend.yml
@@ -69,7 +69,6 @@ jobs:
           file: ./yarn.lock
           format: spdx-json
           output-file: ${{ github.workspace }}/${{ steps.get_releaseversion_strings.outputs.release_version }}/sbom.spdx.json
-          dependency-snapshot: true
 
       - name: Zip artifact
         uses: thedoctor0/zip-release@master


### PR DESCRIPTION
This pull request makes minor improvements to the frontend CI workflow configuration. The most notable change is the addition of a step to generate a Software Bill of Materials (SBOM) for `node_modules`, which enhances supply chain security and transparency.

**Security and dependency management:**

* Added a step to generate an SBOM using `anchore/sbom-action` based on `yarn.lock`, outputting the results in SPDX JSON format for the release artifact.

**Dependency installation:**

* Updated the dependency installation command to use the `--yarn` flag with `bun install`, ensuring compatibility with Yarn lockfiles.