### PR TITLE
Move in: Changes back navigation

### DIFF
--- a/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
+++ b/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
@@ -115,9 +115,7 @@ import {
             }
           </vater-stack>
           <vater-stack direction="row" gap="m">
-            <watt-button (click)="cancel()" variant="secondary"
-              >{{ t('cancel') }}
-            </watt-button>
+            <watt-button (click)="cancel()" variant="secondary">{{ t('cancel') }} </watt-button>
             <watt-button type="submit" [loading]="requestChangeCustomerCharacteristics.loading()"
               >{{ t('updateCustomerData') }}
             </watt-button>
@@ -443,17 +441,13 @@ export class DhUpdateCustomerDataComponent {
   }
 
   cancel() {
-    const previousUrl =
-      this.router.lastSuccessfulNavigation()?.previousNavigation?.finalUrl;
+    const previousUrl = this.router.lastSuccessfulNavigation()?.previousNavigation?.finalUrl;
 
     if (previousUrl) {
       this.router.navigateByUrl(previousUrl.toString(), { replaceUrl: true });
       return;
     }
 
-    this.router.navigate([
-      getPath<BasePaths>('metering-point'),
-      this.internalMeteringPointId()
-    ]);
+    this.router.navigate([getPath<BasePaths>('metering-point'), this.internalMeteringPointId()]);
   }
 }

--- a/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
+++ b/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 //#endregion
-import { Location } from '@angular/common';
 import { Component, computed, effect, inject, input } from '@angular/core';
 import { FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
 
 import { TranslocoDirective } from '@jsverse/transloco';
 
@@ -54,13 +54,12 @@ import { DhCustomerAddressDetailsComponent } from './dh-customer-address-details
 import { createContactAddressDetailsForm } from '../util/create-contact-address-details-form';
 import { createCustomerContactDetailsForm } from '../util/create-customer-contact-details-form';
 import { DhBusinessCustomerDetailsFormComponent } from './dh-business-customer-details-form.component';
+import { WattSkeletonComponent } from '@energinet/watt/skeleton';
 import {
   BasePaths,
   getPath,
   MeteringPointSubPaths,
 } from '@energinet-datahub/dh/core/configuration-routing';
-import { Router } from '@angular/router';
-import { WattSkeletonComponent } from '@energinet/watt/skeleton';
 
 @Component({
   selector: 'dh-update-customer-data',
@@ -116,7 +115,7 @@ import { WattSkeletonComponent } from '@energinet/watt/skeleton';
             }
           </vater-stack>
           <vater-stack direction="row" gap="m">
-            <watt-button (click)="location.back()" variant="secondary"
+            <watt-button (click)="cancel()" variant="secondary"
               >{{ t('cancel') }}
             </watt-button>
             <watt-button type="submit" [loading]="requestChangeCustomerCharacteristics.loading()"
@@ -192,7 +191,6 @@ import { WattSkeletonComponent } from '@energinet/watt/skeleton';
 })
 export class DhUpdateCustomerDataComponent {
   private readonly router = inject(Router);
-  protected readonly location = inject(Location);
   private readonly actor = inject(DhActorStorage).getSelectedActor();
   private readonly toast = injectToast('meteringPoint.moveIn.updateCustomer.toast');
   private readonly effectToast = effect(() =>
@@ -441,6 +439,21 @@ export class DhUpdateCustomerDataComponent {
       getPath<BasePaths>('metering-point'),
       this.internalMeteringPointId(),
       getPath<MeteringPointSubPaths>('process-overview'),
+    ]);
+  }
+
+  cancel() {
+    const previousUrl =
+      this.router.lastSuccessfulNavigation()?.previousNavigation?.finalUrl;
+
+    if (previousUrl) {
+      this.router.navigateByUrl(previousUrl.toString(), { replaceUrl: true });
+      return;
+    }
+
+    this.router.navigate([
+      getPath<BasePaths>('metering-point'),
+      this.internalMeteringPointId()
     ]);
   }
 }

--- a/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
+++ b/libs/dh/metering-point/feature-move-in/src/components/dh-update-customer-data.component.ts
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 //#endregion
+import { Location } from '@angular/common';
 import { Component, computed, effect, inject, input } from '@angular/core';
 import { FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 
@@ -28,7 +29,6 @@ import { DhActorStorage } from '@energinet-datahub/dh/shared/feature-authorizati
 import {
   dhFormControlToSignal,
   dhMakeFormControl,
-  injectRelativeNavigate,
   injectToast,
 } from '@energinet-datahub/dh/shared/ui-util';
 
@@ -116,7 +116,7 @@ import { WattSkeletonComponent } from '@energinet/watt/skeleton';
             }
           </vater-stack>
           <vater-stack direction="row" gap="m">
-            <watt-button (click)="navigate('..')" variant="secondary"
+            <watt-button (click)="location.back()" variant="secondary"
               >{{ t('cancel') }}
             </watt-button>
             <watt-button type="submit" [loading]="requestChangeCustomerCharacteristics.loading()"
@@ -192,6 +192,7 @@ import { WattSkeletonComponent } from '@energinet/watt/skeleton';
 })
 export class DhUpdateCustomerDataComponent {
   private readonly router = inject(Router);
+  protected readonly location = inject(Location);
   private readonly actor = inject(DhActorStorage).getSelectedActor();
   private readonly toast = injectToast('meteringPoint.moveIn.updateCustomer.toast');
   private readonly effectToast = effect(() =>
@@ -236,7 +237,6 @@ export class DhUpdateCustomerDataComponent {
   private readonly technicalContact = computed(() => this.technicalCustomer()?.technicalContact);
   private readonly legalContact = computed(() => this.legalCustomer()?.legalContact);
 
-  navigate = injectRelativeNavigate();
   isBusinessCustomer = computed(
     () => this.temporaryStorageCustomer()?.isBusinessCustomer ?? this.legalCustomer()?.cvr !== null
   );


### PR DESCRIPTION
When at "metering-point/2222222/update-customer-details" it worked fine, but when at "metering-point/2222222/update-customer-details/process-cmi-info" when updating customer data regarding a move-in, I still wanted to navigate back, but a step further. 
This now uses the browser to navigate back.