### PR TITLE
chore: exclude task dependencies when serving dh:mocked

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -88,7 +88,7 @@
     {
       "label": "Serve app-dh",
       "type": "shell",
-      "command": "bun run nx run app-dh:serve:mocked",
+      "command": "bun run nx run app-dh:serve:mocked --exclude-task-dependencies",
       "isBackground": true,
       "presentation": {
         "focus": true,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "nx": "nx",
     "start": "nx serve",
     "dh:dev": "nx run app-dh:serve:development",
-    "dh:mock": "nx run app-dh:serve:mocked",
+    "dh:mock": "nx run app-dh:serve:mocked --exclude-task-dependencies",
     "dh:build": "nx run app-dh:build:production",
     "api:dev": "nx serve api-dh",
     "api:test": "dotnet test apps/dh/api-dh/DataHub.WebApi.sln --configuration=Release --filter 'DisplayName!~TelemetryTests' --logger 'console;verbosity=detailed'",


### PR DESCRIPTION
## Description

Currently when running `dh:mock`, it also serves the BFF and GraphQL watcher even though they are not used in the mocked environment. This PR disables this so we now only serve the frontend application when running in mocked mode.