### PR TITLE
fix(dh): auto-close notification banner

### DIFF
--- a/libs/dh/core/feature-notifications/src/lib/dh-notifications-center.service.ts
+++ b/libs/dh/core/feature-notifications/src/lib/dh-notifications-center.service.ts
@@ -38,7 +38,8 @@ export class DhNotificationsCenterService {
       },
       position: 'top-right',
       dismissible: true,
-      autoClose: false,
+      autoClose: true,
+      duration: 5_000,
       style: {
         border: `1px solid ${this.colorService.getColor('grey400')}`,
         'backdrop-filter': 'blur(30px)',


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
### DataHub
- auto-close notification banner after 5 sec
<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
