### PR TITLE
feat(watt, menu): add async menu items support, and fix imports

### DIFF
--- a/libs/dh/profile/feature-avatar/src/lib/dh-profile-avatar.component.ts
+++ b/libs/dh/profile/feature-avatar/src/lib/dh-profile-avatar.component.ts
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 //#endregion
-import { MatMenuModule } from '@angular/material/menu';
 import { Component, ViewEncapsulation, inject } from '@angular/core';
 import { TranslocoDirective, TranslocoPipe } from '@jsverse/transloco';
 import { MsalService } from '@azure/msal-angular';
 
 import { WattIconComponent } from '@energinet-datahub/watt/icon';
+import { WATT_MENU } from '@energinet-datahub/watt/menu';
 import { DhProfileModalComponent } from '@energinet-datahub/dh/profile/feature-profile-modal';
 import { WattModalService } from '@energinet-datahub/watt/modal';
 import { DisplayLanguage } from '@energinet-datahub/gf/globalization/domain';
@@ -29,34 +29,34 @@ import { DhLanguageService } from '@energinet-datahub/dh/globalization/feature-l
 
 @Component({
   selector: 'dh-profile-avatar',
-  imports: [MatMenuModule, TranslocoDirective, TranslocoPipe, WattIconComponent],
+  imports: [WATT_MENU, TranslocoDirective, TranslocoPipe, WattIconComponent],
   encapsulation: ViewEncapsulation.None,
   styleUrls: ['./dh-profile-avatar.component.scss'],
-  template: `<button data-testid="profileMenu" [matMenuTriggerFor]="menu" class="watt-text-m">
+  template: `<button data-testid="profileMenu" [wattMenuTriggerFor]="menu" class="watt-text-m">
       {{ name() }}
     </button>
-    <mat-menu #menu="matMenu" xPosition="before" class="dh-profile__menu">
+    <watt-menu #menu class="dh-profile__menu">
       <ng-container *transloco="let transloco; read: 'shell'">
-        <button (click)="openProfileModal()" mat-menu-item>
+        <watt-menu-item (click)="openProfileModal()">
           <watt-icon name="user" class="watt-icon--small" />
           <span>{{ transloco('profile') }}</span>
-        </button>
+        </watt-menu-item>
 
-        <button (click)="changeLaguage()" mat-menu-item>
+        <watt-menu-item (click)="changeLaguage()">
           <watt-icon name="language" class="watt-icon--small" />
           @if (selectedLaguage() === displayLanguage.Danish) {
             <span>{{ 'shell.english' | transloco }}</span>
           } @else {
             <span>{{ 'shell.danish' | transloco }}</span>
           }
-        </button>
+        </watt-menu-item>
 
-        <button mat-menu-item (click)="logout()">
+        <watt-menu-item (click)="logout()">
           <watt-icon name="logout" class="watt-icon--small" />
           <span>{{ transloco('logout') }}</span>
-        </button>
+        </watt-menu-item>
       </ng-container>
-    </mat-menu>`,
+    </watt-menu>`,
 })
 export class DhProfileAvatarComponent {
   private readonly authService = inject(MsalService);

--- a/libs/watt/package/menu/+storybook/menu-async-story.component.ts
+++ b/libs/watt/package/menu/+storybook/menu-async-story.component.ts
@@ -89,15 +89,15 @@ export class MenuAsyncStoryComponent {
     // Watch for loadDelay changes and restart loading
     effect((onCleanup) => {
       const delay = this.loadDelay();
-      
+
       // Reset loaded state
       this.itemsLoaded.set(false);
-      
+
       // Start new loading timeout
       const timeout = setTimeout(() => {
         this.itemsLoaded.set(true);
       }, delay);
-      
+
       // Cleanup function will be called when effect reruns or component is destroyed
       onCleanup(() => {
         clearTimeout(timeout);

--- a/libs/watt/package/menu/+storybook/menu-async-story.component.ts
+++ b/libs/watt/package/menu/+storybook/menu-async-story.component.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 //#endregion
-import { Component, input, signal, effect, OnDestroy } from '@angular/core';
+import { Component, input, signal, effect } from '@angular/core';
 import { WattButtonComponent } from '../../button';
 import { WattIconComponent } from '../../icon';
 import { WattMenuComponent } from '../watt-menu.component';
@@ -78,42 +78,31 @@ import { WattMenuTriggerDirective } from '../watt-menu-trigger.directive';
     <p>Items loaded: {{ itemsLoaded() ? 'Yes' : 'No (loading...)' }}</p>
   `,
 })
-export class MenuAsyncStoryComponent implements OnDestroy {
+export class MenuAsyncStoryComponent {
   showIcons = input(true);
   loadDelay = input(1000);
-
-  private loadingTimeout?: ReturnType<typeof setTimeout>;
 
   itemsLoaded = signal(false);
   lastAction = signal<string | null>(null);
 
   constructor() {
     // Watch for loadDelay changes and restart loading
-    effect(() => {
-      this.loadDelay();
-      this.startLoading();
+    effect((onCleanup) => {
+      const delay = this.loadDelay();
+      
+      // Reset loaded state
+      this.itemsLoaded.set(false);
+      
+      // Start new loading timeout
+      const timeout = setTimeout(() => {
+        this.itemsLoaded.set(true);
+      }, delay);
+      
+      // Cleanup function will be called when effect reruns or component is destroyed
+      onCleanup(() => {
+        clearTimeout(timeout);
+      });
     });
-  }
-
-  ngOnDestroy() {
-    if (this.loadingTimeout) {
-      clearTimeout(this.loadingTimeout);
-    }
-  }
-
-  private startLoading() {
-    // Clear any existing timeout
-    if (this.loadingTimeout) {
-      clearTimeout(this.loadingTimeout);
-    }
-
-    // Reset loaded state
-    this.itemsLoaded.set(false);
-
-    // Start new loading timeout
-    this.loadingTimeout = setTimeout(() => {
-      this.itemsLoaded.set(true);
-    }, this.loadDelay());
   }
 
   onAction(action: string) {

--- a/libs/watt/package/menu/+storybook/menu-async-story.component.ts
+++ b/libs/watt/package/menu/+storybook/menu-async-story.component.ts
@@ -1,0 +1,125 @@
+//#region License
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//#endregion
+import { Component, Input, signal, OnInit, OnDestroy } from '@angular/core';
+import { WattButtonComponent } from '../../button';
+import { WattIconComponent } from '../../icon';
+import { WattMenuComponent } from '../watt-menu.component';
+import { WattMenuItemComponent } from '../watt-menu-item.component';
+import { WattMenuTriggerDirective } from '../watt-menu-trigger.directive';
+
+@Component({
+  selector: 'watt-menu-async-story',
+  imports: [
+    WattButtonComponent,
+    WattIconComponent,
+    WattMenuComponent,
+    WattMenuItemComponent,
+    WattMenuTriggerDirective,
+  ],
+  template: `
+    <div style="display: flex; gap: 20px; flex-wrap: wrap;">
+      <div>
+        <h3>Async Menu Items (Dynamic Icons)</h3>
+        <watt-button
+          variant="secondary"
+          [wattMenuTriggerFor]="asyncMenu"
+          aria-label="Open async menu"
+        >
+          Async Dynamic Icons
+          <watt-icon name="down" size="xs" />
+        </watt-button>
+
+        <watt-menu #asyncMenu>
+          @if (itemsLoaded()) {
+            <watt-menu-item (click)="onAction('Profile')">
+              @if (showIcons) {
+                <watt-icon name="user" />
+              }
+              Profile
+            </watt-menu-item>
+            <watt-menu-item (click)="onAction('Settings')">
+              Settings (always no icon)
+            </watt-menu-item>
+            <watt-menu-item (click)="onAction('Preferences')">
+              @if (showIcons) {
+                <watt-icon name="settings" />
+              }
+              Preferences
+            </watt-menu-item>
+            <watt-menu-item (click)="onAction('Help')"> Help (always no icon) </watt-menu-item>
+            <watt-menu-item (click)="onAction('Logout')">
+              @if (showIcons) {
+                <watt-icon name="logout" />
+              }
+              Logout
+            </watt-menu-item>
+          }
+        </watt-menu>
+      </div>
+    </div>
+
+    <p style="margin-top: 20px">Last action: {{ lastAction() || 'None' }}</p>
+    <p>Items loaded: {{ itemsLoaded() ? 'Yes' : 'No (loading...)' }}</p>
+  `,
+})
+export class MenuAsyncStoryComponent implements OnInit, OnDestroy {
+  @Input() showIcons = true;
+  @Input() set loadDelay(value: number) {
+    this._loadDelay = value;
+    this.resetLoading();
+  }
+  get loadDelay(): number {
+    return this._loadDelay;
+  }
+
+  private _loadDelay = 1000;
+  private loadingTimeout?: ReturnType<typeof setTimeout>;
+
+  itemsLoaded = signal(false);
+  lastAction = signal<string | null>(null);
+
+  ngOnInit() {
+    this.resetLoading();
+  }
+
+  ngOnDestroy() {
+    if (this.loadingTimeout) {
+      clearTimeout(this.loadingTimeout);
+    }
+  }
+
+  private resetLoading() {
+    // Clear any existing timeout
+    if (this.loadingTimeout) {
+      clearTimeout(this.loadingTimeout);
+    }
+
+    // Reset loaded state
+    this.itemsLoaded.set(false);
+
+    // Start new loading timeout
+    this.loadingTimeout = setTimeout(() => {
+      this.itemsLoaded.set(true);
+    }, this._loadDelay);
+  }
+
+  onAction(action: string) {
+    this.lastAction.set(action);
+  }
+}

--- a/libs/watt/package/menu/+storybook/watt-menu.stories.ts
+++ b/libs/watt/package/menu/+storybook/watt-menu.stories.ts
@@ -28,6 +28,7 @@ import { WattButtonComponent } from '../../button';
 import { WattIconComponent } from '../../icon';
 import { MenuBasicStoryComponent } from './menu-basic-story.component';
 import { MenuGroupsStoryComponent } from './menu-groups-story.component';
+import { MenuAsyncStoryComponent } from './menu-async-story.component';
 import {
   menuWithIconsTemplate,
   menuNoIconsTemplate,
@@ -53,6 +54,7 @@ const meta: Meta<WattMenuComponent> = {
         WattIconComponent,
         MenuBasicStoryComponent,
         MenuGroupsStoryComponent,
+        MenuAsyncStoryComponent,
         WattMenuTriggerDirective,
       ],
     }),
@@ -61,6 +63,7 @@ const meta: Meta<WattMenuComponent> = {
 
 export default meta;
 type Story = StoryObj<WattMenuComponent>;
+type AsyncStory = StoryObj<MenuAsyncStoryComponent>;
 
 export const Basic: Story = {
   render: () => ({
@@ -100,6 +103,113 @@ ${menuGroupedNoIconsTemplate}
 <!-- Grouped with mixed icons -->
 ${menuGroupedMixedIconsTemplate}`,
       },
+    },
+  },
+};
+
+export const AsyncItems: AsyncStory = {
+  args: {
+    showIcons: true,
+    loadDelay: 1000,
+  },
+  argTypes: {
+    showIcons: {
+      name: 'Show Icons',
+      control: { type: 'boolean' },
+      description: 'Toggle visibility of menu item icons',
+      table: {
+        defaultValue: { summary: 'true' },
+        category: 'Display',
+        type: { summary: 'boolean' },
+      },
+    },
+    loadDelay: {
+      name: 'Load Delay (ms)',
+      control: { type: 'number', min: 0, max: 5000, step: 100 },
+      description: 'Time to wait before menu items are loaded',
+      table: {
+        defaultValue: { summary: '1000' },
+        category: 'Behavior',
+        type: { summary: 'number' },
+      },
+    },
+  },
+  render: (args) => ({
+    props: args,
+    template: `<watt-menu-async-story [showIcons]="showIcons" [loadDelay]="loadDelay" />`,
+  }),
+  parameters: {
+    docs: {
+      source: {
+        code: `<!-- Component usage -->
+@Component({
+  // ...
+})
+export class MyComponent implements OnInit, OnDestroy {
+  showIcons = true;
+  itemsLoaded = signal(false);
+  private loadingTimeout?: ReturnType<typeof setTimeout>;
+
+  ngOnInit() {
+    // Simulate async loading
+    this.loadingTimeout = setTimeout(() => {
+      this.itemsLoaded.set(true);
+    }, 1000);
+  }
+
+  ngOnDestroy() {
+    if (this.loadingTimeout) {
+      clearTimeout(this.loadingTimeout);
+    }
+  }
+
+  onAction(action: string) {
+    console.log('Menu action:', action);
+  }
+}
+
+<!-- Template -->
+<watt-button
+  variant="secondary"
+  [wattMenuTriggerFor]="asyncMenu"
+  aria-label="Open async menu"
+>
+  Async Dynamic Icons
+  <watt-icon name="down" size="xs" />
+</watt-button>
+
+<watt-menu #asyncMenu>
+  @if (itemsLoaded()) {
+    <watt-menu-item (click)="onAction('Profile')">
+      @if (showIcons) {
+        <watt-icon name="user" />
+      }
+      Profile
+    </watt-menu-item>
+    <watt-menu-item (click)="onAction('Settings')">
+      Settings (no icon)
+    </watt-menu-item>
+    <watt-menu-item (click)="onAction('Preferences')">
+      @if (showIcons) {
+        <watt-icon name="settings" />
+      }
+      Preferences
+    </watt-menu-item>
+    <watt-menu-item (click)="onAction('Help')">
+      Help (no icon)
+    </watt-menu-item>
+    <watt-menu-item (click)="onAction('Logout')">
+      @if (showIcons) {
+        <watt-icon name="logout" />
+      }
+      Logout
+    </watt-menu-item>
+  }
+</watt-menu>`,
+      },
+    },
+    controls: {
+      expanded: true,
     },
   },
 };

--- a/libs/watt/package/menu/index.ts
+++ b/libs/watt/package/menu/index.ts
@@ -16,7 +16,22 @@
  * limitations under the License.
  */
 //#endregion
+// Individual exports (kept for backward compatibility)
 export { WattMenuComponent } from './watt-menu.component';
 export { WattMenuItemComponent } from './watt-menu-item.component';
 export { WattMenuGroupComponent } from './watt-menu-group.component';
 export { WattMenuTriggerDirective } from './watt-menu-trigger.directive';
+
+// Import the components for the combined export
+import { WattMenuComponent } from './watt-menu.component';
+import { WattMenuItemComponent } from './watt-menu-item.component';
+import { WattMenuGroupComponent } from './watt-menu-group.component';
+import { WattMenuTriggerDirective } from './watt-menu-trigger.directive';
+
+// Combined export for convenience - all menu-related components
+export const WATT_MENU = [
+  WattMenuComponent,
+  WattMenuItemComponent,
+  WattMenuGroupComponent,
+  WattMenuTriggerDirective,
+] as const;

--- a/libs/watt/package/menu/index.ts
+++ b/libs/watt/package/menu/index.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 //#endregion
-// Individual exports (kept for backward compatibility)
+// Individual exports
 export { WattMenuComponent } from './watt-menu.component';
 export { WattMenuItemComponent } from './watt-menu-item.component';
 export { WattMenuGroupComponent } from './watt-menu-group.component';

--- a/libs/watt/package/menu/watt-menu-item.component.ts
+++ b/libs/watt/package/menu/watt-menu-item.component.ts
@@ -21,19 +21,15 @@ import {
   ViewEncapsulation,
   ChangeDetectionStrategy,
   input,
-  signal,
-  contentChild,
-  computed,
 } from '@angular/core';
 import { MatMenuItem } from '@angular/material/menu';
-import { WattIconComponent } from '@energinet-datahub/watt/icon';
 
 @Component({
   selector: 'watt-menu-item',
   imports: [MatMenuItem],
   template: `<button mat-menu-item [disabled]="disabled()">
     <span class="watt-menu-item-content">
-      <span class="watt-menu-item-icon" [class.watt-menu-item-icon--show]="menuHasIcons()">
+      <span class="watt-menu-item-icon">
         <ng-content select="watt-icon" />
       </span>
       <ng-content />
@@ -61,10 +57,7 @@ import { WattIconComponent } from '@energinet-datahub/watt/icon';
           height: var(--watt-menu-icon-size);
           flex-shrink: 0;
 
-          /* Hide when menu has no icons */
-          &:not(.watt-menu-item-icon--show) {
-            display: none;
-          }
+          /* Icon space visibility is controlled by parent menu CSS */
 
           watt-icon {
             display: flex;
@@ -88,22 +81,4 @@ export class WattMenuItemComponent {
    * Whether the menu item is disabled.
    */
   disabled = input(false);
-
-  /**
-   * Icon child element.
-   * @ignore
-   */
-  private readonly iconChild = contentChild(WattIconComponent);
-
-  /**
-   * Whether this menu item has an icon.
-   * @ignore
-   */
-  hasIcon = computed(() => !!this.iconChild());
-
-  /**
-   * Whether the parent menu has any items with icons.
-   * @ignore
-   */
-  menuHasIcons = signal(false);
 }

--- a/libs/watt/package/menu/watt-menu-item.component.ts
+++ b/libs/watt/package/menu/watt-menu-item.component.ts
@@ -21,12 +21,12 @@ import {
   ViewEncapsulation,
   ChangeDetectionStrategy,
   input,
-  ElementRef,
-  inject,
   signal,
-  afterNextRender,
+  contentChild,
+  computed,
 } from '@angular/core';
 import { MatMenuItem } from '@angular/material/menu';
+import { WattIconComponent } from '@energinet-datahub/watt/icon';
 
 @Component({
   selector: 'watt-menu-item',
@@ -84,31 +84,26 @@ import { MatMenuItem } from '@angular/material/menu';
   },
 })
 export class WattMenuItemComponent {
-  private readonly elementRef = inject(ElementRef);
-
   /**
    * Whether the menu item is disabled.
    */
   disabled = input(false);
 
   /**
+   * Icon child element.
+   * @ignore
+   */
+  private readonly iconChild = contentChild(WattIconComponent);
+
+  /**
    * Whether this menu item has an icon.
    * @ignore
    */
-  private readonly _hasIcon = signal(false);
-  hasIcon = this._hasIcon.asReadonly();
+  hasIcon = computed(() => !!this.iconChild());
 
   /**
    * Whether the parent menu has any items with icons.
    * @ignore
    */
   menuHasIcons = signal(false);
-
-  constructor() {
-    // Check if this menu item has an icon
-    afterNextRender(() => {
-      const iconElement = this.elementRef.nativeElement.querySelector('watt-icon');
-      this._hasIcon.set(!!iconElement);
-    });
-  }
 }

--- a/libs/watt/package/menu/watt-menu-item.component.ts
+++ b/libs/watt/package/menu/watt-menu-item.component.ts
@@ -16,12 +16,7 @@
  * limitations under the License.
  */
 //#endregion
-import {
-  Component,
-  ViewEncapsulation,
-  ChangeDetectionStrategy,
-  input,
-} from '@angular/core';
+import { Component, ViewEncapsulation, ChangeDetectionStrategy, input } from '@angular/core';
 import { MatMenuItem } from '@angular/material/menu';
 
 @Component({

--- a/libs/watt/package/menu/watt-menu.component.ts
+++ b/libs/watt/package/menu/watt-menu.component.ts
@@ -64,11 +64,8 @@ import { WattMenuItemComponent } from './watt-menu-item.component';
 @Component({
   selector: 'watt-menu',
   template: `
-    <mat-menu
-      #menu="matMenu"
-      [class]="'watt-menu-panel' + (hasIcons() ? ' watt-menu-panel--has-icons' : '')"
-    >
-      <ng-content select="watt-menu-group, watt-menu-item" />
+    <mat-menu #menu="matMenu" [class]="panelClasses().join(' ')">
+      <ng-content />
     </mat-menu>
   `,
   styles: [
@@ -119,7 +116,20 @@ export class WattMenuComponent {
    */
   hasIcons = computed(() => this.menuItems().some((item) => item.hasIcon()));
 
+  /**
+   * CSS classes to apply to the menu panel.
+   * @ignore
+   */
+  panelClasses = computed(() => {
+    const classes = ['watt-menu-panel'];
+    if (this.hasIcons()) {
+      classes.push('watt-menu-panel--has-icons');
+    }
+    return classes;
+  });
+
   constructor() {
+    // Update menu items when the content changes
     effect(() => {
       const hasIcons = this.hasIcons();
       this.menuItems().forEach((item) => {

--- a/libs/watt/package/menu/watt-menu.component.ts
+++ b/libs/watt/package/menu/watt-menu.component.ts
@@ -16,12 +16,7 @@
  * limitations under the License.
  */
 //#endregion
-import {
-  Component,
-  ViewEncapsulation,
-  ChangeDetectionStrategy,
-  viewChild,
-} from '@angular/core';
+import { Component, ViewEncapsulation, ChangeDetectionStrategy, viewChild } from '@angular/core';
 import { MatMenu, MatMenuModule } from '@angular/material/menu';
 
 /**

--- a/libs/watt/package/menu/watt-menu.component.ts
+++ b/libs/watt/package/menu/watt-menu.component.ts
@@ -21,12 +21,8 @@ import {
   ViewEncapsulation,
   ChangeDetectionStrategy,
   viewChild,
-  contentChildren,
-  computed,
-  effect,
 } from '@angular/core';
 import { MatMenu, MatMenuModule } from '@angular/material/menu';
-import { WattMenuItemComponent } from './watt-menu-item.component';
 
 /**
  * Watt Menu Component
@@ -64,7 +60,7 @@ import { WattMenuItemComponent } from './watt-menu-item.component';
 @Component({
   selector: 'watt-menu',
   template: `
-    <mat-menu #menu="matMenu" [class]="panelClasses()">
+    <mat-menu #menu="matMenu" class="watt-menu-panel">
       <ng-content />
     </mat-menu>
   `,
@@ -85,8 +81,8 @@ import { WattMenuItemComponent } from './watt-menu-item.component';
           padding-block: var(--watt-menu-padding-block);
         }
 
-        /* When menu has no icons, hide the icon space entirely */
-        &:not(.watt-menu-panel--has-icons) .watt-menu-item-icon {
+        /* Hide icon space when no menu items have icons */
+        &:not(:has(watt-icon)) .watt-menu-item-icon {
           display: none;
         }
       }
@@ -103,34 +99,4 @@ export class WattMenuComponent {
    * @ignore
    */
   menu = viewChild.required<MatMenu>('menu');
-
-  /**
-   * All menu items in this menu.
-   * @ignore
-   */
-  menuItems = contentChildren(WattMenuItemComponent, { descendants: true });
-
-  /**
-   * Whether any menu item has an icon.
-   * @ignore
-   */
-  hasIcons = computed(() => this.menuItems().some((item) => item.hasIcon()));
-
-  /**
-   * CSS classes to apply to the menu panel.
-   * @ignore
-   */
-  panelClasses = computed(() => {
-    return this.hasIcons() ? 'watt-menu-panel watt-menu-panel--has-icons' : 'watt-menu-panel';
-  });
-
-  constructor() {
-    // Update menu items when the content changes
-    effect(() => {
-      const hasIcons = this.hasIcons();
-      this.menuItems().forEach((item) => {
-        item.menuHasIcons.set(hasIcons);
-      });
-    });
-  }
 }

--- a/libs/watt/package/menu/watt-menu.component.ts
+++ b/libs/watt/package/menu/watt-menu.component.ts
@@ -121,9 +121,7 @@ export class WattMenuComponent {
    * @ignore
    */
   panelClasses = computed(() => {
-    return this.hasIcons() 
-      ? 'watt-menu-panel watt-menu-panel--has-icons'
-      : 'watt-menu-panel';
+    return this.hasIcons() ? 'watt-menu-panel watt-menu-panel--has-icons' : 'watt-menu-panel';
   });
 
   constructor() {

--- a/libs/watt/package/menu/watt-menu.component.ts
+++ b/libs/watt/package/menu/watt-menu.component.ts
@@ -64,7 +64,7 @@ import { WattMenuItemComponent } from './watt-menu-item.component';
 @Component({
   selector: 'watt-menu',
   template: `
-    <mat-menu #menu="matMenu" [class]="panelClasses().join(' ')">
+    <mat-menu #menu="matMenu" [class]="panelClasses()">
       <ng-content />
     </mat-menu>
   `,
@@ -121,11 +121,9 @@ export class WattMenuComponent {
    * @ignore
    */
   panelClasses = computed(() => {
-    const classes = ['watt-menu-panel'];
-    if (this.hasIcons()) {
-      classes.push('watt-menu-panel--has-icons');
-    }
-    return classes;
+    return this.hasIcons() 
+      ? 'watt-menu-panel watt-menu-panel--has-icons'
+      : 'watt-menu-panel';
   });
 
   constructor() {

--- a/libs/watt/package/package.json
+++ b/libs/watt/package/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@energinet/watt",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -256,6 +256,7 @@
         "libs/watt/package/utils/intersection-observer/index.ts"
       ],
       "@energinet-datahub/watt/modal": ["libs/watt/package/modal/index.ts"],
+      "@energinet-datahub/watt/menu": ["libs/watt/package/menu/index.ts"],
       "@energinet-datahub/watt/paginator": ["libs/watt/package/paginator/index.ts"],
       "@energinet-datahub/watt/phone-field": ["libs/watt/package/phone-field/index.ts"],
       "@energinet-datahub/watt/progress-tracker": ["libs/watt/package/progress-tracker/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -255,8 +255,8 @@
       "@energinet-datahub/watt/intersection-observer": [
         "libs/watt/package/utils/intersection-observer/index.ts"
       ],
-      "@energinet-datahub/watt/modal": ["libs/watt/package/modal/index.ts"],
       "@energinet-datahub/watt/menu": ["libs/watt/package/menu/index.ts"],
+      "@energinet-datahub/watt/modal": ["libs/watt/package/modal/index.ts"],
       "@energinet-datahub/watt/paginator": ["libs/watt/package/paginator/index.ts"],
       "@energinet-datahub/watt/phone-field": ["libs/watt/package/phone-field/index.ts"],
       "@energinet-datahub/watt/progress-tracker": ["libs/watt/package/progress-tracker/index.ts"],


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

- Add support for async menu items in `watt-menu`
- Optimize imports of `watt-menu`
- Replace `mat-menu` -> `watt-menu` in `dh-profile-avatar.component.ts`
<img width="1005" height="608" alt="image" src="https://github.com/user-attachments/assets/fbbde3f1-9e85-44cc-ae67-9f6b2f9a97d5" />

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
