### PR TITLE
Use --non-interactive flag on dotnet watch command

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi/project.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi/project.json
@@ -24,7 +24,7 @@
       ],
       "executor": "nx:run-commands",
       "options": {
-        "command": "dotnet watch --project apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj --configuration=Debug"
+        "command": "dotnet watch --project apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj --non-interactive --configuration=Debug"
       }
     }
   }


### PR DESCRIPTION
This will automatically restart the server on rude edits (edits that cannot be hot reloaded, typically happens when switching branch fx). Without this flag, the shell will prompt first, which is annoying when using the Nx TUI.