### PR TITLE
Update verify.tool to 0.7.0 for .NET 10 support

### DIFF
--- a/apps/dh/api-dh/.config/dotnet-tools.json
+++ b/apps/dh/api-dh/.config/dotnet-tools.json
@@ -6,13 +6,15 @@
       "version": "10.1.5",
       "commands": [
         "swagger"
-      ]
+      ],
+      "rollForward": false
     },
     "verify.tool": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "commands": [
         "dotnet-verify"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- Updates `verify.tool` from 0.6.0 to 0.7.0
- Version 0.6.0 only targeted net8.0, requiring .NET 8 runtime to be installed alongside .NET 10
- Version 0.7.0 includes a `net10.0` target, eliminating the .NET 8 dependency