### PR TITLE
fix(dh): improve error logging for non-DataHub user login attempts

### DIFF
--- a/libs/dh/shared/feature-authorization/src/lib/dh-actor-token.service.ts
+++ b/libs/dh/shared/feature-authorization/src/lib/dh-actor-token.service.ts
@@ -109,16 +109,7 @@ export class DhActorTokenService {
                   // Prevent multiple logs of the same event in AppInsights
                   if (this.logoutInProgress === false) {
                     if (error instanceof Error) {
-                      if (
-                        error.message.includes('AADB2C90273') &&
-                        error.message.includes('mitid_erhverv.no_identities')
-                      ) {
-                        this.appInsights.trackEvent(
-                          'A non-DataHub user tries to login with MitID Private'
-                        );
-                      } else {
-                        this.appInsights.trackException(error, 3);
-                      }
+                      this.handleError(error);
                     } else {
                       try {
                         const errorString = JSON.stringify(error);
@@ -193,5 +184,16 @@ export class DhActorTokenService {
 
   private isTokenRequest(request: HttpRequest<unknown>): boolean {
     return request.url.includes(this.apiToken.getTokenUrl);
+  }
+
+  private handleError(error: Error): void {
+    if (
+      error.message.includes('AADB2C90273') &&
+      error.message.includes('mitid_erhverv.no_identities')
+    ) {
+      this.appInsights.trackEvent('A non-DataHub user tries to login with MitID Private');
+    } else {
+      this.appInsights.trackException(error, 3);
+    }
   }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
