### PR TITLE
make prefill use computed fields

### DIFF
--- a/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
+++ b/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
@@ -440,8 +440,7 @@ export class DhUpdateCustomerDataComponent {
         return;
       }
 
-      const customers =
-        meteringPoint.commercialRelation?.activeEnergySupplyPeriod?.customers ?? [];
+      const customers = meteringPoint.commercialRelation?.activeEnergySupplyPeriod?.customers ?? [];
       const customer = customers[0];
 
       untracked(() => {


### PR DESCRIPTION
The installation address is not being carried over to the legal, and technical address fields, due to the response not having been cached. We need a way to pre-fill the fields, during a cache miss. By depending on a computed value, this will no longer pose a problem