### PR TITLE
chore: change default landing-page to /metering-point/search

### DIFF
--- a/apps/dh/e2e-dh/src/support/commands.ts
+++ b/apps/dh/e2e-dh/src/support/commands.ts
@@ -43,7 +43,7 @@ function loginViaB2C(email: string, password: string, initialUrl: string) {
 
   // Ensure Microsoft has redirected us back to the app with our logged in user.
   if (initialUrl === '/') {
-    cy.url().should('equals', Cypress.config('baseUrl') + '/message-archive');
+    cy.url().should('equals', Cypress.config('baseUrl') + '/metering-point/search');
   } else {
     cy.url().should('equals', Cypress.config('baseUrl') + initialUrl);
   }

--- a/libs/dh/core/shell/src/lib/dh-core-shell.routes.ts
+++ b/libs/dh/core/shell/src/lib/dh-core-shell.routes.ts
@@ -22,7 +22,12 @@ import { Routes } from '@angular/router';
 import { DhCoreShellComponent } from './dh-core-shell.component';
 import { DhCoreLoginComponent } from './dh-core-login.component';
 
-import { BasePaths, ReportsSubPaths, getPath } from '@energinet-datahub/dh/core/routing';
+import {
+  BasePaths,
+  ReportsSubPaths,
+  MeteringPointSubPaths,
+  getPath,
+} from '@energinet-datahub/dh/core/routing';
 import { PermissionGuard } from '@energinet-datahub/dh/shared/feature-authorization';
 
 export const dhCoreShellRoutes: Routes = [
@@ -32,7 +37,7 @@ export const dhCoreShellRoutes: Routes = [
     children: [
       {
         path: '',
-        redirectTo: getPath<BasePaths>('message-archive'),
+        redirectTo: `${getPath<BasePaths>('metering-point')}/${getPath<MeteringPointSubPaths>('search')}`,
         pathMatch: 'full',
       },
       {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
- Change default landing-page to /metering-point/search

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#1078](https://github.com/Energinet-DataHub/team-mosaic/issues/1078)
