### PR TITLE
fix(metering-point, measure-data): floating point sum precision

### DIFF
--- a/libs/dh/metering-point/feature-measurements/src/components/day.component.ts
+++ b/libs/dh/metering-point/feature-measurements/src/components/day.component.ts
@@ -122,7 +122,7 @@ export class DhMeasurementsDayComponent {
         this.measurements()
           .map((x) => x.current?.quantity)
           .filter((quantity) => quantity !== null && quantity !== undefined)
-          .reduce((acc, quantity) => acc + Number(quantity), 0)
+          .reduce((acc, quantity) => Number.parseFloat((acc + Number(quantity)).toFixed(10)), 0)
       )} ${this.unit()}`
   );
   private readonly unit = computed(() => {

--- a/libs/dh/metering-point/feature-measurements/src/components/month.component.ts
+++ b/libs/dh/metering-point/feature-measurements/src/components/month.component.ts
@@ -152,7 +152,7 @@ export class DhMeasurementsMonthComponent {
         this.measurements()
           .map((x) => x.quantity)
           .filter((quantity) => quantity !== null && quantity !== undefined)
-          .reduce((acc, quantity) => acc + Number(quantity), 0)
+          .reduce((acc, quantity) => Number.parseFloat((acc + Number(quantity)).toFixed(10)), 0)
       )} ${this.unit()}`
   );
   private unit = computed(() => {

--- a/libs/dh/metering-point/feature-measurements/src/components/year.component.ts
+++ b/libs/dh/metering-point/feature-measurements/src/components/year.component.ts
@@ -139,7 +139,7 @@ export class DhMeasurementsYearComponent {
         this.measurements()
           .map((x) => x.quantity)
           .filter((quantity) => quantity !== null && quantity !== undefined)
-          .reduce((acc, quantity) => acc + Number(quantity), 0)
+          .reduce((acc, quantity) => Number.parseFloat((acc + Number(quantity)).toFixed(10)), 0)
       )} ${this.unit()}`
   );
   private unit = computed(() => {

--- a/libs/dh/metering-point/feature-upload-measurements/src/models/measure-data-result.ts
+++ b/libs/dh/metering-point/feature-upload-measurements/src/models/measure-data-result.ts
@@ -172,7 +172,7 @@ export class MeasureDataResult {
   /** Adds a measurement to the result. Chainable. */
   addMeasurement = (measurement: Measurement) => {
     this.measurements.push(measurement);
-    this.sum = parseFloat((this.sum + measurement.quantity).toFixed(10));
+    this.sum = Number.parseFloat((this.sum + measurement.quantity).toFixed(10));
     this.qualities.add(measurement.quality);
     return this;
   };

--- a/libs/dh/metering-point/feature-upload-measurements/tests/parse-measurements.spec.ts
+++ b/libs/dh/metering-point/feature-upload-measurements/tests/parse-measurements.spec.ts
@@ -193,7 +193,8 @@ describe(parseMeasurements, () => {
     for (let i = 0; i < 96; i++) {
       const hour = Math.floor(i / 4);
       const quarter = i % 4;
-      const minutes = quarter === 0 ? '00' : quarter === 1 ? '15' : quarter === 2 ? '30' : '45';
+      const minutesMap = ['00', '15', '30', '45'] as const;
+      const minutes = minutesMap[quarter];
       const position = i + 1;
       const value =
         (i >= 66 && i <= 68) || (i >= 74 && i <= 76) || (i >= 81 && i <= 82) ? '2.123' : '2';


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

- Fix floating-point precision error in measurement data sum                                                                                                                                     
                                                            
**Problem**                                                                                                                                                                                        
When uploading measurement data (måledata) via CSV, the displayed sum shows floating-point noise — e.g. 192.98399999999992 instead of the correct 192.984. This is caused by JavaScript's IEEE 754 floating-point arithmetic accumulating tiny rounding errors when summing decimal values across many rows.

 **Root cause**
In `measure-data-result.ts`, the sum was accumulated using plain `+=`:
`this.sum += measurement.quantity` Each addition introduces a rounding error on the order of ~10⁻¹⁴. Over 96 rows, these errors compound into a visible discrepancy.

**Fix**
Round the intermediate sum after each addition to eliminate floating-point noise while preserving up to 10 decimal places of real precision:

`this.sum = parseFloat((this.sum + measurement.quantity).toFixed(10));`

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- [#1336](https://github.com/Energinet-DataHub/team-mosaic/issues/1336)
