### PR TITLE
fix(dh): charge information fixes

### DIFF
--- a/libs/dh/charges/feature-charges/src/components/information/information.ts
+++ b/libs/dh/charges/feature-charges/src/components/information/information.ts
@@ -135,7 +135,7 @@ import { DhPermissionRequiredDirective } from '@energinet-datahub/dh/shared/feat
         <ng-container *dhPermissionRequired="['charges:manage']">
           <watt-button variant="secondary" [wattMenuTriggerFor]="menu">
             {{ t('charge.actions.menu') }}
-            <watt-icon name="plus" />
+            <watt-icon name="moreVertical" />
           </watt-button>
           <watt-menu #menu>
             <watt-menu-item [routerLink]="[{ outlets: { actions: ['edit'] } }]">


### PR DESCRIPTION
This PR makes sure that when navigating back from a charge to the table view using the breadcrumbs, the filters that were last used is preserved.

Also fixes a bug when `vatInclusive` is `false` + refactors information.ts a bit