### PR TITLE
fix: temporarily hide state column in metering point process overview…

### DIFF
--- a/libs/dh/metering-point/feature-process-overview/src/components/steps.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/components/steps.ts
@@ -132,7 +132,7 @@ export class DhMeteringPointProcessOverviewSteps {
     completedAt: { accessor: 'completedAt', sort: false },
     dueDate: { accessor: 'dueDate', sort: false },
     actor: { accessor: 'actor', sort: false },
-    state: { accessor: 'state', sort: false },
+    //state: { accessor: 'state', sort: false }, // Temporarily hidden until the backend/EDI supports more states
   };
 
   displayedColumns = computed(() => {


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description
`EDI` currently supports only two states, which has been determined to create confusion for users rather than deliver value. Therefore, the state column is hidden on process steps until EDI supports additional states.

- Temporarily hide state column in metering point process overview steps

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000
