### PR TITLE
fix(dh): quickfix for inaccurate chargeById

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/Charges/Client/ChargesClient.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/Charges/Client/ChargesClient.cs
@@ -95,12 +95,12 @@ public class ChargesClient(
     public async Task<Charge?> GetChargeByIdAsync(ChargeIdentifierDto id, CancellationToken ct = default)
     {
         var result = await client.GetChargeInformationAsync(
-            new(0, 1, new(id.Code, [id.Owner], [id.TypeDto]), ChargeInformationSortProperty.Type, false),
+            new(0, 10000, new(id.Code, [id.Owner], [id.TypeDto]), ChargeInformationSortProperty.Type, false),
             ct);
 
         return !result.IsSuccess
             ? throw new GraphQLException(result.DiagnosticMessage)
-            : result.Data?.Select(MapChargeInformationDtoToCharge).SingleOrDefault(defaultValue: null);
+            : result.Data?.Select(MapChargeInformationDtoToCharge).FirstOrDefault(c => c.Code == id.Code);
     }
 
     public async Task<IEnumerable<Charge>> GetChargesByTypeAsync(ChargeType type, CancellationToken ct = default)


### PR DESCRIPTION
The searchText (code) input to the `GetChargeInformationAsync` method is is not an exact match, meaning that a code like `ABC12` would also match `ABC123`. Since we were just returning the first match, we would sometimes get the wrong charge 😱 

This is a quickfix - the proper fix is to get a real `chargeById` endpoint.