### PR TITLE
Move in: Fields should be cleared when getting data from temp storage

### DIFF
--- a/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
+++ b/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
@@ -236,6 +236,23 @@ export class DhUpdateCustomerDataComponent {
   private readonly technicalContact = computed(() => this.technicalCustomer()?.technicalContact);
   private readonly legalContact = computed(() => this.legalCustomer()?.legalContact);
 
+  // During a move-in (processId present), keep contact fields empty while the
+  // temporary storage query is in flight OR when it returns data.
+  // Only prefill contacts if the query is done and returned no data.
+  private readonly shouldClearContacts = computed(
+    () =>
+      !!this.processId() &&
+      (this.temporaryStorageCustomerQuery.loading() || !!this.temporaryStorageCustomer())
+  );
+
+  private readonly effectiveLegalContact = computed(() =>
+    this.shouldClearContacts() ? undefined : this.legalContact()
+  );
+
+  private readonly effectiveTechnicalContact = computed(() =>
+    this.shouldClearContacts() ? undefined : this.technicalContact()
+  );
+
   navigate = injectRelativeNavigate();
   isBusinessCustomer = computed(
     () => this.temporaryStorageCustomer()?.isBusinessCustomer ?? this.legalCustomer()?.cvr !== null
@@ -281,18 +298,18 @@ export class DhUpdateCustomerDataComponent {
         }),
         legalContactDetails: createCustomerContactDetailsForm(
           this.legalCustomer(),
-          this.legalContact()
+          this.effectiveLegalContact()
         ),
         legalContactAddressDetails: createContactAddressDetailsForm(
-          this.legalContact(),
+          this.effectiveLegalContact(),
           this.installationAddress()
         ),
         technicalContactDetails: createCustomerContactDetailsForm(
           this.legalCustomer(),
-          this.technicalContact()
+          this.effectiveTechnicalContact()
         ),
         technicalContactAddressDetails: createContactAddressDetailsForm(
-          this.technicalContact(),
+          this.effectiveTechnicalContact(),
           this.installationAddress()
         ),
       })
@@ -329,7 +346,7 @@ export class DhUpdateCustomerDataComponent {
       this.form().controls.technicalContactDetails.controls.contactGroup.controls.name;
     sync(
       control,
-      technicalNameSameAsContactName ? legalCustomerName : this.technicalContact()?.name,
+      technicalNameSameAsContactName ? legalCustomerName : this.effectiveTechnicalContact()?.name,
       technicalNameSameAsContactName
     );
   });
