### PR TITLE
fix(dh): allow irregular first period when uploading monthly charge series

### DIFF
--- a/libs/dh/charges/feature-parse-series/tests/__snapshots__/parse-charge-series.spec.ts.snap
+++ b/libs/dh/charges/feature-parse-series/tests/__snapshots__/parse-charge-series.spec.ts.snap
@@ -54,6 +54,25 @@ exports[`parseChargeSeries > should error when price is invalid 1`] = `
 }
 `;
 
+exports[`parseChargeSeries > should error when second entry in monthly resolution is not on first of month 1`] = `
+{
+  "errors": [
+    {
+      "index": 1,
+      "key": "MISSING_POINT",
+    },
+  ],
+  "interval": {
+    "end": 2025-02-28T23:00:00.000Z,
+    "start": 2025-01-14T23:00:00.000Z,
+  },
+  "isFatal": true,
+  "points": 1,
+  "progress": 77,
+  "resolution": "MONTHLY",
+}
+`;
+
 exports[`parseChargeSeries > should error when structure is unexpected 1`] = `
 {
   "errors": [
@@ -66,6 +85,25 @@ exports[`parseChargeSeries > should error when structure is unexpected 1`] = `
   "isFatal": true,
   "points": 0,
   "progress": 26,
+  "resolution": "MONTHLY",
+}
+`;
+
+exports[`parseChargeSeries > should error when third entry in monthly resolution is not on first of month 1`] = `
+{
+  "errors": [
+    {
+      "index": 2,
+      "key": "MISSING_POINT",
+    },
+  ],
+  "interval": {
+    "end": 2025-04-14T22:00:00.000Z,
+    "start": 2025-01-14T23:00:00.000Z,
+  },
+  "isFatal": true,
+  "points": 2,
+  "progress": 100,
   "resolution": "MONTHLY",
 }
 `;
@@ -275,6 +313,34 @@ exports[`parseChargeSeries > should handle DST start correctly in quarter hourly
   "points": 13,
   "progress": 100,
   "resolution": "QUARTER_HOURLY",
+}
+`;
+
+exports[`parseChargeSeries > should parse monthly resolution with first entry on last day of month 1`] = `
+{
+  "errors": [],
+  "interval": {
+    "end": 2025-04-30T22:00:00.000Z,
+    "start": 2025-01-30T23:00:00.000Z,
+  },
+  "isFatal": false,
+  "points": 4,
+  "progress": 100,
+  "resolution": "MONTHLY",
+}
+`;
+
+exports[`parseChargeSeries > should parse monthly resolution with first entry starting mid-month 1`] = `
+{
+  "errors": [],
+  "interval": {
+    "end": 2025-05-31T22:00:00.000Z,
+    "start": 2025-01-14T23:00:00.000Z,
+  },
+  "isFatal": false,
+  "points": 5,
+  "progress": 100,
+  "resolution": "MONTHLY",
 }
 `;
 

--- a/libs/dh/charges/feature-parse-series/tests/parse-charge-series.spec.ts
+++ b/libs/dh/charges/feature-parse-series/tests/parse-charge-series.spec.ts
@@ -360,4 +360,59 @@ describe(parseChargeSeries, () => {
     const result = await lastValueFrom(stream);
     expect(makeReadable(result)).toMatchSnapshot();
   });
+
+  it('should parse monthly resolution with first entry starting mid-month', async () => {
+    const csv = [
+      'Position,Periode,Pris',
+      '1,15.1.2025 0.00,100',
+      '2,1.2.2025 0.00,100',
+      '3,1.3.2025 0.00,100',
+      '4,1.4.2025 0.00,100',
+      '5,1.5.2025 0.00,100',
+    ].join('\n');
+
+    const stream = parseChargeSeries(csv, ChargeResolution.Monthly);
+    const result = await lastValueFrom(stream);
+    expect(makeReadable(result)).toMatchSnapshot();
+  });
+
+  it('should parse monthly resolution with first entry on last day of month', async () => {
+    const csv = [
+      'Position,Periode,Pris',
+      '1,31.1.2025 0.00,100',
+      '2,1.2.2025 0.00,100',
+      '3,1.3.2025 0.00,100',
+      '4,1.4.2025 0.00,100',
+    ].join('\n');
+
+    const stream = parseChargeSeries(csv, ChargeResolution.Monthly);
+    const result = await lastValueFrom(stream);
+    expect(makeReadable(result)).toMatchSnapshot();
+  });
+
+  it('should error when second entry in monthly resolution is not on first of month', async () => {
+    const csv = [
+      'Position,Periode,Pris',
+      '1,15.1.2025 0.00,100',
+      '2,15.2.2025 0.00,100',
+      '3,1.3.2025 0.00,100',
+    ].join('\n');
+
+    const stream = parseChargeSeries(csv, ChargeResolution.Monthly);
+    const result = await lastValueFrom(stream);
+    expect(makeReadable(result)).toMatchSnapshot();
+  });
+
+  it('should error when third entry in monthly resolution is not on first of month', async () => {
+    const csv = [
+      'Position,Periode,Pris',
+      '1,15.1.2025 0.00,100',
+      '2,1.2.2025 0.00,100',
+      '3,15.3.2025 0.00,100',
+    ].join('\n');
+
+    const stream = parseChargeSeries(csv, ChargeResolution.Monthly);
+    const result = await lastValueFrom(stream);
+    expect(makeReadable(result)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
It should apparently be possible to upload charge series with the first period being irregular. This only applies to monthy resolution.