### PR TITLE
refactor: replace jsdom with happy-dom in lib vite configs

### DIFF
--- a/libs/dh/actor-conversation/feature-actor-conversation/vite.config.mts
+++ b/libs/dh/actor-conversation/feature-actor-conversation/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/admin/data-access-api/vite.config.mts
+++ b/libs/dh/admin/data-access-api/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',

--- a/libs/dh/admin/feature-permissions/vite.config.mts
+++ b/libs/dh/admin/feature-permissions/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',

--- a/libs/dh/admin/feature-user-management/vite.config.mts
+++ b/libs/dh/admin/feature-user-management/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',

--- a/libs/dh/admin/feature-user-roles/vite.config.mts
+++ b/libs/dh/admin/feature-user-roles/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',

--- a/libs/dh/admin/shell/vite.config.mts
+++ b/libs/dh/admin/shell/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',

--- a/libs/dh/admin/ui-shared/vite.config.mts
+++ b/libs/dh/admin/ui-shared/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     reporters: ['default'],
     coverage: {

--- a/libs/dh/auth/feature-msal/vite.config.mts
+++ b/libs/dh/auth/feature-msal/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/charges/feature-charges/vite.config.mts
+++ b/libs/dh/charges/feature-charges/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/charges/feature-parse-series/vite.config.mts
+++ b/libs/dh/charges/feature-parse-series/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/charges/feature-ui-shared/vite.config.mts
+++ b/libs/dh/charges/feature-ui-shared/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/core/feature-notifications/vite.config.mts
+++ b/libs/dh/core/feature-notifications/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/core/shell/vite.config.mts
+++ b/libs/dh/core/shell/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/core/ui-toolbar-portal/vite.config.mts
+++ b/libs/dh/core/ui-toolbar-portal/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/developer/feature-examples/vite.config.mts
+++ b/libs/dh/developer/feature-examples/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',

--- a/libs/dh/developer/feature-operation/vite.config.mts
+++ b/libs/dh/developer/feature-operation/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',

--- a/libs/dh/esett/feature-balance-responsible/vite.config.mts
+++ b/libs/dh/esett/feature-balance-responsible/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/esett/feature-outgoing-messages/vite.config.mts
+++ b/libs/dh/esett/feature-outgoing-messages/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/esett/shell/vite.config.mts
+++ b/libs/dh/esett/shell/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/globalization/configuration-localization/vite.config.mts
+++ b/libs/dh/globalization/configuration-localization/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/globalization/configuration-watt-translation/vite.config.mts
+++ b/libs/dh/globalization/configuration-watt-translation/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/market-participant/domain/vite.config.mts
+++ b/libs/dh/market-participant/domain/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/market-participant/feature-market-participant/vite.config.mts
+++ b/libs/dh/market-participant/feature-market-participant/vite.config.mts
@@ -46,7 +46,7 @@ export default defineConfig(() => ({
   test: {
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: [
       'tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',

--- a/libs/dh/market-participant/feature-market-roles/vite.config.mts
+++ b/libs/dh/market-participant/feature-market-roles/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/message-archive/domain/vite.config.mts
+++ b/libs/dh/message-archive/domain/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/message-archive/shell/vite.config.mts
+++ b/libs/dh/message-archive/shell/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/metering-point/feature-chargelink/vite.config.mts
+++ b/libs/dh/metering-point/feature-chargelink/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/metering-point/feature-debug/vite.config.mts
+++ b/libs/dh/metering-point/feature-debug/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/metering-point/feature-end-of-supply/vite.config.mts
+++ b/libs/dh/metering-point/feature-end-of-supply/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/metering-point/feature-measurements/vite.config.mts
+++ b/libs/dh/metering-point/feature-measurements/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/metering-point/feature-move-in/vite.config.mts
+++ b/libs/dh/metering-point/feature-move-in/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/metering-point/feature-overview/vite.config.mts
+++ b/libs/dh/metering-point/feature-overview/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/metering-point/feature-process-overview/vite.config.mts
+++ b/libs/dh/metering-point/feature-process-overview/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/metering-point/feature-search/vite.config.mts
+++ b/libs/dh/metering-point/feature-search/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/metering-point/feature-upload-measurements/vite.config.mts
+++ b/libs/dh/metering-point/feature-upload-measurements/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/profile/feature-avatar/vite.config.mts
+++ b/libs/dh/profile/feature-avatar/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/profile/feature-profile-modal/vite.config.mts
+++ b/libs/dh/profile/feature-profile-modal/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/reports/feature-measurements-reports/vite.config.mts
+++ b/libs/dh/reports/feature-measurements-reports/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['src/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/reports/feature-missing-measurements-log/vite.config.mts
+++ b/libs/dh/reports/feature-missing-measurements-log/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/reports/feature-reports/vite.config.mts
+++ b/libs/dh/reports/feature-reports/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['src/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/reports/feature-settlement-reports/vite.config.mts
+++ b/libs/dh/reports/feature-settlement-reports/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['src/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/assets/vite.config.mts
+++ b/libs/dh/shared/assets/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/data-access-graphql/vite.config.mts
+++ b/libs/dh/shared/data-access-graphql/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/data-access-top-bar/vite.config.mts
+++ b/libs/dh/shared/data-access-top-bar/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/feature-authorization/vite.config.mts
+++ b/libs/dh/shared/feature-authorization/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/feature-highlight/vite.config.mts
+++ b/libs/dh/shared/feature-highlight/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     reporters: ['default'],
     coverage: {

--- a/libs/dh/shared/test-util-mocks/vite.config.mts
+++ b/libs/dh/shared/test-util-mocks/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/test-util/vite.config.mts
+++ b/libs/dh/shared/test-util/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/ui-util/vite.config.mts
+++ b/libs/dh/shared/ui-util/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/ui-validators/vite.config.mts
+++ b/libs/dh/shared/ui-validators/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts', 'tests/**/*.test.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/util-apollo/vite.config.mts
+++ b/libs/dh/shared/util-apollo/vite.config.mts
@@ -39,7 +39,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/util-application-insights/vite.config.mts
+++ b/libs/dh/shared/util-application-insights/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/util-navigation/vite.config.mts
+++ b/libs/dh/shared/util-navigation/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     reporters: ['default'],
     coverage: {

--- a/libs/dh/shared/util-new-version-manager/vite.config.mts
+++ b/libs/dh/shared/util-new-version-manager/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/util-release-toggle/vite.config.mts
+++ b/libs/dh/shared/util-release-toggle/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/shared/util-reports/vite.config.mts
+++ b/libs/dh/shared/util-reports/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/wholesale/feature-calculations/vite.config.mts
+++ b/libs/dh/wholesale/feature-calculations/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/wholesale/feature-requests/vite.config.mts
+++ b/libs/dh/wholesale/feature-requests/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/wholesale/shell/vite.config.mts
+++ b/libs/dh/wholesale/shell/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/dh/wholesale/ui-shared/vite.config.mts
+++ b/libs/dh/wholesale/ui-shared/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     reporters: ['default'],
     coverage: {

--- a/libs/gf/globalization/configuration-danish-locale/vite.config.mts
+++ b/libs/gf/globalization/configuration-danish-locale/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/gf/globalization/data-access-localization/vite.config.mts
+++ b/libs/gf/globalization/data-access-localization/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/gf/msw/e2e-util-msw/vite.config.mts
+++ b/libs/gf/msw/e2e-util-msw/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     reporters: ['default'],
     coverage: {

--- a/libs/gf/shared/test-util-matchers/vite.config.mts
+++ b/libs/gf/shared/test-util-matchers/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/gf/shared/util-browser/vite.config.mts
+++ b/libs/gf/shared/util-browser/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],

--- a/libs/gf/shared/util-cookie-information/vite.config.mts
+++ b/libs/gf/shared/util-cookie-information/vite.config.mts
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
     passWithNoTests: true,
     watch: false,
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     include: ['src/**/*.spec.ts', 'tests/**/*.spec.ts'],
     setupFiles: ['tests/test-setup.ts'],
     reporters: ['default'],


### PR DESCRIPTION
## Summary

- Replaces `jsdom` with `happy-dom` as the test environment in all 66 `vite.config.mts` files that used `jsdom`
- `happy-dom` is faster and more spec-compliant than `jsdom`

## Part of series
This is PR 2 of 6 in the [remove per-lib vite configs](https://github.com/Energinet-DataHub/greenforce-frontend/pull/5474) refactor.

Depends on PR 1: #5474