### PR TITLE
Actor Conversation: Add security header to file response from bff

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi/Controllers/ActorConversationController.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Controllers/ActorConversationController.cs
@@ -137,7 +137,7 @@ public sealed class ActorConversationController : ControllerBase
                     fileName = disposition.FileNameStar ?? disposition.FileName;
                 }
             }
-            
+
             Response.Headers.XContentTypeOptions = "no-sniff";
             Response.Headers.ContentSecurityPolicy = "default-src 'none'";
 


### PR DESCRIPTION
Based on security investigations on actor conversation regarding file upload, it was decided that the file retrieval should have additional security headers added


