### PR TITLE
fix: removes required from optional fields

### DIFF
--- a/libs/dh/metering-point/feature-move-in/src/util/create-contact-address-details-form.ts
+++ b/libs/dh/metering-point/feature-move-in/src/util/create-contact-address-details-form.ts
@@ -38,12 +38,11 @@ export function createContactAddressDetailsForm(
     postCode: dhMakeFormControl<string | null>(contact?.postCode, Validators.required),
     cityName: dhMakeFormControl<string | null>(contact?.cityName, Validators.required),
     countryCode: dhMakeFormControl<string | null>(contact?.countryCode),
-    streetCode: dhMakeFormControl<string | null>(contact?.streetCode, Validators.required),
+    streetCode: dhMakeFormControl<string | null>(contact?.streetCode),
     citySubDivisionName: dhMakeFormControl<string | null>(contact?.citySubDivisionName),
     postBox: dhMakeFormControl<string | null>(contact?.postBox),
     municipalityCode: dhMakeFormControl<string | null>(contact?.municipalityCode, [
       dhMunicipalityCodeValidator(),
-      Validators.required,
     ]),
     darReference: dhMakeFormControl<string | null>(contact?.darReference),
   });


### PR DESCRIPTION
Should fix this:
https://energinet.service-now.com/now/nav/ui/classic/params/target/incident.do%3Fsys_id%3D085edf352b933e9006b0f379ed91bf36%26sysparm_stack%3D%26sysparm_view%3Dit_datahub%26sysparm_view_forced%3Dtrue