### PR TITLE
feat: Update EM2 client package, mapping "IsActive" for electrical heating & "Other" time resolution

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Modules/ElectricityMarket/Mappers/MeteringPointMetadataMapperTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Modules/ElectricityMarket/Mappers/MeteringPointMetadataMapperTests.cs
@@ -141,7 +141,8 @@ public class MeteringPointMetadataMapperTests
 
         var electricalHeatingPeriod = new MeteringPointDtoV2.ElectricalHeatingPeriodDto(
             _heatingValidFrom,
-            _heatingValidTo);
+            _heatingValidTo,
+            IsActive: true);
 
         var commercialRelation = new MeteringPointDtoV2.CommercialRelationDto(
             _validFrom,
@@ -231,7 +232,7 @@ public class MeteringPointMetadataMapperTests
             () => Assert.NotEmpty(commercialRelationResult.ActiveElectricalHeatingPeriods!.Id),
             () => Assert.Equal(_heatingValidFrom, commercialRelationResult.ActiveElectricalHeatingPeriods!.ValidFrom),
             () => Assert.Equal(_heatingValidTo, commercialRelationResult.ActiveElectricalHeatingPeriods!.ValidTo),
-            () => Assert.False(commercialRelationResult.ActiveElectricalHeatingPeriods!.IsActive),
+            () => Assert.True(commercialRelationResult.ActiveElectricalHeatingPeriods!.IsActive),
             () => Assert.Null(commercialRelationResult.ActiveElectricalHeatingPeriods!.TransactionType));
     }
 

--- a/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -57,7 +57,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="15.14.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="15.14.0" />
     <PackageReference Include="Energinet.DataHub.EDI.B2CClient" Version="1.1.7" />
-    <PackageReference Include="Energinet.DataHub.ElectricityMarket.Client" Version="1.75.0" />
+    <PackageReference Include="Energinet.DataHub.ElectricityMarket.Client" Version="1.86.0" />
     <PackageReference Include="Energinet.DataHub.MarketParticipant.Authorization" Version="3.0.7" />
     <PackageReference Include="Energinet.DataHub.Measurements.Client" Version="11.3.1" />
     <PackageReference Include="Energinet.DataHub.MessageArchive.Client" Version="2.0.8" />

--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/Mappers/MeteringPointMetadataMapper.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/Mappers/MeteringPointMetadataMapper.cs
@@ -156,7 +156,7 @@ public static class MeteringPointMetadataMapper
             Id = IdentifierEncoder.EncodeMeteringPointId(meteringPointId, electricalHeatingPeriod.ValidFrom, electricalHeatingPeriod.ValidTo),
             ValidFrom = electricalHeatingPeriod.ValidFrom,
             ValidTo = electricalHeatingPeriod.ValidTo,
-            IsActive = false, // TODO: We don't have this value from the backend yet
+            IsActive = electricalHeatingPeriod.IsActive,
             TransactionType = null, // TODO: We don't have this value from the backend yet
         };
     }

--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/Mappers/TimeResolutionMapper.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/Mappers/TimeResolutionMapper.cs
@@ -23,6 +23,7 @@ public static class TimeResolutionMapper
             DataHub.ElectricityMarket.Abstractions.Shared.TimeResolution.QuarterHourly => "PT15M",
             DataHub.ElectricityMarket.Abstractions.Shared.TimeResolution.Hourly => "PT1H",
             DataHub.ElectricityMarket.Abstractions.Shared.TimeResolution.Monthly => "P1M",
+            DataHub.ElectricityMarket.Abstractions.Shared.TimeResolution.Other => "OTHER",
             DataHub.ElectricityMarket.Abstractions.Shared.TimeResolution.Unknown => throw new InvalidOperationException("Invalid TimeResolution"),
         };
     }


### PR DESCRIPTION
Pass ElectricalHeatingPeriod.IsActive through the metering point mapper and update tests to set and assert IsActive=true. Add mapping for TimeResolution.Other -> "OTHER". Also bump Energinet.DataHub.ElectricityMarket.Client from 1.75.0 to 1.86.0.

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

- Update Electricity Market (v2) client package
- Update TimeResolution mapping to now contain "OTHER" value
- Update Electrical Heating Period mapping to now include "IsActive" value

---

<details>
<summary><strong>Testing with Docker (for QA)</strong></summary>

### Prerequisites
- Docker Desktop installed and running
- Git
- SSL certificates (`localhost.crt` and `localhost.key`) in the repository root

### Steps to run locally

1. **Checkout this branch:**
   ```bash
   git fetch origin
   git checkout <branch-name>
   ```

2. **Build and start the containers:**
   ```bash
   docker compose up --build
   ```

3. **Azure authentication:**
   The BFF container will prompt for Azure login using device code flow. Follow the instructions in the terminal to authenticate.

4. **Access the application:**
   Open https://localhost:4200 in your browser.

5. **Stop the containers:**
   ```bash
   docker compose down
   ```

### Troubleshooting
- If you get SSL certificate errors, ensure `localhost.crt` and `localhost.key` exist in the repo root
- If port 4200 or 5001 is in use, stop conflicting services or modify `docker-compose.yml`

</details>