@@ -341,7 +358,6 @@ export class DhUpdateCustomerDataComponent {
   private readonly syncTechnicalContactAddress = effect(() => {
     const technicalAddressSameAsInstallation = this.technicalAddressSameAsInstallationToggle();
     const addressGroup = this.form().controls.technicalContactAddressDetails.controls.addressGroup;
-    const contact = this.technicalContact();
     const installationAddress = this.installationAddress();
 
     sync(
@@ -350,7 +366,7 @@ export class DhUpdateCustomerDataComponent {
         ? installationAddress
           ? { ...installationAddress, postBox: null }
           : null
-        : contact,
+        : this.effectiveTechnicalContact(),
       technicalAddressSameAsInstallation
     );
   });
@@ -366,7 +382,7 @@ export class DhUpdateCustomerDataComponent {
     const control = this.form().controls.legalContactDetails.controls.contactGroup.controls.name;
     sync(
       control,
-      legalNameSameAsContactName ? legalCustomerName : this.legalContact()?.name,
+      legalNameSameAsContactName ? legalCustomerName : this.effectiveLegalContact()?.name,
       legalNameSameAsContactName
     );
   });
@@ -378,7 +394,6 @@ export class DhUpdateCustomerDataComponent {
   private readonly syncLegalContactAddress = effect(() => {
     const legalAddressSameAsInstallation = this.legalAddressSameAsInstallationToggle();
     const addressGroup = this.form().controls.legalContactAddressDetails.controls.addressGroup;
-    const contact = this.legalContact();
     const installationAddress = this.installationAddress();
 
     sync(
@@ -387,7 +402,7 @@ export class DhUpdateCustomerDataComponent {
         ? installationAddress
           ? { ...installationAddress, postBox: null }
           : null
-        : contact,
+        : this.effectiveLegalContact(),
       legalAddressSameAsInstallation
     );
   });

--- a/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
+++ b/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
@@ -236,10 +236,6 @@ export class DhUpdateCustomerDataComponent {
   private readonly technicalContact = computed(() => this.technicalCustomer()?.technicalContact);
   private readonly legalContact = computed(() => this.legalCustomer()?.legalContact);
 
-  // During a move-in (processId present), only keep contact fields empty when
-  // temporary storage data actually exists.
-  // Avoid coupling this state to query loading, since a loading transition can
-  // cause derived form state to be recreated and wipe user-entered values.
   private readonly shouldClearContacts = computed(
     () => !!this.processId() && !!this.temporaryStorageCustomer()
   );

--- a/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
+++ b/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
@@ -236,13 +236,12 @@ export class DhUpdateCustomerDataComponent {
   private readonly technicalContact = computed(() => this.technicalCustomer()?.technicalContact);
   private readonly legalContact = computed(() => this.legalCustomer()?.legalContact);
 
-  // During a move-in (processId present), keep contact fields empty while the
-  // temporary storage query is in flight OR when it returns data.
-  // Only prefill contacts if the query is done and returned no data.
+  // During a move-in (processId present), only keep contact fields empty when
+  // temporary storage data actually exists.
+  // Avoid coupling this state to query loading, since a loading transition can
+  // cause derived form state to be recreated and wipe user-entered values.
   private readonly shouldClearContacts = computed(
-    () =>
-      !!this.processId() &&
-      (this.temporaryStorageCustomerQuery.loading() || !!this.temporaryStorageCustomer())
+    () => !!this.processId() && !!this.temporaryStorageCustomer()
   );
 
   private readonly effectiveLegalContact = computed(() =>

--- a/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
+++ b/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
@@ -245,7 +245,6 @@ export class DhUpdateCustomerDataComponent {
     this.shouldClearContacts() ? undefined : this.technicalContact()
   );
 
-  navigate = injectRelativeNavigate();
   isBusinessCustomer = computed(
     () => this.temporaryStorageCustomer()?.isBusinessCustomer ?? this.legalCustomer()?.cvr !== null
   );

--- a/libs/dh/shared/data-access-graphql/schema.graphql
+++ b/libs/dh/shared/data-access-graphql/schema.graphql
@@ -1209,10 +1209,6 @@ type Mutation {
   mergeMarketParticipants(input: MergeMarketParticipantsInput!): MergeMarketParticipantsPayload!
   updateOrganization(input: UpdateOrganizationInput!): UpdateOrganizationPayload!
   updatePermission(input: UpdatePermissionInput!): UpdatePermissionPayload!
-  updateUserRoleAssignment(input: UpdateUserRoleAssignmentInput!): UpdateUserRoleAssignmentPayload!
-  updateUserRole(input: UpdateUserRoleInput!): UpdateUserRolePayload!
-  createUserRole(input: CreateUserRoleInput!): CreateUserRolePayload!
-  deactivateUserRole(input: DeactivateUserRoleInput!): DeactivateUserRolePayload!
   updateUserProfile(input: UpdateUserProfileInput!): UpdateUserProfilePayload!
   updateUserIdentity(input: UpdateUserIdentityInput!): UpdateUserIdentityPayload!
   inviteUser(input: InviteUserInput!): InviteUserPayload!
@@ -1222,6 +1218,10 @@ type Mutation {
   reActivateUser(input: ReActivateUserInput!): ReActivateUserPayload!
   initiateMitIdSignup: InitiateMitIdSignupPayload!
   resetMitId(input: ResetMitIdInput!): ResetMitIdPayload!
+  updateUserRoleAssignment(input: UpdateUserRoleAssignmentInput!): UpdateUserRoleAssignmentPayload!
+  updateUserRole(input: UpdateUserRoleInput!): UpdateUserRolePayload!
+  createUserRole(input: CreateUserRoleInput!): CreateUserRolePayload!
+  deactivateUserRole(input: DeactivateUserRoleInput!): DeactivateUserRolePayload!
   requestMeasurementsReport(requestMeasurementsReportInput: RequestMeasurementsReportInput!): RequestMeasurementsReportPayload!
   cancelMeasurementsReport(input: CancelMeasurementsReportInput!): CancelMeasurementsReportPayload!
   dismissNotification(input: DismissNotificationInput!): DismissNotificationPayload!
@@ -1451,16 +1451,16 @@ type Query {
   permissionById(id: Int!): Permission!
   filteredPermissions(filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: [PermissionDtoSortInput!]): FilteredPermissionsConnection
   permissionsByEicFunction(eicFunction: EicFunction!): [PermissionDetailsDto!]!
-  userRolesByActorId(actorId: UUID!): [UserRoleDto!]!
-  userRolesByEicFunction(eicFunction: EicFunction!): [UserRoleDto!]!
-  filteredUserRoles(status: UserRoleStatus eicFunctions: [EicFunction!] filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: [UserRoleSortInput!]): FilteredUserRolesConnection
-  userRoles(actorId: UUID): [UserRoleDto!]!
-  userRoleById(id: UUID!): UserRoleWithPermissions!
   domainExists(email: String!): Boolean!
   emailExists(email: String!): Boolean!
   userById(id: UUID!): User!
   users(skip: Int take: Int actorId: UUID userRoleIds: [UUID!] userStatus: [UserStatus!] filter: String order: UsersSortInput): UsersCollectionSegment
   userProfile: UserProfile!
+  userRolesByActorId(actorId: UUID!): [UserRoleDto!]!
+  userRolesByEicFunction(eicFunction: EicFunction!): [UserRoleDto!]!
+  filteredUserRoles(status: UserRoleStatus eicFunctions: [EicFunction!] filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: [UserRoleSortInput!]): FilteredUserRolesConnection
+  userRoles(actorId: UUID): [UserRoleDto!]!
+  userRoleById(id: UUID!): UserRoleWithPermissions!
   measurementsReports: [MeasurementsReport!]!
   archivedMessagesForMeteringPoint(created: DateRange! meteringPointId: String! senderId: UUID receiverId: UUID documentType: MeteringPointDocumentType "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: ArchivedMessageSortInput): ArchivedMessagesForMeteringPointConnection
   archivedMessages(created: DateRange! senderId: UUID receiverId: UUID documentTypes: [ArchivedMessageDocumentType!] businessReasons: [BusinessReason!] includeRelated: Boolean filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: ArchivedMessageSortInput): ArchivedMessagesConnection

--- a/libs/dh/shared/data-access-graphql/schema.graphql
+++ b/libs/dh/shared/data-access-graphql/schema.graphql
@@ -1209,6 +1209,10 @@ type Mutation {
   mergeMarketParticipants(input: MergeMarketParticipantsInput!): MergeMarketParticipantsPayload!
   updateOrganization(input: UpdateOrganizationInput!): UpdateOrganizationPayload!
   updatePermission(input: UpdatePermissionInput!): UpdatePermissionPayload!
+  updateUserRoleAssignment(input: UpdateUserRoleAssignmentInput!): UpdateUserRoleAssignmentPayload!
+  updateUserRole(input: UpdateUserRoleInput!): UpdateUserRolePayload!
+  createUserRole(input: CreateUserRoleInput!): CreateUserRolePayload!
+  deactivateUserRole(input: DeactivateUserRoleInput!): DeactivateUserRolePayload!
   updateUserProfile(input: UpdateUserProfileInput!): UpdateUserProfilePayload!
   updateUserIdentity(input: UpdateUserIdentityInput!): UpdateUserIdentityPayload!
   inviteUser(input: InviteUserInput!): InviteUserPayload!
@@ -1218,10 +1222,6 @@ type Mutation {
   reActivateUser(input: ReActivateUserInput!): ReActivateUserPayload!
   initiateMitIdSignup: InitiateMitIdSignupPayload!
   resetMitId(input: ResetMitIdInput!): ResetMitIdPayload!
-  updateUserRoleAssignment(input: UpdateUserRoleAssignmentInput!): UpdateUserRoleAssignmentPayload!
-  updateUserRole(input: UpdateUserRoleInput!): UpdateUserRolePayload!
-  createUserRole(input: CreateUserRoleInput!): CreateUserRolePayload!
-  deactivateUserRole(input: DeactivateUserRoleInput!): DeactivateUserRolePayload!
   requestMeasurementsReport(requestMeasurementsReportInput: RequestMeasurementsReportInput!): RequestMeasurementsReportPayload!
   cancelMeasurementsReport(input: CancelMeasurementsReportInput!): CancelMeasurementsReportPayload!
   dismissNotification(input: DismissNotificationInput!): DismissNotificationPayload!
@@ -1451,16 +1451,16 @@ type Query {
   permissionById(id: Int!): Permission!
   filteredPermissions(filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: [PermissionDtoSortInput!]): FilteredPermissionsConnection
   permissionsByEicFunction(eicFunction: EicFunction!): [PermissionDetailsDto!]!
-  domainExists(email: String!): Boolean!
-  emailExists(email: String!): Boolean!
-  userById(id: UUID!): User!
-  users(skip: Int take: Int actorId: UUID userRoleIds: [UUID!] userStatus: [UserStatus!] filter: String order: UsersSortInput): UsersCollectionSegment
-  userProfile: UserProfile!
   userRolesByActorId(actorId: UUID!): [UserRoleDto!]!
   userRolesByEicFunction(eicFunction: EicFunction!): [UserRoleDto!]!
   filteredUserRoles(status: UserRoleStatus eicFunctions: [EicFunction!] filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: [UserRoleSortInput!]): FilteredUserRolesConnection
   userRoles(actorId: UUID): [UserRoleDto!]!
   userRoleById(id: UUID!): UserRoleWithPermissions!
+  domainExists(email: String!): Boolean!
+  emailExists(email: String!): Boolean!
+  userById(id: UUID!): User!
+  users(skip: Int take: Int actorId: UUID userRoleIds: [UUID!] userStatus: [UserStatus!] filter: String order: UsersSortInput): UsersCollectionSegment
+  userProfile: UserProfile!
   measurementsReports: [MeasurementsReport!]!
   archivedMessagesForMeteringPoint(created: DateRange! meteringPointId: String! senderId: UUID receiverId: UUID documentType: MeteringPointDocumentType "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: ArchivedMessageSortInput): ArchivedMessagesForMeteringPointConnection
   archivedMessages(created: DateRange! senderId: UUID receiverId: UUID documentTypes: [ArchivedMessageDocumentType!] businessReasons: [BusinessReason!] includeRelated: Boolean filter: String "Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String "Returns the last _n_ elements from the list." last: Int "Returns the elements in the list that come before the specified cursor." before: String order: ArchivedMessageSortInput): ArchivedMessagesConnection


### PR DESCRIPTION
When you send a move in request and need to update customer data as part of the move in process, the contact fields cannot be prefilled.