### PR TITLE
refactor(watt): align segmented buttons with Figma design

### DIFF
--- a/libs/watt/package/package.json
+++ b/libs/watt/package/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@energinet/watt",
-  "version": "4.3.78",
+  "version": "4.3.79",
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/libs/watt/package/package.json
+++ b/libs/watt/package/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@energinet/watt",
-  "version": "4.3.77",
+  "version": "4.3.78",
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/libs/watt/package/segmented-buttons/+storybook/storybook-segmented-buttons-showcase.component.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/storybook-segmented-buttons-showcase.component.ts
@@ -111,15 +111,21 @@ import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.compone
               @for (position of positions; track position) {
                 <watt-segmented-button [class]="position">Label</watt-segmented-button>
                 <watt-segmented-button [class]="position + ' hover'">Label</watt-segmented-button>
-                <watt-segmented-button [class]="position + ' disabled'">Label</watt-segmented-button>
+                <watt-segmented-button [class]="position + ' disabled'"
+                  >Label</watt-segmented-button
+                >
               }
 
               <div class="blocks-gap"></div>
 
               @for (position of positions; track position) {
-                <watt-segmented-button [class]="position + ' selected'">Label</watt-segmented-button>
+                <watt-segmented-button [class]="position + ' selected'"
+                  >Label</watt-segmented-button
+                >
                 <div></div>
-                <watt-segmented-button [class]="position + ' disabled selected'">Label</watt-segmented-button>
+                <watt-segmented-button [class]="position + ' disabled selected'"
+                  >Label</watt-segmented-button
+                >
               }
             </div>
           </div>

--- a/libs/watt/package/segmented-buttons/+storybook/storybook-segmented-buttons-showcase.component.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/storybook-segmented-buttons-showcase.component.ts
@@ -1,0 +1,145 @@
+//#region License
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//#endregion
+import { Component, effect, input, ViewEncapsulation } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+
+import { WattSegmentedButtonComponent } from '../watt-segmented-button.component';
+import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.component';
+
+const POSITIONS = ['start', 'middle', 'end'] as const;
+
+@Component({
+  selector: 'watt-storybook-segmented-buttons-showcase',
+  imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
+  encapsulation: ViewEncapsulation.None,
+  styles: `
+    .watt-storybook-segmented-buttons-showcase {
+      background: #e5e5e5;
+      padding: 40px;
+      margin: -16px;
+
+      .page {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        max-width: 560px;
+      }
+
+      .section {
+        background: white;
+        border-radius: 12px;
+        padding: 48px 56px;
+      }
+
+      .section-title {
+        font-family: 'Open Sans', sans-serif;
+        font-size: 36px;
+        font-weight: 300;
+        color: rgba(0, 0, 0, 0.87);
+        margin: 0 0 24px;
+      }
+
+      .divider {
+        border: none;
+        border-top: 1px solid var(--watt-color-neutral-grey-300);
+        margin: 0 0 32px;
+      }
+
+      .dashed-border {
+        border: 2px dashed #7c4dff;
+        border-radius: 8px;
+        padding: 24px 40px;
+        margin-top: 8px;
+      }
+
+      .blocks-grid {
+        display: grid;
+        grid-template-columns: repeat(3, auto);
+        gap: 24px 32px;
+        justify-items: start;
+      }
+
+      .column-header {
+        font-family: 'Open Sans', sans-serif;
+        font-size: 14px;
+        color: rgba(0, 0, 0, 0.6);
+      }
+
+      .blocks-gap {
+        grid-column: 1 / -1;
+        height: 16px;
+      }
+    }
+  `,
+  template: `
+    <div class="watt-storybook-segmented-buttons-showcase">
+      <div class="page">
+        <div class="section">
+          <div class="section-title">Segmented button</div>
+          <hr class="divider" />
+          <watt-segmented-buttons [formControl]="overviewControl">
+            <watt-segmented-button value="day">Dag</watt-segmented-button>
+            <watt-segmented-button value="month">Måned</watt-segmented-button>
+            <watt-segmented-button value="year">År</watt-segmented-button>
+            <watt-segmented-button value="all">Alle år</watt-segmented-button>
+          </watt-segmented-buttons>
+        </div>
+
+        <div class="section">
+          <div class="section-title">Building blocks</div>
+          <hr class="divider" />
+          <div class="dashed-border">
+            <div class="blocks-grid">
+              <div class="column-header">Enabled</div>
+              <div class="column-header">Hover</div>
+              <div class="column-header">Disabled</div>
+
+              @for (position of positions; track position) {
+                <watt-segmented-button [class]="position">Label</watt-segmented-button>
+                <watt-segmented-button [class]="position + ' hover'">Label</watt-segmented-button>
+                <watt-segmented-button [class]="position + ' disabled'">Label</watt-segmented-button>
+              }
+
+              <div class="blocks-gap"></div>
+
+              @for (position of positions; track position) {
+                <watt-segmented-button [class]="position + ' selected'">Label</watt-segmented-button>
+                <div></div>
+                <watt-segmented-button [class]="position + ' disabled selected'">Label</watt-segmented-button>
+              }
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class WattStorybookSegmentedButtonsShowcaseComponent {
+  disabled = input(false);
+
+  positions = POSITIONS;
+  overviewControl = new FormControl('day');
+
+  constructor() {
+    effect(() => {
+      if (this.disabled()) this.overviewControl.disable();
+      else this.overviewControl.enable();
+    });
+  }
+}

--- a/libs/watt/package/segmented-buttons/+storybook/storybook-segmented-buttons-showcase.component.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/storybook-segmented-buttons-showcase.component.ts
@@ -22,8 +22,6 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { WattSegmentedButtonComponent } from '../watt-segmented-button.component';
 import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.component';
 
-const POSITIONS = ['start', 'middle', 'end'] as const;
-
 @Component({
   selector: 'watt-storybook-segmented-buttons-showcase',
   imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
@@ -133,7 +131,7 @@ const POSITIONS = ['start', 'middle', 'end'] as const;
 export class WattStorybookSegmentedButtonsShowcaseComponent {
   disabled = input(false);
 
-  positions = POSITIONS;
+  positions = ['start', 'middle', 'end'] as const;
   overviewControl = new FormControl('day');
 
   constructor() {

--- a/libs/watt/package/segmented-buttons/+storybook/storybook-segmented-buttons-showcase.component.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/storybook-segmented-buttons-showcase.component.ts
@@ -93,9 +93,9 @@ import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.compone
           <hr class="divider" />
           <watt-segmented-buttons [formControl]="overviewControl">
             <watt-segmented-button value="day">Dag</watt-segmented-button>
-            <watt-segmented-button value="month">Måned</watt-segmented-button>
+            <watt-segmented-button link="/month">Måned</watt-segmented-button>
             <watt-segmented-button value="year">År</watt-segmented-button>
-            <watt-segmented-button value="all">Alle år</watt-segmented-button>
+            <watt-segmented-button link="/all">Alle år</watt-segmented-button>
           </watt-segmented-buttons>
         </div>
 

--- a/libs/watt/package/segmented-buttons/+storybook/storybook-segmented-buttons-showcase.component.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/storybook-segmented-buttons-showcase.component.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 //#endregion
-import { Component, effect, input, ViewEncapsulation } from '@angular/core';
+import { Component, effect, input } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
 import { WattSegmentedButtonComponent } from '../watt-segmented-button.component';
@@ -25,12 +25,11 @@ import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.compone
 @Component({
   selector: 'watt-storybook-segmented-buttons-showcase',
   imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
-  encapsulation: ViewEncapsulation.None,
   styles: `
-    .watt-storybook-segmented-buttons-showcase {
+    :host {
+      display: block;
       background: #e5e5e5;
       padding: 40px;
-      margin: -16px;
 
       .page {
         display: flex;
@@ -86,48 +85,42 @@ import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.compone
     }
   `,
   template: `
-    <div class="watt-storybook-segmented-buttons-showcase">
-      <div class="page">
-        <div class="section">
-          <div class="section-title">Segmented button</div>
-          <hr class="divider" />
-          <watt-segmented-buttons [formControl]="overviewControl">
-            <watt-segmented-button value="day">Dag</watt-segmented-button>
-            <watt-segmented-button link="/month">Måned</watt-segmented-button>
-            <watt-segmented-button value="year">År</watt-segmented-button>
-            <watt-segmented-button link="/all">Alle år</watt-segmented-button>
-          </watt-segmented-buttons>
-        </div>
+    <div class="page">
+      <div class="section">
+        <div class="section-title">Segmented button</div>
+        <hr class="divider" />
+        <watt-segmented-buttons [formControl]="overviewControl">
+          <watt-segmented-button value="day">Dag</watt-segmented-button>
+          <watt-segmented-button link="/month">Måned</watt-segmented-button>
+          <watt-segmented-button value="year">År</watt-segmented-button>
+          <watt-segmented-button link="/all">Alle år</watt-segmented-button>
+        </watt-segmented-buttons>
+      </div>
 
-        <div class="section">
-          <div class="section-title">Building blocks</div>
-          <hr class="divider" />
-          <div class="dashed-border">
-            <div class="blocks-grid">
-              <div class="column-header">Enabled</div>
-              <div class="column-header">Hover</div>
-              <div class="column-header">Disabled</div>
+      <div class="section">
+        <div class="section-title">Building blocks</div>
+        <hr class="divider" />
+        <div class="dashed-border">
+          <div class="blocks-grid">
+            <div class="column-header">Enabled</div>
+            <div class="column-header">Hover</div>
+            <div class="column-header">Disabled</div>
 
-              @for (position of positions; track position) {
-                <watt-segmented-button [class]="position">Label</watt-segmented-button>
-                <watt-segmented-button [class]="position + ' hover'">Label</watt-segmented-button>
-                <watt-segmented-button [class]="position + ' disabled'"
-                  >Label</watt-segmented-button
-                >
-              }
+            @for (position of positions; track position) {
+              <watt-segmented-button [class]="position">Label</watt-segmented-button>
+              <watt-segmented-button [class]="position + ' hover'">Label</watt-segmented-button>
+              <watt-segmented-button [class]="position + ' disabled'">Label</watt-segmented-button>
+            }
 
-              <div class="blocks-gap"></div>
+            <div class="blocks-gap"></div>
 
-              @for (position of positions; track position) {
-                <watt-segmented-button [class]="position + ' selected'"
-                  >Label</watt-segmented-button
-                >
-                <div></div>
-                <watt-segmented-button [class]="position + ' disabled selected'"
-                  >Label</watt-segmented-button
-                >
-              }
-            </div>
+            @for (position of positions; track position) {
+              <watt-segmented-button [class]="position + ' selected'">Label</watt-segmented-button>
+              <div></div>
+              <watt-segmented-button [class]="position + ' disabled selected'"
+                >Label</watt-segmented-button
+              >
+            }
           </div>
         </div>
       </div>

--- a/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
@@ -124,7 +124,8 @@ export const Overview: Story = {
             color: rgba(0, 0, 0, 0.6);
           }
 
-          .hover-cell watt-segmented-button {
+          .hover-cell ::ng-deep watt-segmented-button a,
+          .hover-cell ::ng-deep watt-segmented-button button {
             background-color: var(--watt-color-neutral-grey-200);
           }
 
@@ -133,9 +134,41 @@ export const Overview: Story = {
             height: 16px;
           }
 
-          .start watt-segmented-button { border-radius: 4px 0 0 4px; }
-          .middle watt-segmented-button { border-radius: 0; }
-          .end watt-segmented-button { border-radius: 0 4px 4px 0; }
+          .start ::ng-deep watt-segmented-button a,
+          .start ::ng-deep watt-segmented-button button {
+            border-right-width: 0;
+            border-radius: 4px 0 0 4px;
+          }
+
+          .middle ::ng-deep watt-segmented-button a,
+          .middle ::ng-deep watt-segmented-button button {
+            border-right-width: 0;
+            border-radius: 0;
+          }
+
+          .end ::ng-deep watt-segmented-button a,
+          .end ::ng-deep watt-segmented-button button {
+            border-radius: 0 4px 4px 0;
+          }
+
+          .mock-selected ::ng-deep watt-segmented-button a,
+          .mock-selected ::ng-deep watt-segmented-button button {
+            background-color: var(--watt-color-primary);
+            color: var(--watt-color-neutral-white);
+          }
+
+          .mock-disabled ::ng-deep watt-segmented-button a,
+          .mock-disabled ::ng-deep watt-segmented-button button {
+            background-color: var(--watt-color-neutral-grey-200);
+            color: rgba(0, 0, 0, 0.26);
+            cursor: default;
+          }
+
+          .mock-disabled.mock-selected ::ng-deep watt-segmented-button a,
+          .mock-disabled.mock-selected ::ng-deep watt-segmented-button button {
+            background-color: var(--watt-color-neutral-grey-400);
+            color: var(--watt-on-light-high-emphasis);
+          }
         `,
       ],
       template: `
@@ -166,8 +199,8 @@ export const Overview: Story = {
                 <div class="start hover-cell">
                   <watt-segmented-button>Label</watt-segmented-button>
                 </div>
-                <div class="start">
-                  <watt-segmented-button class="watt-segmented-button--disabled">Label</watt-segmented-button>
+                <div class="start mock-disabled">
+                  <watt-segmented-button>Label</watt-segmented-button>
                 </div>
 
                 <div class="middle">
@@ -176,8 +209,8 @@ export const Overview: Story = {
                 <div class="middle hover-cell">
                   <watt-segmented-button>Label</watt-segmented-button>
                 </div>
-                <div class="middle">
-                  <watt-segmented-button class="watt-segmented-button--disabled">Label</watt-segmented-button>
+                <div class="middle mock-disabled">
+                  <watt-segmented-button>Label</watt-segmented-button>
                 </div>
 
                 <div class="end">
@@ -186,34 +219,34 @@ export const Overview: Story = {
                 <div class="end hover-cell">
                   <watt-segmented-button>Label</watt-segmented-button>
                 </div>
-                <div class="end">
-                  <watt-segmented-button class="watt-segmented-button--disabled">Label</watt-segmented-button>
+                <div class="end mock-disabled">
+                  <watt-segmented-button>Label</watt-segmented-button>
                 </div>
 
                 <div class="blocks-gap"></div>
 
-                <div class="start">
-                  <watt-segmented-button class="watt-segmented-button--selected">Label</watt-segmented-button>
+                <div class="start mock-selected">
+                  <watt-segmented-button>Label</watt-segmented-button>
                 </div>
                 <div></div>
-                <div class="start">
-                  <watt-segmented-button class="watt-segmented-button--disabled watt-segmented-button--selected">Label</watt-segmented-button>
+                <div class="start mock-disabled mock-selected">
+                  <watt-segmented-button>Label</watt-segmented-button>
                 </div>
 
-                <div class="middle">
-                  <watt-segmented-button class="watt-segmented-button--selected">Label</watt-segmented-button>
+                <div class="middle mock-selected">
+                  <watt-segmented-button>Label</watt-segmented-button>
                 </div>
                 <div></div>
-                <div class="middle">
-                  <watt-segmented-button class="watt-segmented-button--disabled watt-segmented-button--selected">Label</watt-segmented-button>
+                <div class="middle mock-disabled mock-selected">
+                  <watt-segmented-button>Label</watt-segmented-button>
                 </div>
 
-                <div class="end">
-                  <watt-segmented-button class="watt-segmented-button--selected">Label</watt-segmented-button>
+                <div class="end mock-selected">
+                  <watt-segmented-button>Label</watt-segmented-button>
                 </div>
                 <div></div>
-                <div class="end">
-                  <watt-segmented-button class="watt-segmented-button--disabled watt-segmented-button--selected">Label</watt-segmented-button>
+                <div class="end mock-disabled mock-selected">
+                  <watt-segmented-button>Label</watt-segmented-button>
                 </div>
               </div>
             </div>

--- a/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
@@ -114,31 +114,17 @@ type Position = (typeof POSITIONS)[number];
               <div class="column-header">Disabled</div>
 
               @for (position of positions; track position) {
-                <watt-segmented-buttons>
-                  <watt-segmented-button [class]="position">Label</watt-segmented-button>
-                </watt-segmented-buttons>
-
-                <watt-segmented-buttons>
-                  <watt-segmented-button [class]="position + ' hover'">Label</watt-segmented-button>
-                </watt-segmented-buttons>
-
-                <watt-segmented-buttons [formControl]="disabledBlocks[$index]">
-                  <watt-segmented-button [class]="position" value="x">Label</watt-segmented-button>
-                </watt-segmented-buttons>
+                <watt-segmented-button [class]="position">Label</watt-segmented-button>
+                <watt-segmented-button [class]="position + ' hover'">Label</watt-segmented-button>
+                <watt-segmented-button [class]="position + ' disabled'">Label</watt-segmented-button>
               }
 
               <div class="blocks-gap"></div>
 
               @for (position of positions; track position) {
-                <watt-segmented-buttons [formControl]="selectedBlocks[$index]">
-                  <watt-segmented-button [class]="position" value="x">Label</watt-segmented-button>
-                </watt-segmented-buttons>
-
+                <watt-segmented-button [class]="position + ' selected'">Label</watt-segmented-button>
                 <div></div>
-
-                <watt-segmented-buttons [formControl]="disabledSelectedBlocks[$index]">
-                  <watt-segmented-button [class]="position" value="x">Label</watt-segmented-button>
-                </watt-segmented-buttons>
+                <watt-segmented-button [class]="position + ' disabled selected'">Label</watt-segmented-button>
               }
             </div>
           </div>
@@ -152,9 +138,6 @@ class WattSegmentedButtonsShowcase {
 
   positions = POSITIONS;
   overviewControl = new FormControl('day');
-  disabledBlocks = POSITIONS.map(() => new FormControl({ value: null, disabled: true }));
-  selectedBlocks = POSITIONS.map(() => new FormControl('x'));
-  disabledSelectedBlocks = POSITIONS.map(() => new FormControl({ value: 'x', disabled: true }));
 
   constructor() {
     effect(() => {

--- a/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
@@ -16,13 +16,15 @@
  * limitations under the License.
  */
 //#endregion
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component, effect, input, ViewEncapsulation } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { provideRouter } from '@angular/router';
 import { Meta, applicationConfig, moduleMetadata, StoryObj } from '@storybook/angular';
 
 import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.component';
 import { WattSegmentedButtonComponent } from '../watt-segmented-button.component';
+
+const BLOCK_ROWS = [0, 1, 2] as const;
 
 @Component({
   selector: 'watt-segmented-buttons-showcase',
@@ -119,7 +121,7 @@ import { WattSegmentedButtonComponent } from '../watt-segmented-button.component
               <div class="column-header">Hover</div>
               <div class="column-header">Disabled</div>
 
-              @for (_ of [1, 2, 3]; track $index) {
+              @for (i of rows; track i) {
                 <watt-segmented-buttons>
                   <watt-segmented-button>Label</watt-segmented-button>
                 </watt-segmented-buttons>
@@ -130,21 +132,21 @@ import { WattSegmentedButtonComponent } from '../watt-segmented-button.component
                   </watt-segmented-buttons>
                 </div>
 
-                <watt-segmented-buttons [formControl]="disabledBlock">
+                <watt-segmented-buttons [formControl]="disabledBlocks[i]">
                   <watt-segmented-button value="x">Label</watt-segmented-button>
                 </watt-segmented-buttons>
               }
 
               <div class="blocks-gap"></div>
 
-              @for (_ of [1, 2, 3]; track $index) {
-                <watt-segmented-buttons [formControl]="selectedBlock">
+              @for (i of rows; track i) {
+                <watt-segmented-buttons [formControl]="selectedBlocks[i]">
                   <watt-segmented-button value="x">Label</watt-segmented-button>
                 </watt-segmented-buttons>
 
                 <div></div>
 
-                <watt-segmented-buttons [formControl]="disabledSelectedBlock">
+                <watt-segmented-buttons [formControl]="disabledSelectedBlocks[i]">
                   <watt-segmented-button value="x">Label</watt-segmented-button>
                 </watt-segmented-buttons>
               }
@@ -156,10 +158,23 @@ import { WattSegmentedButtonComponent } from '../watt-segmented-button.component
   `,
 })
 class WattSegmentedButtonsShowcase {
+  disabled = input(false);
+
   overviewControl = new FormControl('day');
-  disabledBlock = new FormControl({ value: null, disabled: true });
-  selectedBlock = new FormControl('x');
-  disabledSelectedBlock = new FormControl({ value: 'x', disabled: true });
+  disabledBlocks = BLOCK_ROWS.map(() => new FormControl({ value: null, disabled: true }));
+  selectedBlocks = BLOCK_ROWS.map(() => new FormControl('x'));
+  disabledSelectedBlocks = BLOCK_ROWS.map(
+    () => new FormControl({ value: 'x', disabled: true })
+  );
+
+  rows = BLOCK_ROWS;
+
+  constructor() {
+    effect(() => {
+      if (this.disabled()) this.overviewControl.disable();
+      else this.overviewControl.enable();
+    });
+  }
 }
 
 const meta: Meta<WattSegmentedButtonsShowcase> = {
@@ -169,11 +184,23 @@ const meta: Meta<WattSegmentedButtonsShowcase> = {
     applicationConfig({ providers: [provideRouter([])] }),
     moduleMetadata({ imports: [WattSegmentedButtonsShowcase] }),
   ],
+  argTypes: {
+    disabled: {
+      control: 'boolean',
+      description: 'Disable the overview segmented buttons group',
+    },
+  },
+  args: {
+    disabled: false,
+  },
 };
 export default meta;
 
 type Story = StoryObj<WattSegmentedButtonsShowcase>;
 
 export const Overview: Story = {
-  render: () => ({ template: `<watt-segmented-buttons-showcase />` }),
+  render: (args) => ({
+    props: args,
+    template: `<watt-segmented-buttons-showcase [disabled]="disabled" />`,
+  }),
 };

--- a/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
@@ -23,7 +23,7 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.component';
 import { WattSegmentedButtonComponent } from '../watt-segmented-button.component';
 
-const meta: Meta<WattSegmentedButtonsComponent & { disabled: boolean }> = {
+const meta: Meta<WattSegmentedButtonsComponent> = {
   title: 'Components/Segmented buttons',
   component: WattSegmentedButtonsComponent,
   decorators: [
@@ -34,225 +34,110 @@ const meta: Meta<WattSegmentedButtonsComponent & { disabled: boolean }> = {
       imports: [ReactiveFormsModule, WattSegmentedButtonsComponent, WattSegmentedButtonComponent],
     }),
   ],
-  argTypes: {
-    disabled: {
-      control: 'boolean',
-      description: 'Disable the segmented buttons group',
-    },
-  },
-  args: {
-    disabled: false,
-  },
 };
 export default meta;
 
-type Story = StoryObj<WattSegmentedButtonsComponent & { disabled: boolean }>;
-
-const sourceCode = `
-<watt-segmented-buttons [formControl]="formControl">
-  <watt-segmented-button value="day">Dag</watt-segmented-button>
-  <watt-segmented-button value="month">Måned</watt-segmented-button>
-  <watt-segmented-button value="year">År</watt-segmented-button>
-  <watt-segmented-button value="all">Alle år</watt-segmented-button>
-</watt-segmented-buttons>
-`.trim();
+type Story = StoryObj<WattSegmentedButtonsComponent>;
 
 export const Overview: Story = {
-  parameters: {
-    docs: {
-      source: { code: sourceCode },
+  render: () => ({
+    props: { formControl: new FormControl('day') },
+    template: `
+      <watt-segmented-buttons [formControl]="formControl">
+        <watt-segmented-button value="day">Dag</watt-segmented-button>
+        <watt-segmented-button value="month">Måned</watt-segmented-button>
+        <watt-segmented-button value="year">År</watt-segmented-button>
+        <watt-segmented-button value="all">Alle år</watt-segmented-button>
+      </watt-segmented-buttons>
+    `,
+  }),
+};
+
+export const Standalone: Story = {
+  render: () => ({
+    props: { formControl: new FormControl('only') },
+    template: `
+      <watt-segmented-buttons [formControl]="formControl">
+        <watt-segmented-button value="only">Only option</watt-segmented-button>
+      </watt-segmented-buttons>
+    `,
+  }),
+};
+
+export const SelectedPositions: Story = {
+  name: 'Selected positions',
+  render: () => ({
+    props: {
+      firstSelected: new FormControl('day'),
+      middleSelected: new FormControl('month'),
+      lastSelected: new FormControl('year'),
+      noneSelected: new FormControl(null),
     },
-  },
-  render: (args) => {
-    const formControl = new FormControl('day');
-    if (args.disabled) formControl.disable();
-    return {
-      props: { formControl },
-      styles: [
-        `
-          :host {
-            display: block;
-            background: #e5e5e5;
-            padding: 40px;
-            margin: -16px;
-          }
+    styles: [`.stack { display: flex; flex-direction: column; gap: 16px; }`],
+    template: `
+      <div class="stack">
+        <watt-segmented-buttons [formControl]="noneSelected">
+          <watt-segmented-button value="day">Dag</watt-segmented-button>
+          <watt-segmented-button value="month">Måned</watt-segmented-button>
+          <watt-segmented-button value="year">År</watt-segmented-button>
+        </watt-segmented-buttons>
 
-          .page {
-            display: flex;
-            flex-direction: column;
-            gap: 24px;
-            max-width: 560px;
-          }
+        <watt-segmented-buttons [formControl]="firstSelected">
+          <watt-segmented-button value="day">Dag</watt-segmented-button>
+          <watt-segmented-button value="month">Måned</watt-segmented-button>
+          <watt-segmented-button value="year">År</watt-segmented-button>
+        </watt-segmented-buttons>
 
-          .section {
-            background: white;
-            border-radius: 12px;
-            padding: 48px 56px;
-          }
+        <watt-segmented-buttons [formControl]="middleSelected">
+          <watt-segmented-button value="day">Dag</watt-segmented-button>
+          <watt-segmented-button value="month">Måned</watt-segmented-button>
+          <watt-segmented-button value="year">År</watt-segmented-button>
+        </watt-segmented-buttons>
 
-          .section-title {
-            font-family: 'Open Sans', sans-serif;
-            font-size: 36px;
-            font-weight: 300;
-            color: rgba(0, 0, 0, 0.87);
-            margin: 0 0 24px;
-          }
+        <watt-segmented-buttons [formControl]="lastSelected">
+          <watt-segmented-button value="day">Dag</watt-segmented-button>
+          <watt-segmented-button value="month">Måned</watt-segmented-button>
+          <watt-segmented-button value="year">År</watt-segmented-button>
+        </watt-segmented-buttons>
+      </div>
+    `,
+  }),
+};
 
-          .divider {
-            border: none;
-            border-top: 1px solid var(--watt-color-neutral-grey-300);
-            margin: 0 0 32px;
-          }
+export const Disabled: Story = {
+  render: () => ({
+    props: {
+      disabledNoSelection: new FormControl({ value: null, disabled: true }),
+      disabledWithSelection: new FormControl({ value: 'month', disabled: true }),
+    },
+    styles: [`.stack { display: flex; flex-direction: column; gap: 16px; }`],
+    template: `
+      <div class="stack">
+        <watt-segmented-buttons [formControl]="disabledNoSelection">
+          <watt-segmented-button value="day">Dag</watt-segmented-button>
+          <watt-segmented-button value="month">Måned</watt-segmented-button>
+          <watt-segmented-button value="year">År</watt-segmented-button>
+        </watt-segmented-buttons>
 
-          .dashed-border {
-            border: 2px dashed #7c4dff;
-            border-radius: 8px;
-            padding: 24px 40px;
-            margin-top: 8px;
-          }
+        <watt-segmented-buttons [formControl]="disabledWithSelection">
+          <watt-segmented-button value="day">Dag</watt-segmented-button>
+          <watt-segmented-button value="month">Måned</watt-segmented-button>
+          <watt-segmented-button value="year">År</watt-segmented-button>
+        </watt-segmented-buttons>
+      </div>
+    `,
+  }),
+};
 
-          .blocks-grid {
-            display: grid;
-            grid-template-columns: repeat(3, auto);
-            gap: 24px 32px;
-            justify-items: start;
-          }
-
-          .column-header {
-            font-family: 'Open Sans', sans-serif;
-            font-size: 14px;
-            color: rgba(0, 0, 0, 0.6);
-          }
-
-          .hover-cell ::ng-deep watt-segmented-button a,
-          .hover-cell ::ng-deep watt-segmented-button button {
-            background-color: var(--watt-color-neutral-grey-200);
-          }
-
-          .blocks-gap {
-            grid-column: 1 / -1;
-            height: 16px;
-          }
-
-          .start ::ng-deep watt-segmented-button a,
-          .start ::ng-deep watt-segmented-button button {
-            border-right-width: 0;
-            border-radius: 4px 0 0 4px;
-          }
-
-          .middle ::ng-deep watt-segmented-button a,
-          .middle ::ng-deep watt-segmented-button button {
-            border-right-width: 0;
-            border-radius: 0;
-          }
-
-          .end ::ng-deep watt-segmented-button a,
-          .end ::ng-deep watt-segmented-button button {
-            border-radius: 0 4px 4px 0;
-          }
-
-          .mock-selected ::ng-deep watt-segmented-button a,
-          .mock-selected ::ng-deep watt-segmented-button button {
-            background-color: var(--watt-color-primary);
-            color: var(--watt-color-neutral-white);
-          }
-
-          .mock-disabled ::ng-deep watt-segmented-button a,
-          .mock-disabled ::ng-deep watt-segmented-button button {
-            background-color: var(--watt-color-neutral-grey-200);
-            color: rgba(0, 0, 0, 0.26);
-            cursor: default;
-          }
-
-          .mock-disabled.mock-selected ::ng-deep watt-segmented-button a,
-          .mock-disabled.mock-selected ::ng-deep watt-segmented-button button {
-            background-color: var(--watt-color-neutral-grey-400);
-            color: var(--watt-on-light-high-emphasis);
-          }
-        `,
-      ],
-      template: `
-        <div class="page">
-          <div class="section">
-            <div class="section-title">Segmented button</div>
-            <hr class="divider" />
-            <watt-segmented-buttons [formControl]="formControl">
-              <watt-segmented-button value="day">Dag</watt-segmented-button>
-              <watt-segmented-button value="month">Måned</watt-segmented-button>
-              <watt-segmented-button value="year">År</watt-segmented-button>
-              <watt-segmented-button value="all">Alle år</watt-segmented-button>
-            </watt-segmented-buttons>
-          </div>
-
-          <div class="section">
-            <div class="section-title">Building blocks</div>
-            <hr class="divider" />
-            <div class="dashed-border">
-              <div class="blocks-grid">
-                <div class="column-header">Enabled</div>
-                <div class="column-header">Hover</div>
-                <div class="column-header">Disabled</div>
-
-                <div class="start">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div class="start hover-cell">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div class="start mock-disabled">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-
-                <div class="middle">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div class="middle hover-cell">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div class="middle mock-disabled">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-
-                <div class="end">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div class="end hover-cell">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div class="end mock-disabled">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-
-                <div class="blocks-gap"></div>
-
-                <div class="start mock-selected">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div></div>
-                <div class="start mock-disabled mock-selected">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-
-                <div class="middle mock-selected">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div></div>
-                <div class="middle mock-disabled mock-selected">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-
-                <div class="end mock-selected">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div></div>
-                <div class="end mock-disabled mock-selected">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      `,
-    };
-  },
+export const WithRouterLinks: Story = {
+  name: 'With router links',
+  render: () => ({
+    template: `
+      <watt-segmented-buttons>
+        <watt-segmented-button link="/day">Dag</watt-segmented-button>
+        <watt-segmented-button link="/month">Måned</watt-segmented-button>
+        <watt-segmented-button link="/year">År</watt-segmented-button>
+      </watt-segmented-buttons>
+    `,
+  }),
 };

--- a/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
@@ -16,243 +16,164 @@
  * limitations under the License.
  */
 //#endregion
-import { Meta, applicationConfig, moduleMetadata, StoryObj } from '@storybook/angular';
-import { provideRouter } from '@angular/router';
-
+import { Component, ViewEncapsulation } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { provideRouter } from '@angular/router';
+import { Meta, applicationConfig, moduleMetadata, StoryObj } from '@storybook/angular';
+
 import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.component';
 import { WattSegmentedButtonComponent } from '../watt-segmented-button.component';
 
-const meta: Meta<WattSegmentedButtonsComponent & { disabled: boolean }> = {
-  title: 'Components/Segmented buttons',
-  component: WattSegmentedButtonsComponent,
-  decorators: [
-    applicationConfig({
-      providers: [provideRouter([])],
-    }),
-    moduleMetadata({
-      imports: [ReactiveFormsModule, WattSegmentedButtonsComponent, WattSegmentedButtonComponent],
-    }),
-  ],
-  argTypes: {
-    disabled: {
-      control: 'boolean',
-      description: 'Disable the segmented buttons group',
-    },
-  },
-  args: {
-    disabled: false,
-  },
-};
-export default meta;
+@Component({
+  selector: 'watt-segmented-buttons-showcase',
+  imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
+  encapsulation: ViewEncapsulation.None,
+  styles: `
+    .watt-segmented-buttons-showcase {
+      background: #e5e5e5;
+      padding: 40px;
+      margin: -16px;
 
-type Story = StoryObj<WattSegmentedButtonsComponent & { disabled: boolean }>;
+      .page {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        max-width: 560px;
+      }
 
-const sourceCode = `
-<watt-segmented-buttons [formControl]="formControl">
-  <watt-segmented-button value="day">Dag</watt-segmented-button>
-  <watt-segmented-button value="month">Måned</watt-segmented-button>
-  <watt-segmented-button value="year">År</watt-segmented-button>
-  <watt-segmented-button value="all">Alle år</watt-segmented-button>
-</watt-segmented-buttons>
-`.trim();
+      .section {
+        background: white;
+        border-radius: 12px;
+        padding: 48px 56px;
+      }
 
-export const Overview: Story = {
-  parameters: {
-    docs: {
-      source: { code: sourceCode },
-    },
-  },
-  render: (args) => {
-    const formControl = new FormControl('day');
-    if (args.disabled) formControl.disable();
-    return {
-      props: { formControl },
-      styles: [
-        `
-          :host {
-            display: block;
-            background: #e5e5e5;
-            padding: 40px;
-            margin: -16px;
-          }
+      .section-title {
+        font-family: 'Open Sans', sans-serif;
+        font-size: 36px;
+        font-weight: 300;
+        color: rgba(0, 0, 0, 0.87);
+        margin: 0 0 24px;
+      }
 
-          .page {
-            display: flex;
-            flex-direction: column;
-            gap: 24px;
-            max-width: 560px;
-          }
+      .divider {
+        border: none;
+        border-top: 1px solid var(--watt-color-neutral-grey-300);
+        margin: 0 0 32px;
+      }
 
-          .section {
-            background: white;
-            border-radius: 12px;
-            padding: 48px 56px;
-          }
+      .dashed-border {
+        border: 2px dashed #7c4dff;
+        border-radius: 8px;
+        padding: 24px 40px;
+        margin-top: 8px;
+      }
 
-          .section-title {
-            font-family: 'Open Sans', sans-serif;
-            font-size: 36px;
-            font-weight: 300;
-            color: rgba(0, 0, 0, 0.87);
-            margin: 0 0 24px;
-          }
+      .blocks-grid {
+        display: grid;
+        grid-template-columns: repeat(3, auto);
+        gap: 24px 32px;
+        justify-items: start;
+      }
 
-          .divider {
-            border: none;
-            border-top: 1px solid var(--watt-color-neutral-grey-300);
-            margin: 0 0 32px;
-          }
+      .column-header {
+        font-family: 'Open Sans', sans-serif;
+        font-size: 14px;
+        color: rgba(0, 0, 0, 0.6);
+      }
 
-          .dashed-border {
-            border: 2px dashed #7c4dff;
-            border-radius: 8px;
-            padding: 24px 40px;
-            margin-top: 8px;
-          }
+      .blocks-gap {
+        grid-column: 1 / -1;
+        height: 16px;
+      }
 
-          .blocks-grid {
-            display: grid;
-            grid-template-columns: repeat(3, auto);
-            gap: 24px 32px;
-            justify-items: start;
-          }
+      /*
+       * Hover is an interaction state and cannot be expressed via FormControl
+       * or component inputs. The block below mirrors the component's own
+       * :hover background so the documentation matches Figma exactly.
+       */
+      .hover-cell watt-segmented-button button {
+        background-color: var(--watt-color-neutral-grey-200);
+      }
+    }
+  `,
+  template: `
+    <div class="watt-segmented-buttons-showcase">
+      <div class="page">
+        <div class="section">
+          <div class="section-title">Segmented button</div>
+          <hr class="divider" />
+          <watt-segmented-buttons [formControl]="overviewControl">
+            <watt-segmented-button value="day">Dag</watt-segmented-button>
+            <watt-segmented-button value="month">Måned</watt-segmented-button>
+            <watt-segmented-button value="year">År</watt-segmented-button>
+            <watt-segmented-button value="all">Alle år</watt-segmented-button>
+          </watt-segmented-buttons>
+        </div>
 
-          .column-header {
-            font-family: 'Open Sans', sans-serif;
-            font-size: 14px;
-            color: rgba(0, 0, 0, 0.6);
-          }
+        <div class="section">
+          <div class="section-title">Building blocks</div>
+          <hr class="divider" />
+          <div class="dashed-border">
+            <div class="blocks-grid">
+              <div class="column-header">Enabled</div>
+              <div class="column-header">Hover</div>
+              <div class="column-header">Disabled</div>
 
-          .hover-cell ::ng-deep watt-segmented-button a,
-          .hover-cell ::ng-deep watt-segmented-button button {
-            background-color: var(--watt-color-neutral-grey-200);
-          }
-
-          .blocks-gap {
-            grid-column: 1 / -1;
-            height: 16px;
-          }
-
-          .start ::ng-deep watt-segmented-button a,
-          .start ::ng-deep watt-segmented-button button {
-            border-right-width: 0;
-            border-radius: 4px 0 0 4px;
-          }
-
-          .middle ::ng-deep watt-segmented-button a,
-          .middle ::ng-deep watt-segmented-button button {
-            border-right-width: 0;
-            border-radius: 0;
-          }
-
-          .end ::ng-deep watt-segmented-button a,
-          .end ::ng-deep watt-segmented-button button {
-            border-radius: 0 4px 4px 0;
-          }
-
-          .mock-selected ::ng-deep watt-segmented-button a,
-          .mock-selected ::ng-deep watt-segmented-button button {
-            background-color: var(--watt-color-primary);
-            color: var(--watt-color-neutral-white);
-          }
-
-          .mock-disabled ::ng-deep watt-segmented-button a,
-          .mock-disabled ::ng-deep watt-segmented-button button {
-            background-color: var(--watt-color-neutral-grey-200);
-            color: rgba(0, 0, 0, 0.26);
-            cursor: default;
-          }
-
-          .mock-disabled.mock-selected ::ng-deep watt-segmented-button a,
-          .mock-disabled.mock-selected ::ng-deep watt-segmented-button button {
-            background-color: var(--watt-color-neutral-grey-400);
-            color: var(--watt-on-light-high-emphasis);
-          }
-        `,
-      ],
-      template: `
-        <div class="page">
-          <div class="section">
-            <div class="section-title">Segmented button</div>
-            <hr class="divider" />
-            <watt-segmented-buttons [formControl]="formControl">
-              <watt-segmented-button value="day">Dag</watt-segmented-button>
-              <watt-segmented-button value="month">Måned</watt-segmented-button>
-              <watt-segmented-button value="year">År</watt-segmented-button>
-              <watt-segmented-button value="all">Alle år</watt-segmented-button>
-            </watt-segmented-buttons>
-          </div>
-
-          <div class="section">
-            <div class="section-title">Building blocks</div>
-            <hr class="divider" />
-            <div class="dashed-border">
-              <div class="blocks-grid">
-                <div class="column-header">Enabled</div>
-                <div class="column-header">Hover</div>
-                <div class="column-header">Disabled</div>
-
-                <div class="start">
+              @for (_ of [1, 2, 3]; track $index) {
+                <watt-segmented-buttons>
                   <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div class="start hover-cell">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div class="start mock-disabled">
-                  <watt-segmented-button>Label</watt-segmented-button>
+                </watt-segmented-buttons>
+
+                <div class="hover-cell">
+                  <watt-segmented-buttons>
+                    <watt-segmented-button>Label</watt-segmented-button>
+                  </watt-segmented-buttons>
                 </div>
 
-                <div class="middle">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div class="middle hover-cell">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div class="middle mock-disabled">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
+                <watt-segmented-buttons [formControl]="disabledBlock">
+                  <watt-segmented-button value="x">Label</watt-segmented-button>
+                </watt-segmented-buttons>
+              }
 
-                <div class="end">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div class="end hover-cell">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div class="end mock-disabled">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
+              <div class="blocks-gap"></div>
 
-                <div class="blocks-gap"></div>
+              @for (_ of [1, 2, 3]; track $index) {
+                <watt-segmented-buttons [formControl]="selectedBlock">
+                  <watt-segmented-button value="x">Label</watt-segmented-button>
+                </watt-segmented-buttons>
 
-                <div class="start mock-selected">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
                 <div></div>
-                <div class="start mock-disabled mock-selected">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
 
-                <div class="middle mock-selected">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div></div>
-                <div class="middle mock-disabled mock-selected">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-
-                <div class="end mock-selected">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-                <div></div>
-                <div class="end mock-disabled mock-selected">
-                  <watt-segmented-button>Label</watt-segmented-button>
-                </div>
-              </div>
+                <watt-segmented-buttons [formControl]="disabledSelectedBlock">
+                  <watt-segmented-button value="x">Label</watt-segmented-button>
+                </watt-segmented-buttons>
+              }
             </div>
           </div>
         </div>
-      `,
-    };
-  },
+      </div>
+    </div>
+  `,
+})
+class WattSegmentedButtonsShowcase {
+  overviewControl = new FormControl('day');
+  disabledBlock = new FormControl({ value: null, disabled: true });
+  selectedBlock = new FormControl('x');
+  disabledSelectedBlock = new FormControl({ value: 'x', disabled: true });
+}
+
+const meta: Meta<WattSegmentedButtonsShowcase> = {
+  title: 'Components/Segmented buttons',
+  component: WattSegmentedButtonsShowcase,
+  decorators: [
+    applicationConfig({ providers: [provideRouter([])] }),
+    moduleMetadata({ imports: [WattSegmentedButtonsShowcase] }),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<WattSegmentedButtonsShowcase>;
+
+export const Overview: Story = {
+  render: () => ({ template: `<watt-segmented-buttons-showcase />` }),
 };

--- a/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
@@ -24,7 +24,8 @@ import { Meta, applicationConfig, moduleMetadata, StoryObj } from '@storybook/an
 import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.component';
 import { WattSegmentedButtonComponent } from '../watt-segmented-button.component';
 
-const BLOCK_ROWS = [0, 1, 2] as const;
+const POSITIONS = ['start', 'middle', 'end'] as const;
+type Position = (typeof POSITIONS)[number];
 
 @Component({
   selector: 'watt-segmented-buttons-showcase',
@@ -87,15 +88,6 @@ const BLOCK_ROWS = [0, 1, 2] as const;
         grid-column: 1 / -1;
         height: 16px;
       }
-
-      /*
-       * Hover is an interaction state and cannot be expressed via FormControl
-       * or component inputs. The block below mirrors the component's own
-       * :hover background so the documentation matches Figma exactly.
-       */
-      .hover-cell watt-segmented-button button {
-        background-color: var(--watt-color-neutral-grey-200);
-      }
     }
   `,
   template: `
@@ -121,33 +113,31 @@ const BLOCK_ROWS = [0, 1, 2] as const;
               <div class="column-header">Hover</div>
               <div class="column-header">Disabled</div>
 
-              @for (i of rows; track i) {
+              @for (position of positions; track position) {
                 <watt-segmented-buttons>
-                  <watt-segmented-button>Label</watt-segmented-button>
+                  <watt-segmented-button [class]="position">Label</watt-segmented-button>
                 </watt-segmented-buttons>
 
-                <div class="hover-cell">
-                  <watt-segmented-buttons>
-                    <watt-segmented-button>Label</watt-segmented-button>
-                  </watt-segmented-buttons>
-                </div>
+                <watt-segmented-buttons>
+                  <watt-segmented-button [class]="position + ' hover'">Label</watt-segmented-button>
+                </watt-segmented-buttons>
 
-                <watt-segmented-buttons [formControl]="disabledBlocks[i]">
-                  <watt-segmented-button value="x">Label</watt-segmented-button>
+                <watt-segmented-buttons [formControl]="disabledBlocks[$index]">
+                  <watt-segmented-button [class]="position" value="x">Label</watt-segmented-button>
                 </watt-segmented-buttons>
               }
 
               <div class="blocks-gap"></div>
 
-              @for (i of rows; track i) {
-                <watt-segmented-buttons [formControl]="selectedBlocks[i]">
-                  <watt-segmented-button value="x">Label</watt-segmented-button>
+              @for (position of positions; track position) {
+                <watt-segmented-buttons [formControl]="selectedBlocks[$index]">
+                  <watt-segmented-button [class]="position" value="x">Label</watt-segmented-button>
                 </watt-segmented-buttons>
 
                 <div></div>
 
-                <watt-segmented-buttons [formControl]="disabledSelectedBlocks[i]">
-                  <watt-segmented-button value="x">Label</watt-segmented-button>
+                <watt-segmented-buttons [formControl]="disabledSelectedBlocks[$index]">
+                  <watt-segmented-button [class]="position" value="x">Label</watt-segmented-button>
                 </watt-segmented-buttons>
               }
             </div>
@@ -160,12 +150,11 @@ const BLOCK_ROWS = [0, 1, 2] as const;
 class WattSegmentedButtonsShowcase {
   disabled = input(false);
 
+  positions = POSITIONS;
   overviewControl = new FormControl('day');
-  disabledBlocks = BLOCK_ROWS.map(() => new FormControl({ value: null, disabled: true }));
-  selectedBlocks = BLOCK_ROWS.map(() => new FormControl('x'));
-  disabledSelectedBlocks = BLOCK_ROWS.map(() => new FormControl({ value: 'x', disabled: true }));
-
-  rows = BLOCK_ROWS;
+  disabledBlocks = POSITIONS.map(() => new FormControl({ value: null, disabled: true }));
+  selectedBlocks = POSITIONS.map(() => new FormControl('x'));
+  disabledSelectedBlocks = POSITIONS.map(() => new FormControl({ value: 'x', disabled: true }));
 
   constructor() {
     effect(() => {

--- a/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
@@ -23,7 +23,7 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.component';
 import { WattSegmentedButtonComponent } from '../watt-segmented-button.component';
 
-const meta: Meta<WattSegmentedButtonsComponent> = {
+const meta: Meta<WattSegmentedButtonsComponent & { disabled: boolean }> = {
   title: 'Components/Segmented buttons',
   component: WattSegmentedButtonsComponent,
   decorators: [
@@ -34,110 +34,225 @@ const meta: Meta<WattSegmentedButtonsComponent> = {
       imports: [ReactiveFormsModule, WattSegmentedButtonsComponent, WattSegmentedButtonComponent],
     }),
   ],
+  argTypes: {
+    disabled: {
+      control: 'boolean',
+      description: 'Disable the segmented buttons group',
+    },
+  },
+  args: {
+    disabled: false,
+  },
 };
 export default meta;
 
-type Story = StoryObj<WattSegmentedButtonsComponent>;
+type Story = StoryObj<WattSegmentedButtonsComponent & { disabled: boolean }>;
+
+const sourceCode = `
+<watt-segmented-buttons [formControl]="formControl">
+  <watt-segmented-button value="day">Dag</watt-segmented-button>
+  <watt-segmented-button value="month">Måned</watt-segmented-button>
+  <watt-segmented-button value="year">År</watt-segmented-button>
+  <watt-segmented-button value="all">Alle år</watt-segmented-button>
+</watt-segmented-buttons>
+`.trim();
 
 export const Overview: Story = {
-  render: () => ({
-    props: { formControl: new FormControl('day') },
-    template: `
-      <watt-segmented-buttons [formControl]="formControl">
-        <watt-segmented-button value="day">Dag</watt-segmented-button>
-        <watt-segmented-button value="month">Måned</watt-segmented-button>
-        <watt-segmented-button value="year">År</watt-segmented-button>
-        <watt-segmented-button value="all">Alle år</watt-segmented-button>
-      </watt-segmented-buttons>
-    `,
-  }),
-};
-
-export const Standalone: Story = {
-  render: () => ({
-    props: { formControl: new FormControl('only') },
-    template: `
-      <watt-segmented-buttons [formControl]="formControl">
-        <watt-segmented-button value="only">Only option</watt-segmented-button>
-      </watt-segmented-buttons>
-    `,
-  }),
-};
-
-export const SelectedPositions: Story = {
-  name: 'Selected positions',
-  render: () => ({
-    props: {
-      firstSelected: new FormControl('day'),
-      middleSelected: new FormControl('month'),
-      lastSelected: new FormControl('year'),
-      noneSelected: new FormControl(null),
+  parameters: {
+    docs: {
+      source: { code: sourceCode },
     },
-    styles: [`.stack { display: flex; flex-direction: column; gap: 16px; }`],
-    template: `
-      <div class="stack">
-        <watt-segmented-buttons [formControl]="noneSelected">
-          <watt-segmented-button value="day">Dag</watt-segmented-button>
-          <watt-segmented-button value="month">Måned</watt-segmented-button>
-          <watt-segmented-button value="year">År</watt-segmented-button>
-        </watt-segmented-buttons>
+  },
+  render: (args) => {
+    const formControl = new FormControl('day');
+    if (args.disabled) formControl.disable();
+    return {
+      props: { formControl },
+      styles: [
+        `
+          :host {
+            display: block;
+            background: #e5e5e5;
+            padding: 40px;
+            margin: -16px;
+          }
 
-        <watt-segmented-buttons [formControl]="firstSelected">
-          <watt-segmented-button value="day">Dag</watt-segmented-button>
-          <watt-segmented-button value="month">Måned</watt-segmented-button>
-          <watt-segmented-button value="year">År</watt-segmented-button>
-        </watt-segmented-buttons>
+          .page {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+            max-width: 560px;
+          }
 
-        <watt-segmented-buttons [formControl]="middleSelected">
-          <watt-segmented-button value="day">Dag</watt-segmented-button>
-          <watt-segmented-button value="month">Måned</watt-segmented-button>
-          <watt-segmented-button value="year">År</watt-segmented-button>
-        </watt-segmented-buttons>
+          .section {
+            background: white;
+            border-radius: 12px;
+            padding: 48px 56px;
+          }
 
-        <watt-segmented-buttons [formControl]="lastSelected">
-          <watt-segmented-button value="day">Dag</watt-segmented-button>
-          <watt-segmented-button value="month">Måned</watt-segmented-button>
-          <watt-segmented-button value="year">År</watt-segmented-button>
-        </watt-segmented-buttons>
-      </div>
-    `,
-  }),
-};
+          .section-title {
+            font-family: 'Open Sans', sans-serif;
+            font-size: 36px;
+            font-weight: 300;
+            color: rgba(0, 0, 0, 0.87);
+            margin: 0 0 24px;
+          }
 
-export const Disabled: Story = {
-  render: () => ({
-    props: {
-      disabledNoSelection: new FormControl({ value: null, disabled: true }),
-      disabledWithSelection: new FormControl({ value: 'month', disabled: true }),
-    },
-    styles: [`.stack { display: flex; flex-direction: column; gap: 16px; }`],
-    template: `
-      <div class="stack">
-        <watt-segmented-buttons [formControl]="disabledNoSelection">
-          <watt-segmented-button value="day">Dag</watt-segmented-button>
-          <watt-segmented-button value="month">Måned</watt-segmented-button>
-          <watt-segmented-button value="year">År</watt-segmented-button>
-        </watt-segmented-buttons>
+          .divider {
+            border: none;
+            border-top: 1px solid var(--watt-color-neutral-grey-300);
+            margin: 0 0 32px;
+          }
 
-        <watt-segmented-buttons [formControl]="disabledWithSelection">
-          <watt-segmented-button value="day">Dag</watt-segmented-button>
-          <watt-segmented-button value="month">Måned</watt-segmented-button>
-          <watt-segmented-button value="year">År</watt-segmented-button>
-        </watt-segmented-buttons>
-      </div>
-    `,
-  }),
-};
+          .dashed-border {
+            border: 2px dashed #7c4dff;
+            border-radius: 8px;
+            padding: 24px 40px;
+            margin-top: 8px;
+          }
 
-export const WithRouterLinks: Story = {
-  name: 'With router links',
-  render: () => ({
-    template: `
-      <watt-segmented-buttons>
-        <watt-segmented-button link="/day">Dag</watt-segmented-button>
-        <watt-segmented-button link="/month">Måned</watt-segmented-button>
-        <watt-segmented-button link="/year">År</watt-segmented-button>
-      </watt-segmented-buttons>
-    `,
-  }),
+          .blocks-grid {
+            display: grid;
+            grid-template-columns: repeat(3, auto);
+            gap: 24px 32px;
+            justify-items: start;
+          }
+
+          .column-header {
+            font-family: 'Open Sans', sans-serif;
+            font-size: 14px;
+            color: rgba(0, 0, 0, 0.6);
+          }
+
+          .hover-cell ::ng-deep watt-segmented-button a,
+          .hover-cell ::ng-deep watt-segmented-button button {
+            background-color: var(--watt-color-neutral-grey-200);
+          }
+
+          .blocks-gap {
+            grid-column: 1 / -1;
+            height: 16px;
+          }
+
+          .start ::ng-deep watt-segmented-button a,
+          .start ::ng-deep watt-segmented-button button {
+            border-right-width: 0;
+            border-radius: 4px 0 0 4px;
+          }
+
+          .middle ::ng-deep watt-segmented-button a,
+          .middle ::ng-deep watt-segmented-button button {
+            border-right-width: 0;
+            border-radius: 0;
+          }
+
+          .end ::ng-deep watt-segmented-button a,
+          .end ::ng-deep watt-segmented-button button {
+            border-radius: 0 4px 4px 0;
+          }
+
+          .mock-selected ::ng-deep watt-segmented-button a,
+          .mock-selected ::ng-deep watt-segmented-button button {
+            background-color: var(--watt-color-primary);
+            color: var(--watt-color-neutral-white);
+          }
+
+          .mock-disabled ::ng-deep watt-segmented-button a,
+          .mock-disabled ::ng-deep watt-segmented-button button {
+            background-color: var(--watt-color-neutral-grey-200);
+            color: rgba(0, 0, 0, 0.26);
+            cursor: default;
+          }
+
+          .mock-disabled.mock-selected ::ng-deep watt-segmented-button a,
+          .mock-disabled.mock-selected ::ng-deep watt-segmented-button button {
+            background-color: var(--watt-color-neutral-grey-400);
+            color: var(--watt-on-light-high-emphasis);
+          }
+        `,
+      ],
+      template: `
+        <div class="page">
+          <div class="section">
+            <div class="section-title">Segmented button</div>
+            <hr class="divider" />
+            <watt-segmented-buttons [formControl]="formControl">
+              <watt-segmented-button value="day">Dag</watt-segmented-button>
+              <watt-segmented-button value="month">Måned</watt-segmented-button>
+              <watt-segmented-button value="year">År</watt-segmented-button>
+              <watt-segmented-button value="all">Alle år</watt-segmented-button>
+            </watt-segmented-buttons>
+          </div>
+
+          <div class="section">
+            <div class="section-title">Building blocks</div>
+            <hr class="divider" />
+            <div class="dashed-border">
+              <div class="blocks-grid">
+                <div class="column-header">Enabled</div>
+                <div class="column-header">Hover</div>
+                <div class="column-header">Disabled</div>
+
+                <div class="start">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div class="start hover-cell">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div class="start mock-disabled">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+
+                <div class="middle">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div class="middle hover-cell">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div class="middle mock-disabled">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+
+                <div class="end">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div class="end hover-cell">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div class="end mock-disabled">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+
+                <div class="blocks-gap"></div>
+
+                <div class="start mock-selected">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div></div>
+                <div class="start mock-disabled mock-selected">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+
+                <div class="middle mock-selected">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div></div>
+                <div class="middle mock-disabled mock-selected">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+
+                <div class="end mock-selected">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div></div>
+                <div class="end mock-disabled mock-selected">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      `,
+    };
+  },
 };

--- a/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
@@ -163,9 +163,7 @@ class WattSegmentedButtonsShowcase {
   overviewControl = new FormControl('day');
   disabledBlocks = BLOCK_ROWS.map(() => new FormControl({ value: null, disabled: true }));
   selectedBlocks = BLOCK_ROWS.map(() => new FormControl('x'));
-  disabledSelectedBlocks = BLOCK_ROWS.map(
-    () => new FormControl({ value: 'x', disabled: true })
-  );
+  disabledSelectedBlocks = BLOCK_ROWS.map(() => new FormControl({ value: 'x', disabled: true }));
 
   rows = BLOCK_ROWS;
 

--- a/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
@@ -16,15 +16,14 @@
  * limitations under the License.
  */
 //#endregion
-import { Meta, applicationConfig, moduleMetadata, StoryFn } from '@storybook/angular';
+import { Meta, applicationConfig, moduleMetadata, StoryObj } from '@storybook/angular';
 import { provideRouter } from '@angular/router';
 
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.component';
-import { WattButtonComponent } from '@energinet/watt/button';
 import { WattSegmentedButtonComponent } from '../watt-segmented-button.component';
 
-const meta: Meta<WattSegmentedButtonsComponent> = {
+const meta: Meta<WattSegmentedButtonsComponent & { disabled: boolean }> = {
   title: 'Components/Segmented buttons',
   component: WattSegmentedButtonsComponent,
   decorators: [
@@ -36,42 +35,195 @@ const meta: Meta<WattSegmentedButtonsComponent> = {
         ReactiveFormsModule,
         WattSegmentedButtonsComponent,
         WattSegmentedButtonComponent,
-        WattButtonComponent,
       ],
     }),
   ],
+  argTypes: {
+    disabled: {
+      control: 'boolean',
+      description: 'Disable the segmented buttons group',
+    },
+  },
+  args: {
+    disabled: false,
+  },
 };
 export default meta;
 
-export const WithFormControl: StoryFn<WattSegmentedButtonsComponent> = () => ({
-  props: {
-    exampleFormControl: new FormControl('year'),
+type Story = StoryObj<WattSegmentedButtonsComponent & { disabled: boolean }>;
+
+const sourceCode = `
+<watt-segmented-buttons [formControl]="formControl">
+  <watt-segmented-button value="day">Dag</watt-segmented-button>
+  <watt-segmented-button value="month">Måned</watt-segmented-button>
+  <watt-segmented-button value="year">År</watt-segmented-button>
+  <watt-segmented-button value="all">Alle år</watt-segmented-button>
+</watt-segmented-buttons>
+`.trim();
+
+export const Overview: Story = {
+  parameters: {
+    docs: {
+      source: { code: sourceCode },
+    },
   },
-  template: `
-    <watt-segmented-buttons [formControl]="exampleFormControl">
-      <watt-segmented-button value="day">Day</watt-segmented-button>
-      <watt-segmented-button value="month">Month</watt-segmented-button>
-      <watt-segmented-button value="year">Year</watt-segmented-button>
-      <watt-segmented-button value="all years">All Years</watt-segmented-button>
-    </watt-segmented-buttons>
-    <h5>Form value: {{exampleFormControl.value}}</h5>
-  `,
-});
-export const Disable: StoryFn<WattSegmentedButtonsComponent> = () => ({
-  props: {
-    exampleFormControl: new FormControl('year'),
+  render: (args) => {
+    const formControl = new FormControl('day');
+    if (args.disabled) formControl.disable();
+    return {
+      props: { formControl },
+      styles: [
+        `
+          :host {
+            display: block;
+            background: #e5e5e5;
+            padding: 40px;
+            margin: -16px;
+          }
+
+          .page {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+            max-width: 560px;
+          }
+
+          .section {
+            background: white;
+            border-radius: 12px;
+            padding: 48px 56px;
+          }
+
+          .section-title {
+            font-family: 'Open Sans', sans-serif;
+            font-size: 36px;
+            font-weight: 300;
+            color: rgba(0, 0, 0, 0.87);
+            margin: 0 0 24px;
+          }
+
+          .divider {
+            border: none;
+            border-top: 1px solid var(--watt-color-neutral-grey-300);
+            margin: 0 0 32px;
+          }
+
+          .dashed-border {
+            border: 2px dashed #7c4dff;
+            border-radius: 8px;
+            padding: 24px 40px;
+            margin-top: 8px;
+          }
+
+          .blocks-grid {
+            display: grid;
+            grid-template-columns: repeat(3, auto);
+            gap: 24px 32px;
+            justify-items: start;
+          }
+
+          .column-header {
+            font-family: 'Open Sans', sans-serif;
+            font-size: 14px;
+            color: rgba(0, 0, 0, 0.6);
+          }
+
+          .hover-cell watt-segmented-button {
+            background-color: var(--watt-color-neutral-grey-200);
+          }
+
+          .blocks-gap {
+            grid-column: 1 / -1;
+            height: 16px;
+          }
+
+          .start watt-segmented-button { border-radius: 4px 0 0 4px; }
+          .middle watt-segmented-button { border-radius: 0; }
+          .end watt-segmented-button { border-radius: 0 4px 4px 0; }
+        `,
+      ],
+      template: `
+        <div class="page">
+          <div class="section">
+            <div class="section-title">Segmented button</div>
+            <hr class="divider" />
+            <watt-segmented-buttons [formControl]="formControl">
+              <watt-segmented-button value="day">Dag</watt-segmented-button>
+              <watt-segmented-button value="month">Måned</watt-segmented-button>
+              <watt-segmented-button value="year">År</watt-segmented-button>
+              <watt-segmented-button value="all">Alle år</watt-segmented-button>
+            </watt-segmented-buttons>
+          </div>
+
+          <div class="section">
+            <div class="section-title">Building blocks</div>
+            <hr class="divider" />
+            <div class="dashed-border">
+              <div class="blocks-grid">
+                <div class="column-header">Enabled</div>
+                <div class="column-header">Hover</div>
+                <div class="column-header">Disabled</div>
+
+                <div class="start">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div class="start hover-cell">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div class="start">
+                  <watt-segmented-button class="watt-segmented-button--disabled">Label</watt-segmented-button>
+                </div>
+
+                <div class="middle">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div class="middle hover-cell">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div class="middle">
+                  <watt-segmented-button class="watt-segmented-button--disabled">Label</watt-segmented-button>
+                </div>
+
+                <div class="end">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div class="end hover-cell">
+                  <watt-segmented-button>Label</watt-segmented-button>
+                </div>
+                <div class="end">
+                  <watt-segmented-button class="watt-segmented-button--disabled">Label</watt-segmented-button>
+                </div>
+
+                <div class="blocks-gap"></div>
+
+                <div class="start">
+                  <watt-segmented-button class="watt-segmented-button--selected">Label</watt-segmented-button>
+                </div>
+                <div></div>
+                <div class="start">
+                  <watt-segmented-button class="watt-segmented-button--disabled watt-segmented-button--selected">Label</watt-segmented-button>
+                </div>
+
+                <div class="middle">
+                  <watt-segmented-button class="watt-segmented-button--selected">Label</watt-segmented-button>
+                </div>
+                <div></div>
+                <div class="middle">
+                  <watt-segmented-button class="watt-segmented-button--disabled watt-segmented-button--selected">Label</watt-segmented-button>
+                </div>
+
+                <div class="end">
+                  <watt-segmented-button class="watt-segmented-button--selected">Label</watt-segmented-button>
+                </div>
+                <div></div>
+                <div class="end">
+                  <watt-segmented-button class="watt-segmented-button--disabled watt-segmented-button--selected">Label</watt-segmented-button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      `,
+    };
   },
-  template: `
-    <watt-segmented-buttons [formControl]="exampleFormControl">
-      <watt-segmented-button value="day">Day</watt-segmented-button>
-      <watt-segmented-button value="month">Month</watt-segmented-button>
-      <watt-segmented-button value="year">Year</watt-segmented-button>
-      <watt-segmented-button value="all years">All Years</watt-segmented-button>
-    </watt-segmented-buttons>
-    <h5>Form value: {{exampleFormControl.value}}</h5>
-    <div style="display: flex; grid-gap: 10px; margin-top: 20px;">
-      <watt-button (click)="exampleFormControl.disable()">disable</watt-button>
-      <watt-button (click)="exampleFormControl.enable()">enable</watt-button>
-    </div>
-  `,
-});
+};

--- a/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
@@ -31,11 +31,7 @@ const meta: Meta<WattSegmentedButtonsComponent & { disabled: boolean }> = {
       providers: [provideRouter([])],
     }),
     moduleMetadata({
-      imports: [
-        ReactiveFormsModule,
-        WattSegmentedButtonsComponent,
-        WattSegmentedButtonComponent,
-      ],
+      imports: [ReactiveFormsModule, WattSegmentedButtonsComponent, WattSegmentedButtonComponent],
     }),
   ],
   argTypes: {

--- a/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
@@ -16,149 +16,17 @@
  * limitations under the License.
  */
 //#endregion
-import { Component, effect, input, ViewEncapsulation } from '@angular/core';
-import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { provideRouter } from '@angular/router';
 import { Meta, applicationConfig, moduleMetadata, StoryObj } from '@storybook/angular';
 
-import { WattSegmentedButtonsComponent } from '../watt-segmented-buttons.component';
-import { WattSegmentedButtonComponent } from '../watt-segmented-button.component';
+import { WattStorybookSegmentedButtonsShowcaseComponent } from './storybook-segmented-buttons-showcase.component';
 
-const POSITIONS = ['start', 'middle', 'end'] as const;
-type Position = (typeof POSITIONS)[number];
-
-@Component({
-  selector: 'watt-segmented-buttons-showcase',
-  imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
-  encapsulation: ViewEncapsulation.None,
-  styles: `
-    .watt-segmented-buttons-showcase {
-      background: #e5e5e5;
-      padding: 40px;
-      margin: -16px;
-
-      .page {
-        display: flex;
-        flex-direction: column;
-        gap: 24px;
-        max-width: 560px;
-      }
-
-      .section {
-        background: white;
-        border-radius: 12px;
-        padding: 48px 56px;
-      }
-
-      .section-title {
-        font-family: 'Open Sans', sans-serif;
-        font-size: 36px;
-        font-weight: 300;
-        color: rgba(0, 0, 0, 0.87);
-        margin: 0 0 24px;
-      }
-
-      .divider {
-        border: none;
-        border-top: 1px solid var(--watt-color-neutral-grey-300);
-        margin: 0 0 32px;
-      }
-
-      .dashed-border {
-        border: 2px dashed #7c4dff;
-        border-radius: 8px;
-        padding: 24px 40px;
-        margin-top: 8px;
-      }
-
-      .blocks-grid {
-        display: grid;
-        grid-template-columns: repeat(3, auto);
-        gap: 24px 32px;
-        justify-items: start;
-      }
-
-      .column-header {
-        font-family: 'Open Sans', sans-serif;
-        font-size: 14px;
-        color: rgba(0, 0, 0, 0.6);
-      }
-
-      .blocks-gap {
-        grid-column: 1 / -1;
-        height: 16px;
-      }
-    }
-  `,
-  template: `
-    <div class="watt-segmented-buttons-showcase">
-      <div class="page">
-        <div class="section">
-          <div class="section-title">Segmented button</div>
-          <hr class="divider" />
-          <watt-segmented-buttons [formControl]="overviewControl">
-            <watt-segmented-button value="day">Dag</watt-segmented-button>
-            <watt-segmented-button value="month">Måned</watt-segmented-button>
-            <watt-segmented-button value="year">År</watt-segmented-button>
-            <watt-segmented-button value="all">Alle år</watt-segmented-button>
-          </watt-segmented-buttons>
-        </div>
-
-        <div class="section">
-          <div class="section-title">Building blocks</div>
-          <hr class="divider" />
-          <div class="dashed-border">
-            <div class="blocks-grid">
-              <div class="column-header">Enabled</div>
-              <div class="column-header">Hover</div>
-              <div class="column-header">Disabled</div>
-
-              @for (position of positions; track position) {
-                <watt-segmented-button [class]="position">Label</watt-segmented-button>
-                <watt-segmented-button [class]="position + ' hover'">Label</watt-segmented-button>
-                <watt-segmented-button [class]="position + ' disabled'"
-                  >Label</watt-segmented-button
-                >
-              }
-
-              <div class="blocks-gap"></div>
-
-              @for (position of positions; track position) {
-                <watt-segmented-button [class]="position + ' selected'"
-                  >Label</watt-segmented-button
-                >
-                <div></div>
-                <watt-segmented-button [class]="position + ' disabled selected'"
-                  >Label</watt-segmented-button
-                >
-              }
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  `,
-})
-class WattSegmentedButtonsShowcase {
-  disabled = input(false);
-
-  positions = POSITIONS;
-  overviewControl = new FormControl('day');
-
-  constructor() {
-    effect(() => {
-      if (this.disabled()) this.overviewControl.disable();
-      else this.overviewControl.enable();
-    });
-  }
-}
-
-const meta: Meta<WattSegmentedButtonsShowcase> = {
+const meta: Meta<WattStorybookSegmentedButtonsShowcaseComponent> = {
   title: 'Components/Segmented buttons',
-  component: WattSegmentedButtonsShowcase,
+  component: WattStorybookSegmentedButtonsShowcaseComponent,
   decorators: [
     applicationConfig({ providers: [provideRouter([])] }),
-    moduleMetadata({ imports: [WattSegmentedButtonsShowcase] }),
+    moduleMetadata({ imports: [WattStorybookSegmentedButtonsShowcaseComponent] }),
   ],
   argTypes: {
     disabled: {
@@ -172,11 +40,11 @@ const meta: Meta<WattSegmentedButtonsShowcase> = {
 };
 export default meta;
 
-type Story = StoryObj<WattSegmentedButtonsShowcase>;
+type Story = StoryObj<WattStorybookSegmentedButtonsShowcaseComponent>;
 
 export const Overview: Story = {
   render: (args) => ({
     props: args,
-    template: `<watt-segmented-buttons-showcase [disabled]="disabled" />`,
+    template: `<watt-storybook-segmented-buttons-showcase [disabled]="disabled" />`,
   }),
 };

--- a/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
+++ b/libs/watt/package/segmented-buttons/+storybook/watt-segmented-buttons.component.stories.ts
@@ -116,15 +116,21 @@ type Position = (typeof POSITIONS)[number];
               @for (position of positions; track position) {
                 <watt-segmented-button [class]="position">Label</watt-segmented-button>
                 <watt-segmented-button [class]="position + ' hover'">Label</watt-segmented-button>
-                <watt-segmented-button [class]="position + ' disabled'">Label</watt-segmented-button>
+                <watt-segmented-button [class]="position + ' disabled'"
+                  >Label</watt-segmented-button
+                >
               }
 
               <div class="blocks-gap"></div>
 
               @for (position of positions; track position) {
-                <watt-segmented-button [class]="position + ' selected'">Label</watt-segmented-button>
+                <watt-segmented-button [class]="position + ' selected'"
+                  >Label</watt-segmented-button
+                >
                 <div></div>
-                <watt-segmented-button [class]="position + ' disabled selected'">Label</watt-segmented-button>
+                <watt-segmented-button [class]="position + ' disabled selected'"
+                  >Label</watt-segmented-button
+                >
               }
             </div>
           </div>

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -16,16 +16,129 @@
  * limitations under the License.
  */
 //#endregion
-import { Component, input, TemplateRef, viewChild } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  input,
+  inject,
+  ElementRef,
+} from '@angular/core';
+import { RouterLink, RouterLinkActive } from '@angular/router';
 
 @Component({
   selector: 'watt-segmented-button',
-  template: ` <ng-template>
-    <ng-content />
-  </ng-template>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, RouterLinkActive],
+  styles: `
+    :host {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 6.5rem;
+      height: 2.5rem;
+      padding: 0 0.75rem;
+      border: 1px solid var(--watt-color-neutral-grey-700);
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--watt-on-light-high-emphasis);
+      cursor: pointer;
+      user-select: none;
+      box-sizing: border-box;
+
+      a, button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        color: inherit;
+        text-decoration: none;
+        background: none;
+        border: none;
+        font: inherit;
+        cursor: inherit;
+        padding: 0;
+      }
+
+      &:focus-visible {
+        outline: 2px solid var(--watt-color-primary);
+        outline-offset: -2px;
+      }
+
+      &:hover:not(.watt-segmented-button--selected):not(:has(a.active)):not(.watt-segmented-button--disabled),
+      &:focus-within:not(.watt-segmented-button--selected):not(:has(a.active)):not(.watt-segmented-button--disabled) {
+        background-color: var(--watt-color-neutral-grey-200);
+      }
+
+      &.watt-segmented-button--selected,
+      &:has(a.active) {
+        background-color: var(--watt-color-primary);
+        color: var(--watt-color-neutral-white);
+      }
+
+      &.watt-segmented-button--disabled {
+        cursor: default;
+        background-color: var(--watt-color-neutral-grey-200);
+        color: rgba(0, 0, 0, 0.26); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+
+        &.watt-segmented-button--selected {
+          background-color: var(--watt-color-neutral-grey-400);
+          color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+        }
+      }
+
+      &.watt-segmented-button--first {
+        border-right-width: 0;
+        border-radius: 4px 0 0 4px;
+      }
+
+      &.watt-segmented-button--middle {
+        border-right-width: 0;
+        border-radius: 0;
+      }
+
+      &.watt-segmented-button--last {
+        border-radius: 0 4px 4px 0;
+      }
+    }
+  `,
+  host: {
+    '[class.watt-segmented-button--selected]': 'selected',
+    '[class.watt-segmented-button--disabled]': 'disabled',
+    '[class.watt-segmented-button--first]': 'position === "first"',
+    '[class.watt-segmented-button--middle]': 'position === "middle"',
+    '[class.watt-segmented-button--last]': 'position === "last"',
+  },
+  template: `
+    @if (link()) {
+      <a
+        [routerLink]="link()"
+        queryParamsHandling="merge"
+        routerLinkActive
+        #rla="routerLinkActive"
+        [class.active]="rla.isActive"
+      >
+        <ng-content />
+      </a>
+    } @else {
+      <button type="button" [disabled]="disabled" (click)="onClick()"><ng-content /></button>
+    }
+  `,
 })
 export class WattSegmentedButtonComponent {
-  templateRef = viewChild.required<TemplateRef<unknown>>(TemplateRef);
   value = input<string>();
   link = input<string>();
+
+  selected = false;
+  disabled = false;
+  position: 'first' | 'middle' | 'last' | 'standalone' = 'standalone';
+
+  private readonly elementRef = inject(ElementRef);
+
+  onClick(): void {
+    if (this.disabled) return;
+    this.elementRef.nativeElement.dispatchEvent(
+      new CustomEvent('segmentSelect', { bubbles: true, detail: this.value() })
+    );
+  }
 }

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -85,13 +85,20 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
     :host(.disabled) button {
       cursor: default;
       background-color: var(--watt-color-neutral-grey-200);
-      color: rgba(0, 0, 0, 0.26); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+      color: rgba(
+        0,
+        0,
+        0,
+        0.26
+      ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
     }
 
     :host(.disabled.selected) a,
     :host(.disabled.selected) button {
       background-color: var(--watt-color-neutral-grey-400);
-      color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+      color: var(
+        --watt-on-light-high-emphasis
+      ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
     }
 
     :host(.start) a,

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -38,7 +38,8 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       display: flex;
     }
 
-    a, button {
+    a,
+    button {
       display: flex;
       align-items: center;
       justify-content: center;
@@ -83,7 +84,12 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       &[aria-disabled='true'] {
         cursor: default;
         background-color: var(--watt-color-neutral-grey-200);
-        color: rgba(0, 0, 0, 0.26); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+        color: rgba(
+          0,
+          0,
+          0,
+          0.26
+        ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
 
         &:hover,
         &:focus-visible {
@@ -92,7 +98,9 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
 
         &[aria-checked='true'] {
           background-color: var(--watt-color-neutral-grey-400);
-          color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+          color: var(
+            --watt-on-light-high-emphasis
+          ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
 
           &:hover,
           &:focus-visible {

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -16,13 +16,7 @@
  * limitations under the License.
  */
 //#endregion
-import {
-  Component,
-  ChangeDetectionStrategy,
-  input,
-  inject,
-  ElementRef,
-} from '@angular/core';
+import { Component, ChangeDetectionStrategy, input, inject, ElementRef } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
 @Component({
@@ -34,7 +28,8 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
       display: flex;
     }
 
-    a, button {
+    a,
+    button {
       display: flex;
       align-items: center;
       justify-content: center;
@@ -81,7 +76,12 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
     :host(.watt-segmented-button--disabled) button {
       cursor: default;
       background-color: var(--watt-color-neutral-grey-200);
-      color: rgba(0, 0, 0, 0.26); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+      color: rgba(
+        0,
+        0,
+        0,
+        0.26
+      ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
 
       &:hover,
       &:focus-visible {
@@ -92,7 +92,9 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
     :host(.watt-segmented-button--disabled.watt-segmented-button--selected) a,
     :host(.watt-segmented-button--disabled.watt-segmented-button--selected) button {
       background-color: var(--watt-color-neutral-grey-400);
-      color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+      color: var(
+        --watt-on-light-high-emphasis
+      ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
 
       &:hover,
       &:focus-visible {

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -81,7 +81,8 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
         }
       }
 
-      &[aria-disabled='true'] {
+      &[aria-disabled='true'],
+      &:disabled {
         cursor: default;
         background-color: var(--watt-color-neutral-grey-200);
         color: rgba(

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -57,66 +57,24 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       user-select: none;
       box-sizing: border-box;
       font-family: inherit;
-
-      &:hover,
-      &:focus-visible {
-        background-color: var(--watt-color-neutral-grey-200);
-      }
-
-      &:focus-visible {
-        outline: none;
-        box-shadow: 0 0 0 2px var(--watt-color-primary-dark);
-        position: relative;
-        z-index: 1;
-      }
-
-      &[aria-checked='true'],
-      &.active {
-        background-color: var(--watt-color-primary);
-        color: var(--watt-color-neutral-white);
-
-        &:hover,
-        &:focus-visible {
-          background-color: var(--watt-color-primary);
-        }
-      }
-
-      &[aria-disabled='true'],
-      &:disabled {
-        cursor: default;
-        background-color: var(--watt-color-neutral-grey-200);
-        color: rgba(
-          0,
-          0,
-          0,
-          0.26
-        ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
-
-        &:hover,
-        &:focus-visible {
-          background-color: var(--watt-color-neutral-grey-200);
-        }
-
-        &[aria-checked='true'] {
-          background-color: var(--watt-color-neutral-grey-400);
-          color: var(
-            --watt-on-light-high-emphasis
-          ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
-
-          &:hover,
-          &:focus-visible {
-            background-color: var(--watt-color-neutral-grey-400);
-          }
-        }
-      }
     }
 
-    /* Documentation aliases — also used by the parent group to apply position. */
+    a:hover,
+    button:hover,
     :host(.hover) a,
     :host(.hover) button {
       background-color: var(--watt-color-neutral-grey-200);
     }
 
+    a:focus-visible,
+    button:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 2px var(--watt-color-primary-dark);
+      position: relative;
+      z-index: 1;
+    }
+
+    a.active,
     :host(.selected) a,
     :host(.selected) button {
       background-color: var(--watt-color-primary);
@@ -127,20 +85,13 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
     :host(.disabled) button {
       cursor: default;
       background-color: var(--watt-color-neutral-grey-200);
-      color: rgba(
-        0,
-        0,
-        0,
-        0.26
-      ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+      color: rgba(0, 0, 0, 0.26); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
     }
 
     :host(.disabled.selected) a,
     :host(.disabled.selected) button {
       background-color: var(--watt-color-neutral-grey-400);
-      color: var(
-        --watt-on-light-high-emphasis
-      ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+      color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
     }
 
     :host(.start) a,

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -16,20 +16,29 @@
  * limitations under the License.
  */
 //#endregion
-import { Component, ChangeDetectionStrategy, input, inject, ElementRef } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  input,
+  signal,
+  inject,
+  ElementRef,
+} from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { RouterLink, RouterLinkActive } from '@angular/router';
+
+export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standalone';
 
 @Component({
   selector: 'watt-segmented-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink, RouterLinkActive],
+  imports: [RouterLink, RouterLinkActive, NgTemplateOutlet],
   styles: `
     :host {
       display: flex;
     }
 
-    a,
-    button {
+    a, button {
       display: flex;
       align-items: center;
       justify-content: center;
@@ -37,6 +46,7 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
       height: 2.5rem;
       padding: 0 0.75rem;
       border: 1px solid var(--watt-color-neutral-grey-700);
+      border-radius: 4px;
       font-size: 1rem;
       font-weight: 600;
       color: var(--watt-on-light-high-emphasis);
@@ -58,47 +68,37 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
         position: relative;
         z-index: 1;
       }
-    }
 
-    a.active,
-    :host(.watt-segmented-button--selected) a,
-    :host(.watt-segmented-button--selected) button {
-      background-color: var(--watt-color-primary);
-      color: var(--watt-color-neutral-white);
-
-      &:hover,
-      &:focus-visible {
+      &[aria-checked='true'],
+      &.active {
         background-color: var(--watt-color-primary);
+        color: var(--watt-color-neutral-white);
+
+        &:hover,
+        &:focus-visible {
+          background-color: var(--watt-color-primary);
+        }
       }
-    }
 
-    :host(.watt-segmented-button--disabled) a,
-    :host(.watt-segmented-button--disabled) button {
-      cursor: default;
-      background-color: var(--watt-color-neutral-grey-200);
-      color: rgba(
-        0,
-        0,
-        0,
-        0.26
-      ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
-
-      &:hover,
-      &:focus-visible {
+      &[aria-disabled='true'] {
+        cursor: default;
         background-color: var(--watt-color-neutral-grey-200);
-      }
-    }
+        color: rgba(0, 0, 0, 0.26); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
 
-    :host(.watt-segmented-button--disabled.watt-segmented-button--selected) a,
-    :host(.watt-segmented-button--disabled.watt-segmented-button--selected) button {
-      background-color: var(--watt-color-neutral-grey-400);
-      color: var(
-        --watt-on-light-high-emphasis
-      ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+        &:hover,
+        &:focus-visible {
+          background-color: var(--watt-color-neutral-grey-200);
+        }
 
-      &:hover,
-      &:focus-visible {
-        background-color: var(--watt-color-neutral-grey-400);
+        &[aria-checked='true'] {
+          background-color: var(--watt-color-neutral-grey-400);
+          color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+
+          &:hover,
+          &:focus-visible {
+            background-color: var(--watt-color-neutral-grey-400);
+          }
+        }
       }
     }
 
@@ -120,25 +120,39 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
     }
   `,
   host: {
-    '[class.watt-segmented-button--selected]': 'selected',
-    '[class.watt-segmented-button--disabled]': 'disabled',
-    '[class.watt-segmented-button--first]': 'position === "first"',
-    '[class.watt-segmented-button--middle]': 'position === "middle"',
-    '[class.watt-segmented-button--last]': 'position === "last"',
+    '[class.watt-segmented-button--first]': 'position() === "first"',
+    '[class.watt-segmented-button--middle]': 'position() === "middle"',
+    '[class.watt-segmented-button--last]': 'position() === "last"',
   },
   template: `
+    <ng-template #labelTemplate><ng-content /></ng-template>
+
     @if (link()) {
       <a
-        [routerLink]="link()"
+        role="radio"
+        [routerLink]="disabled() ? null : link()"
         queryParamsHandling="merge"
         routerLinkActive
         #rla="routerLinkActive"
         [class.active]="rla.isActive"
+        [attr.aria-checked]="selected() || rla.isActive"
+        [attr.aria-disabled]="disabled() ? true : null"
+        [attr.tabindex]="tabIndex()"
       >
-        <ng-content />
+        <ng-container *ngTemplateOutlet="labelTemplate" />
       </a>
     } @else {
-      <button type="button" [disabled]="disabled" (click)="onClick()"><ng-content /></button>
+      <button
+        type="button"
+        role="radio"
+        [attr.aria-checked]="selected()"
+        [attr.aria-disabled]="disabled() ? true : null"
+        [attr.tabindex]="tabIndex()"
+        [disabled]="disabled()"
+        (click)="onClick()"
+      >
+        <ng-container *ngTemplateOutlet="labelTemplate" />
+      </button>
     }
   `,
 })
@@ -146,16 +160,25 @@ export class WattSegmentedButtonComponent {
   value = input<string>();
   link = input<string>();
 
-  selected = false;
-  disabled = false;
-  position: 'first' | 'middle' | 'last' | 'standalone' = 'standalone';
+  selected = signal(false);
+  disabled = signal(false);
+  position = signal<WattSegmentedButtonPosition>('standalone');
+  tabIndex = signal<number>(0);
 
   private readonly elementRef = inject(ElementRef);
 
+  focus(): void {
+    const host = this.elementRef.nativeElement as HTMLElement;
+    const interactive = host.querySelector<HTMLElement>('a, button');
+    interactive?.focus();
+  }
+
   onClick(): void {
-    if (this.disabled) return;
+    if (this.disabled()) return;
+    const value = this.value();
+    if (value === undefined) return;
     this.elementRef.nativeElement.dispatchEvent(
-      new CustomEvent('segmentSelect', { bubbles: true, detail: this.value() })
+      new CustomEvent('segmentSelect', { bubbles: true, detail: value })
     );
   }
 }

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -72,7 +72,8 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       }
 
       &[aria-checked='true'],
-      &.active {
+      &.active,
+      :host(.selected) & {
         background-color: var(--watt-color-primary);
         color: var(--watt-color-neutral-white);
 
@@ -83,7 +84,8 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       }
 
       &[aria-disabled='true'],
-      &:disabled {
+      &:disabled,
+      :host(.disabled) & {
         cursor: default;
         background-color: var(--watt-color-neutral-grey-200);
         color: rgba(
@@ -97,18 +99,21 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
         &:focus-visible {
           background-color: var(--watt-color-neutral-grey-200);
         }
+      }
+    }
 
-        &[aria-checked='true'] {
-          background-color: var(--watt-color-neutral-grey-400);
-          color: var(
-            --watt-on-light-high-emphasis
-          ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+    :host(.disabled.selected) a,
+    :host(.disabled.selected) button,
+    :host(.disabled) a[aria-checked='true'],
+    :host(.disabled) button[aria-checked='true'],
+    a[aria-disabled='true'][aria-checked='true'],
+    button:disabled[aria-checked='true'] {
+      background-color: var(--watt-color-neutral-grey-400);
+      color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
 
-          &:hover,
-          &:focus-visible {
-            background-color: var(--watt-color-neutral-grey-400);
-          }
-        }
+      &:hover,
+      &:focus-visible {
+        background-color: var(--watt-color-neutral-grey-400);
       }
     }
 

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -59,8 +59,7 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       font-family: inherit;
 
       &:hover,
-      &:focus-visible,
-      :host(.hover) & {
+      &:focus-visible {
         background-color: var(--watt-color-neutral-grey-200);
       }
 
@@ -72,8 +71,7 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       }
 
       &[aria-checked='true'],
-      &.active,
-      :host(.selected) & {
+      &.active {
         background-color: var(--watt-color-primary);
         color: var(--watt-color-neutral-white);
 
@@ -84,8 +82,7 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       }
 
       &[aria-disabled='true'],
-      &:disabled,
-      :host(.disabled) & {
+      &:disabled {
         cursor: default;
         background-color: var(--watt-color-neutral-grey-200);
         color: rgba(
@@ -99,24 +96,44 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
         &:focus-visible {
           background-color: var(--watt-color-neutral-grey-200);
         }
+
+        &[aria-checked='true'] {
+          background-color: var(--watt-color-neutral-grey-400);
+          color: var(
+            --watt-on-light-high-emphasis
+          ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+
+          &:hover,
+          &:focus-visible {
+            background-color: var(--watt-color-neutral-grey-400);
+          }
+        }
       }
     }
 
-    :host(.disabled.selected) a,
-    :host(.disabled.selected) button,
-    :host(.disabled) a[aria-checked='true'],
-    :host(.disabled) button[aria-checked='true'],
-    a[aria-disabled='true'][aria-checked='true'],
-    button:disabled[aria-checked='true'] {
-      background-color: var(--watt-color-neutral-grey-400);
-      color: var(
-        --watt-on-light-high-emphasis
-      ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+    /* Documentation aliases — flat selectors so they aren't affected by CSS nesting limitations */
+    :host(.hover) a,
+    :host(.hover) button {
+      background-color: var(--watt-color-neutral-grey-200);
+    }
 
-      &:hover,
-      &:focus-visible {
-        background-color: var(--watt-color-neutral-grey-400);
-      }
+    :host(.selected) a,
+    :host(.selected) button {
+      background-color: var(--watt-color-primary);
+      color: var(--watt-color-neutral-white);
+    }
+
+    :host(.disabled) a,
+    :host(.disabled) button {
+      cursor: default;
+      background-color: var(--watt-color-neutral-grey-200);
+      color: rgba(0, 0, 0, 0.26); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+    }
+
+    :host(.disabled.selected) a,
+    :host(.disabled.selected) button {
+      background-color: var(--watt-color-neutral-grey-400);
+      color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
     }
 
     :host(.watt-segmented-button--first) a,

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -59,7 +59,8 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       font-family: inherit;
 
       &:hover,
-      &:focus-visible {
+      &:focus-visible,
+      :host(.hover) & {
         background-color: var(--watt-color-neutral-grey-200);
       }
 
@@ -112,19 +113,25 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
     }
 
     :host(.watt-segmented-button--first) a,
-    :host(.watt-segmented-button--first) button {
+    :host(.watt-segmented-button--first) button,
+    :host(.start) a,
+    :host(.start) button {
       border-right-width: 0;
       border-radius: 4px 0 0 4px;
     }
 
     :host(.watt-segmented-button--middle) a,
-    :host(.watt-segmented-button--middle) button {
+    :host(.watt-segmented-button--middle) button,
+    :host(.middle) a,
+    :host(.middle) button {
       border-right-width: 0;
       border-radius: 0;
     }
 
     :host(.watt-segmented-button--last) a,
-    :host(.watt-segmented-button--last) button {
+    :host(.watt-segmented-button--last) button,
+    :host(.end) a,
+    :host(.end) button {
       border-radius: 0 4px 4px 0;
     }
   `,

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -85,12 +85,7 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       &:disabled {
         cursor: default;
         background-color: var(--watt-color-neutral-grey-200);
-        color: rgba(
-          0,
-          0,
-          0,
-          0.26
-        ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+        color: rgba(0, 0, 0, 0.26); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
 
         &:hover,
         &:focus-visible {
@@ -99,9 +94,7 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
 
         &[aria-checked='true'] {
           background-color: var(--watt-color-neutral-grey-400);
-          color: var(
-            --watt-on-light-high-emphasis
-          ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+          color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
 
           &:hover,
           &:focus-visible {
@@ -111,7 +104,7 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       }
     }
 
-    /* Documentation aliases — flat selectors so they aren't affected by CSS nesting limitations */
+    /* Documentation aliases — also used by the parent group to apply position. */
     :host(.hover) a,
     :host(.hover) button {
       background-color: var(--watt-color-neutral-grey-200);
@@ -143,34 +136,23 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
     }
 
-    :host(.watt-segmented-button--first) a,
-    :host(.watt-segmented-button--first) button,
     :host(.start) a,
     :host(.start) button {
       border-right-width: 0;
       border-radius: 4px 0 0 4px;
     }
 
-    :host(.watt-segmented-button--middle) a,
-    :host(.watt-segmented-button--middle) button,
     :host(.middle) a,
     :host(.middle) button {
       border-right-width: 0;
       border-radius: 0;
     }
 
-    :host(.watt-segmented-button--last) a,
-    :host(.watt-segmented-button--last) button,
     :host(.end) a,
     :host(.end) button {
       border-radius: 0 4px 4px 0;
     }
   `,
-  host: {
-    '[class.watt-segmented-button--first]': 'position() === "first"',
-    '[class.watt-segmented-button--middle]': 'position() === "middle"',
-    '[class.watt-segmented-button--last]': 'position() === "last"',
-  },
   template: `
     <ng-template #labelTemplate><ng-content /></ng-template>
 
@@ -208,10 +190,9 @@ export class WattSegmentedButtonComponent {
 
   selected = signal(false);
   disabled = signal(false);
-  position = signal<WattSegmentedButtonPosition>('standalone');
   tabIndex = signal(0);
 
-  private readonly elementRef = inject(ElementRef);
+  readonly elementRef = inject(ElementRef);
 
   focus(): void {
     const host = this.elementRef.nativeElement as HTMLElement;

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -85,7 +85,12 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
       &:disabled {
         cursor: default;
         background-color: var(--watt-color-neutral-grey-200);
-        color: rgba(0, 0, 0, 0.26); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+        color: rgba(
+          0,
+          0,
+          0,
+          0.26
+        ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
 
         &:hover,
         &:focus-visible {
@@ -94,7 +99,9 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
 
         &[aria-checked='true'] {
           background-color: var(--watt-color-neutral-grey-400);
-          color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+          color: var(
+            --watt-on-light-high-emphasis
+          ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
 
           &:hover,
           &:focus-visible {

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -32,6 +32,10 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
   styles: `
     :host {
       display: flex;
+    }
+
+    a, button {
+      display: flex;
       align-items: center;
       justify-content: center;
       min-width: 6.5rem;
@@ -41,65 +45,76 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
       font-size: 1rem;
       font-weight: 600;
       color: var(--watt-on-light-high-emphasis);
+      background: none;
+      text-decoration: none;
       cursor: pointer;
       user-select: none;
       box-sizing: border-box;
+      font-family: inherit;
 
-      a, button {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        height: 100%;
-        color: inherit;
-        text-decoration: none;
-        background: none;
-        border: none;
-        font: inherit;
-        cursor: inherit;
-        padding: 0;
+      &:hover,
+      &:focus-visible {
+        background-color: var(--watt-color-neutral-grey-200);
       }
 
       &:focus-visible {
-        outline: 2px solid var(--watt-color-primary);
-        outline-offset: -2px;
+        outline: none;
+        box-shadow: 0 0 0 2px var(--watt-color-primary-dark);
+        position: relative;
+        z-index: 1;
       }
+    }
 
-      &:hover:not(.watt-segmented-button--selected):not(:has(a.active)):not(.watt-segmented-button--disabled),
-      &:focus-within:not(.watt-segmented-button--selected):not(:has(a.active)):not(.watt-segmented-button--disabled) {
-        background-color: var(--watt-color-neutral-grey-200);
-      }
+    a.active,
+    :host(.watt-segmented-button--selected) a,
+    :host(.watt-segmented-button--selected) button {
+      background-color: var(--watt-color-primary);
+      color: var(--watt-color-neutral-white);
 
-      &.watt-segmented-button--selected,
-      &:has(a.active) {
+      &:hover,
+      &:focus-visible {
         background-color: var(--watt-color-primary);
-        color: var(--watt-color-neutral-white);
       }
+    }
 
-      &.watt-segmented-button--disabled {
-        cursor: default;
+    :host(.watt-segmented-button--disabled) a,
+    :host(.watt-segmented-button--disabled) button {
+      cursor: default;
+      background-color: var(--watt-color-neutral-grey-200);
+      color: rgba(0, 0, 0, 0.26); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+
+      &:hover,
+      &:focus-visible {
         background-color: var(--watt-color-neutral-grey-200);
-        color: rgba(0, 0, 0, 0.26); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
-
-        &.watt-segmented-button--selected {
-          background-color: var(--watt-color-neutral-grey-400);
-          color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
-        }
       }
+    }
 
-      &.watt-segmented-button--first {
-        border-right-width: 0;
-        border-radius: 4px 0 0 4px;
-      }
+    :host(.watt-segmented-button--disabled.watt-segmented-button--selected) a,
+    :host(.watt-segmented-button--disabled.watt-segmented-button--selected) button {
+      background-color: var(--watt-color-neutral-grey-400);
+      color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
 
-      &.watt-segmented-button--middle {
-        border-right-width: 0;
-        border-radius: 0;
+      &:hover,
+      &:focus-visible {
+        background-color: var(--watt-color-neutral-grey-400);
       }
+    }
 
-      &.watt-segmented-button--last {
-        border-radius: 0 4px 4px 0;
-      }
+    :host(.watt-segmented-button--first) a,
+    :host(.watt-segmented-button--first) button {
+      border-right-width: 0;
+      border-radius: 4px 0 0 4px;
+    }
+
+    :host(.watt-segmented-button--middle) a,
+    :host(.watt-segmented-button--middle) button {
+      border-right-width: 0;
+      border-radius: 0;
+    }
+
+    :host(.watt-segmented-button--last) a,
+    :host(.watt-segmented-button--last) button {
+      border-radius: 0 4px 4px 0;
     }
   `,
   host: {

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -109,7 +109,9 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
     a[aria-disabled='true'][aria-checked='true'],
     button:disabled[aria-checked='true'] {
       background-color: var(--watt-color-neutral-grey-400);
-      color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+      color: var(
+        --watt-on-light-high-emphasis
+      ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
 
       &:hover,
       &:focus-visible {

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -154,7 +154,6 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
         type="button"
         role="radio"
         [attr.aria-checked]="selected()"
-        [attr.aria-disabled]="disabled() ? true : null"
         [attr.tabindex]="tabIndex()"
         [disabled]="disabled()"
         (click)="onClick()"
@@ -171,7 +170,7 @@ export class WattSegmentedButtonComponent {
   selected = signal(false);
   disabled = signal(false);
   position = signal<WattSegmentedButtonPosition>('standalone');
-  tabIndex = signal<number>(0);
+  tabIndex = signal(0);
 
   private readonly elementRef = inject(ElementRef);
 

--- a/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-button.component.ts
@@ -127,13 +127,20 @@ export type WattSegmentedButtonPosition = 'first' | 'middle' | 'last' | 'standal
     :host(.disabled) button {
       cursor: default;
       background-color: var(--watt-color-neutral-grey-200);
-      color: rgba(0, 0, 0, 0.26); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+      color: rgba(
+        0,
+        0,
+        0,
+        0.26
+      ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
     }
 
     :host(.disabled.selected) a,
     :host(.disabled.selected) button {
       background-color: var(--watt-color-neutral-grey-400);
-      color: var(--watt-on-light-high-emphasis); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
+      color: var(
+        --watt-on-light-high-emphasis
+      ); /* Not part of Watt foundations — see Figma note on disabled segmented buttons */
     }
 
     :host(.watt-segmented-button--first) a,

--- a/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.spec.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.spec.ts
@@ -1,0 +1,382 @@
+//#region License
+/**
+ * @license
+ * Copyright 2020 Energinet DataHub A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License2");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//#endregion
+import { Component } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { provideRouter } from '@angular/router';
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
+import { WattSegmentedButtonComponent } from './watt-segmented-button.component';
+import { WattSegmentedButtonsComponent } from './watt-segmented-buttons.component';
+
+describe(WattSegmentedButtonsComponent, () => {
+  describe('content projection', () => {
+    it('projects content inside the button variant', async () => {
+      await render(
+        `
+          <watt-segmented-buttons>
+            <watt-segmented-button value="day">Day label</watt-segmented-button>
+          </watt-segmented-buttons>
+        `,
+        { imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent] }
+      );
+
+      expect(screen.getByRole('radio', { name: 'Day label' })).toBeInTheDocument();
+    });
+
+    it('projects content inside the link variant', async () => {
+      await render(
+        `
+          <watt-segmented-buttons>
+            <watt-segmented-button link="/day">Day link</watt-segmented-button>
+          </watt-segmented-buttons>
+        `,
+        {
+          imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent],
+          providers: [provideRouter([])],
+        }
+      );
+
+      const link = screen.getByRole('radio', { name: 'Day link' });
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveAttribute('href', '/day');
+    });
+
+    it('projects content in both variants when rendered side by side', async () => {
+      await render(
+        `
+          <watt-segmented-buttons>
+            <watt-segmented-button value="one">One</watt-segmented-button>
+            <watt-segmented-button link="/two">Two</watt-segmented-button>
+            <watt-segmented-button value="three">Three</watt-segmented-button>
+          </watt-segmented-buttons>
+        `,
+        {
+          imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent],
+          providers: [provideRouter([])],
+        }
+      );
+
+      expect(screen.getByRole('radio', { name: 'One' })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'Two' })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'Three' })).toBeInTheDocument();
+    });
+  });
+
+  describe('selection', () => {
+    async function setup(initialValue: string | null = 'day') {
+      @Component({
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
+        template: `
+          <watt-segmented-buttons [formControl]="control">
+            <watt-segmented-button value="day">Day</watt-segmented-button>
+            <watt-segmented-button value="month">Month</watt-segmented-button>
+            <watt-segmented-button value="year">Year</watt-segmented-button>
+          </watt-segmented-buttons>
+        `,
+      })
+      class TestHostComponent {
+        control = new FormControl(initialValue);
+      }
+
+      const { fixture } = await render(TestHostComponent);
+      return { host: fixture.componentInstance };
+    }
+
+    it('marks the initially selected button as checked', async () => {
+      await setup('month');
+
+      expect(screen.getByRole('radio', { name: 'Day' })).toHaveAttribute(
+        'aria-checked',
+        'false'
+      );
+      expect(screen.getByRole('radio', { name: 'Month' })).toHaveAttribute(
+        'aria-checked',
+        'true'
+      );
+      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute(
+        'aria-checked',
+        'false'
+      );
+    });
+
+    it('updates the form control when clicking a button', async () => {
+      const { host } = await setup('day');
+
+      await userEvent.click(screen.getByRole('radio', { name: 'Year' }));
+
+      expect(host.control.value).toBe('year');
+      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute(
+        'aria-checked',
+        'true'
+      );
+    });
+
+    it('does not emit when a button has no value', async () => {
+      @Component({
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
+        template: `
+          <watt-segmented-buttons [formControl]="control">
+            <watt-segmented-button value="keep">Keep</watt-segmented-button>
+            <watt-segmented-button>No value</watt-segmented-button>
+          </watt-segmented-buttons>
+        `,
+      })
+      class TestHostComponent {
+        control = new FormControl('keep');
+      }
+
+      const { fixture } = await render(TestHostComponent);
+
+      await userEvent.click(screen.getByRole('radio', { name: 'No value' }));
+
+      expect(fixture.componentInstance.control.value).toBe('keep');
+    });
+  });
+
+  describe('disabled state', () => {
+    it('marks all buttons with aria-disabled when the group is disabled', async () => {
+      @Component({
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
+        template: `
+          <watt-segmented-buttons [formControl]="control">
+            <watt-segmented-button value="day">Day</watt-segmented-button>
+            <watt-segmented-button value="month">Month</watt-segmented-button>
+          </watt-segmented-buttons>
+        `,
+      })
+      class TestHostComponent {
+        control = new FormControl({ value: 'day', disabled: true });
+      }
+
+      await render(TestHostComponent);
+
+      expect(screen.getByRole('radio', { name: 'Day' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+      expect(screen.getByRole('radio', { name: 'Month' })).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+    });
+
+    it('does not change selection when clicking a disabled group', async () => {
+      @Component({
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
+        template: `
+          <watt-segmented-buttons [formControl]="control">
+            <watt-segmented-button value="day">Day</watt-segmented-button>
+            <watt-segmented-button value="month">Month</watt-segmented-button>
+          </watt-segmented-buttons>
+        `,
+      })
+      class TestHostComponent {
+        control = new FormControl({ value: 'day', disabled: true });
+      }
+
+      const { fixture } = await render(TestHostComponent);
+
+      await userEvent.click(screen.getByRole('radio', { name: 'Month' }));
+
+      expect(fixture.componentInstance.control.value).toBe('day');
+    });
+
+    it('removes disabled link from tab order and prevents navigation', async () => {
+      @Component({
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
+        template: `
+          <watt-segmented-buttons [formControl]="control">
+            <watt-segmented-button link="/day">Day</watt-segmented-button>
+          </watt-segmented-buttons>
+        `,
+      })
+      class TestHostComponent {
+        control = new FormControl({ value: null, disabled: true });
+      }
+
+      await render(TestHostComponent, { providers: [provideRouter([])] });
+
+      const link = screen.getByRole('radio', { name: 'Day' });
+      expect(link).toHaveAttribute('tabindex', '-1');
+      expect(link).toHaveAttribute('aria-disabled', 'true');
+      expect(link).not.toHaveAttribute('href');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('exposes the group as a radiogroup', async () => {
+      await render(
+        `
+          <watt-segmented-buttons>
+            <watt-segmented-button value="day">Day</watt-segmented-button>
+            <watt-segmented-button value="month">Month</watt-segmented-button>
+          </watt-segmented-buttons>
+        `,
+        { imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent] }
+      );
+
+      expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+      expect(screen.getAllByRole('radio')).toHaveLength(2);
+    });
+
+    it('uses roving tabindex so only the selected button is in the tab order', async () => {
+      @Component({
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
+        template: `
+          <watt-segmented-buttons [formControl]="control">
+            <watt-segmented-button value="day">Day</watt-segmented-button>
+            <watt-segmented-button value="month">Month</watt-segmented-button>
+            <watt-segmented-button value="year">Year</watt-segmented-button>
+          </watt-segmented-buttons>
+        `,
+      })
+      class TestHostComponent {
+        control = new FormControl('month');
+      }
+
+      await render(TestHostComponent);
+
+      expect(screen.getByRole('radio', { name: 'Day' })).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByRole('radio', { name: 'Month' })).toHaveAttribute('tabindex', '0');
+      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    async function setup(initialValue: string | null = 'day') {
+      @Component({
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
+        template: `
+          <watt-segmented-buttons [formControl]="control">
+            <watt-segmented-button value="day">Day</watt-segmented-button>
+            <watt-segmented-button value="month">Month</watt-segmented-button>
+            <watt-segmented-button value="year">Year</watt-segmented-button>
+          </watt-segmented-buttons>
+        `,
+      })
+      class TestHostComponent {
+        control = new FormControl(initialValue);
+      }
+
+      const { fixture } = await render(TestHostComponent);
+      return { host: fixture.componentInstance };
+    }
+
+    it('moves selection right with ArrowRight', async () => {
+      const { host } = await setup('day');
+      screen.getByRole('radio', { name: 'Day' }).focus();
+
+      await userEvent.keyboard('{ArrowRight}');
+
+      expect(host.control.value).toBe('month');
+    });
+
+    it('moves selection left with ArrowLeft', async () => {
+      const { host } = await setup('month');
+      screen.getByRole('radio', { name: 'Month' }).focus();
+
+      await userEvent.keyboard('{ArrowLeft}');
+
+      expect(host.control.value).toBe('day');
+    });
+
+    it('wraps from last to first on ArrowRight', async () => {
+      const { host } = await setup('year');
+      screen.getByRole('radio', { name: 'Year' }).focus();
+
+      await userEvent.keyboard('{ArrowRight}');
+
+      expect(host.control.value).toBe('day');
+    });
+
+    it('wraps from first to last on ArrowLeft', async () => {
+      const { host } = await setup('day');
+      screen.getByRole('radio', { name: 'Day' }).focus();
+
+      await userEvent.keyboard('{ArrowLeft}');
+
+      expect(host.control.value).toBe('year');
+    });
+
+    it('jumps to first with Home', async () => {
+      const { host } = await setup('year');
+      screen.getByRole('radio', { name: 'Year' }).focus();
+
+      await userEvent.keyboard('{Home}');
+
+      expect(host.control.value).toBe('day');
+    });
+
+    it('jumps to last with End', async () => {
+      const { host } = await setup('day');
+      screen.getByRole('radio', { name: 'Day' }).focus();
+
+      await userEvent.keyboard('{End}');
+
+      expect(host.control.value).toBe('year');
+    });
+  });
+
+  describe('single button', () => {
+    it('renders a single button as a standalone (full border radius)', async () => {
+      const { container } = await render(
+        `
+          <watt-segmented-buttons>
+            <watt-segmented-button value="only">Only</watt-segmented-button>
+          </watt-segmented-buttons>
+        `,
+        { imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent] }
+      );
+
+      const button = container.querySelector('watt-segmented-button');
+      expect(button).not.toHaveClass('watt-segmented-button--first');
+      expect(button).not.toHaveClass('watt-segmented-button--middle');
+      expect(button).not.toHaveClass('watt-segmented-button--last');
+    });
+  });
+});

--- a/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.spec.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.spec.ts
@@ -82,11 +82,7 @@ describe(WattSegmentedButtonsComponent, () => {
   describe('selection', () => {
     async function setup(initialValue: string | null = 'day') {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>
@@ -106,18 +102,9 @@ describe(WattSegmentedButtonsComponent, () => {
     it('marks the initially selected button as checked', async () => {
       await setup('month');
 
-      expect(screen.getByRole('radio', { name: 'Day' })).toHaveAttribute(
-        'aria-checked',
-        'false'
-      );
-      expect(screen.getByRole('radio', { name: 'Month' })).toHaveAttribute(
-        'aria-checked',
-        'true'
-      );
-      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute(
-        'aria-checked',
-        'false'
-      );
+      expect(screen.getByRole('radio', { name: 'Day' })).toHaveAttribute('aria-checked', 'false');
+      expect(screen.getByRole('radio', { name: 'Month' })).toHaveAttribute('aria-checked', 'true');
+      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute('aria-checked', 'false');
     });
 
     it('updates the form control when clicking a button', async () => {
@@ -126,19 +113,12 @@ describe(WattSegmentedButtonsComponent, () => {
       await userEvent.click(screen.getByRole('radio', { name: 'Year' }));
 
       expect(host.control.value).toBe('year');
-      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute(
-        'aria-checked',
-        'true'
-      );
+      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute('aria-checked', 'true');
     });
 
     it('does not emit when a button has no value', async () => {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="keep">Keep</watt-segmented-button>
@@ -161,11 +141,7 @@ describe(WattSegmentedButtonsComponent, () => {
   describe('disabled state', () => {
     it('marks native buttons as disabled when the group is disabled', async () => {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>
@@ -185,11 +161,7 @@ describe(WattSegmentedButtonsComponent, () => {
 
     it('does not change selection when clicking a disabled group', async () => {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>
@@ -210,11 +182,7 @@ describe(WattSegmentedButtonsComponent, () => {
 
     it('removes disabled link from tab order and prevents navigation', async () => {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button link="/day">Day</watt-segmented-button>
@@ -252,11 +220,7 @@ describe(WattSegmentedButtonsComponent, () => {
 
     it('uses roving tabindex so only the selected button is in the tab order', async () => {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>
@@ -280,11 +244,7 @@ describe(WattSegmentedButtonsComponent, () => {
   describe('keyboard navigation', () => {
     async function setup(initialValue: string | null = 'day') {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>

--- a/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.spec.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.spec.ts
@@ -82,11 +82,7 @@ describe(WattSegmentedButtonsComponent, () => {
   describe('selection', () => {
     async function setup(initialValue: string | null = 'day') {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>
@@ -106,18 +102,9 @@ describe(WattSegmentedButtonsComponent, () => {
     it('marks the initially selected button as checked', async () => {
       await setup('month');
 
-      expect(screen.getByRole('radio', { name: 'Day' })).toHaveAttribute(
-        'aria-checked',
-        'false'
-      );
-      expect(screen.getByRole('radio', { name: 'Month' })).toHaveAttribute(
-        'aria-checked',
-        'true'
-      );
-      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute(
-        'aria-checked',
-        'false'
-      );
+      expect(screen.getByRole('radio', { name: 'Day' })).toHaveAttribute('aria-checked', 'false');
+      expect(screen.getByRole('radio', { name: 'Month' })).toHaveAttribute('aria-checked', 'true');
+      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute('aria-checked', 'false');
     });
 
     it('updates the form control when clicking a button', async () => {
@@ -126,19 +113,12 @@ describe(WattSegmentedButtonsComponent, () => {
       await userEvent.click(screen.getByRole('radio', { name: 'Year' }));
 
       expect(host.control.value).toBe('year');
-      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute(
-        'aria-checked',
-        'true'
-      );
+      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute('aria-checked', 'true');
     });
 
     it('does not emit when a button has no value', async () => {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="keep">Keep</watt-segmented-button>
@@ -161,11 +141,7 @@ describe(WattSegmentedButtonsComponent, () => {
   describe('disabled state', () => {
     it('marks all buttons with aria-disabled when the group is disabled', async () => {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>
@@ -179,23 +155,13 @@ describe(WattSegmentedButtonsComponent, () => {
 
       await render(TestHostComponent);
 
-      expect(screen.getByRole('radio', { name: 'Day' })).toHaveAttribute(
-        'aria-disabled',
-        'true'
-      );
-      expect(screen.getByRole('radio', { name: 'Month' })).toHaveAttribute(
-        'aria-disabled',
-        'true'
-      );
+      expect(screen.getByRole('radio', { name: 'Day' })).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByRole('radio', { name: 'Month' })).toHaveAttribute('aria-disabled', 'true');
     });
 
     it('does not change selection when clicking a disabled group', async () => {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>
@@ -216,11 +182,7 @@ describe(WattSegmentedButtonsComponent, () => {
 
     it('removes disabled link from tab order and prevents navigation', async () => {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button link="/day">Day</watt-segmented-button>
@@ -258,11 +220,7 @@ describe(WattSegmentedButtonsComponent, () => {
 
     it('uses roving tabindex so only the selected button is in the tab order', async () => {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>
@@ -286,11 +244,7 @@ describe(WattSegmentedButtonsComponent, () => {
   describe('keyboard navigation', () => {
     async function setup(initialValue: string | null = 'day') {
       @Component({
-        imports: [
-          WattSegmentedButtonsComponent,
-          WattSegmentedButtonComponent,
-          ReactiveFormsModule,
-        ],
+        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>

--- a/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.spec.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.spec.ts
@@ -82,7 +82,11 @@ describe(WattSegmentedButtonsComponent, () => {
   describe('selection', () => {
     async function setup(initialValue: string | null = 'day') {
       @Component({
-        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>
@@ -102,9 +106,18 @@ describe(WattSegmentedButtonsComponent, () => {
     it('marks the initially selected button as checked', async () => {
       await setup('month');
 
-      expect(screen.getByRole('radio', { name: 'Day' })).toHaveAttribute('aria-checked', 'false');
-      expect(screen.getByRole('radio', { name: 'Month' })).toHaveAttribute('aria-checked', 'true');
-      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute('aria-checked', 'false');
+      expect(screen.getByRole('radio', { name: 'Day' })).toHaveAttribute(
+        'aria-checked',
+        'false'
+      );
+      expect(screen.getByRole('radio', { name: 'Month' })).toHaveAttribute(
+        'aria-checked',
+        'true'
+      );
+      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute(
+        'aria-checked',
+        'false'
+      );
     });
 
     it('updates the form control when clicking a button', async () => {
@@ -113,12 +126,19 @@ describe(WattSegmentedButtonsComponent, () => {
       await userEvent.click(screen.getByRole('radio', { name: 'Year' }));
 
       expect(host.control.value).toBe('year');
-      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute('aria-checked', 'true');
+      expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute(
+        'aria-checked',
+        'true'
+      );
     });
 
     it('does not emit when a button has no value', async () => {
       @Component({
-        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="keep">Keep</watt-segmented-button>
@@ -139,9 +159,13 @@ describe(WattSegmentedButtonsComponent, () => {
   });
 
   describe('disabled state', () => {
-    it('marks all buttons with aria-disabled when the group is disabled', async () => {
+    it('marks native buttons as disabled when the group is disabled', async () => {
       @Component({
-        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>
@@ -155,13 +179,17 @@ describe(WattSegmentedButtonsComponent, () => {
 
       await render(TestHostComponent);
 
-      expect(screen.getByRole('radio', { name: 'Day' })).toHaveAttribute('aria-disabled', 'true');
-      expect(screen.getByRole('radio', { name: 'Month' })).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByRole('radio', { name: 'Day' })).toBeDisabled();
+      expect(screen.getByRole('radio', { name: 'Month' })).toBeDisabled();
     });
 
     it('does not change selection when clicking a disabled group', async () => {
       @Component({
-        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>
@@ -182,7 +210,11 @@ describe(WattSegmentedButtonsComponent, () => {
 
     it('removes disabled link from tab order and prevents navigation', async () => {
       @Component({
-        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button link="/day">Day</watt-segmented-button>
@@ -220,7 +252,11 @@ describe(WattSegmentedButtonsComponent, () => {
 
     it('uses roving tabindex so only the selected button is in the tab order', async () => {
       @Component({
-        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>
@@ -244,7 +280,11 @@ describe(WattSegmentedButtonsComponent, () => {
   describe('keyboard navigation', () => {
     async function setup(initialValue: string | null = 'day') {
       @Component({
-        imports: [WattSegmentedButtonsComponent, WattSegmentedButtonComponent, ReactiveFormsModule],
+        imports: [
+          WattSegmentedButtonsComponent,
+          WattSegmentedButtonComponent,
+          ReactiveFormsModule,
+        ],
         template: `
           <watt-segmented-buttons [formControl]="control">
             <watt-segmented-button value="day">Day</watt-segmented-button>

--- a/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.spec.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.spec.ts
@@ -328,9 +328,9 @@ describe(WattSegmentedButtonsComponent, () => {
       );
 
       const button = container.querySelector('watt-segmented-button');
-      expect(button).not.toHaveClass('watt-segmented-button--first');
-      expect(button).not.toHaveClass('watt-segmented-button--middle');
-      expect(button).not.toHaveClass('watt-segmented-button--last');
+      expect(button).not.toHaveClass('start');
+      expect(button).not.toHaveClass('middle');
+      expect(button).not.toHaveClass('end');
     });
   });
 });

--- a/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.ts
@@ -96,9 +96,7 @@ export class WattSegmentedButtonsComponent implements ControlValueAccessor {
     const buttons = this.buttons();
     if (buttons.length === 0) return;
 
-    const currentIndex = buttons.findIndex(
-      (button) => button.value() === this.selected()
-    );
+    const currentIndex = buttons.findIndex((button) => button.value() === this.selected());
     const activeIndex = currentIndex === -1 ? 0 : currentIndex;
 
     let nextIndex: number | null = null;

--- a/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.ts
@@ -29,17 +29,17 @@ import {
   ChangeDetectionStrategy,
 } from '@angular/core';
 
-import {
-  WattSegmentedButtonComponent,
-  WattSegmentedButtonPosition,
-} from './watt-segmented-button.component';
+import { WattSegmentedButtonComponent } from './watt-segmented-button.component';
 
 type ReadonlyButtons = readonly WattSegmentedButtonComponent[];
 
-function resolvePosition(index: number, total: number): WattSegmentedButtonPosition {
-  if (total === 1) return 'standalone';
-  if (index === 0) return 'first';
-  if (index === total - 1) return 'last';
+const POSITION_CLASSES = ['start', 'middle', 'end'] as const;
+type PositionClass = (typeof POSITION_CLASSES)[number] | null;
+
+function resolvePosition(index: number, total: number): PositionClass {
+  if (total === 1) return null;
+  if (index === 0) return 'start';
+  if (index === total - 1) return 'end';
   return 'middle';
 }
 
@@ -104,8 +104,11 @@ export class WattSegmentedButtonsComponent implements ControlValueAccessor {
         const button = buttons[i];
         button.selected.set(button.value() === selected);
         button.disabled.set(disabled);
-        button.position.set(resolvePosition(i, buttons.length));
         button.tabIndex.set(!disabled && i === focusedIndex ? 0 : -1);
+
+        const position = resolvePosition(i, buttons.length);
+        const classList = button.elementRef.nativeElement.classList;
+        for (const cls of POSITION_CLASSES) classList.toggle(cls, cls === position);
       }
     });
   }

--- a/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.ts
@@ -29,7 +29,17 @@ import {
   ChangeDetectionStrategy,
 } from '@angular/core';
 
-import { WattSegmentedButtonComponent } from './watt-segmented-button.component';
+import {
+  WattSegmentedButtonComponent,
+  WattSegmentedButtonPosition,
+} from './watt-segmented-button.component';
+
+function resolvePosition(index: number, total: number): WattSegmentedButtonPosition {
+  if (total === 1) return 'standalone';
+  if (index === 0) return 'first';
+  if (index === total - 1) return 'last';
+  return 'middle';
+}
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -42,7 +52,9 @@ import { WattSegmentedButtonComponent } from './watt-segmented-button.component'
   ],
   selector: 'watt-segmented-buttons',
   host: {
+    role: 'radiogroup',
     '(segmentSelect)': 'onSegmentSelect($event)',
+    '(keydown)': 'onKeydown($event)',
   },
   styles: `
     :host {
@@ -62,13 +74,14 @@ export class WattSegmentedButtonsComponent implements ControlValueAccessor {
       const buttons = this.buttons();
       const selected = this.selected();
       const disabled = this.disabled();
-      const last = buttons.length - 1;
+      const focusedIndex = this.resolveFocusedIndex(buttons, selected);
 
       for (let i = 0; i < buttons.length; i++) {
         const button = buttons[i];
-        button.selected = button.value() === selected;
-        button.disabled = disabled;
-        button.position = i === 0 ? 'first' : i === last ? 'last' : 'middle';
+        button.selected.set(button.value() === selected);
+        button.disabled.set(disabled);
+        button.position.set(resolvePosition(i, buttons.length));
+        button.tabIndex.set(!disabled && i === focusedIndex ? 0 : -1);
       }
     });
   }
@@ -76,6 +89,43 @@ export class WattSegmentedButtonsComponent implements ControlValueAccessor {
   onSegmentSelect(event: Event): void {
     if (this.disabled()) return;
     this.selected.set((event as CustomEvent<string>).detail);
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (this.disabled()) return;
+    const buttons = this.buttons();
+    if (buttons.length === 0) return;
+
+    const currentIndex = buttons.findIndex(
+      (button) => button.value() === this.selected()
+    );
+    const activeIndex = currentIndex === -1 ? 0 : currentIndex;
+
+    let nextIndex: number | null = null;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextIndex = (activeIndex + 1) % buttons.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextIndex = (activeIndex - 1 + buttons.length) % buttons.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = buttons.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    const nextButton = buttons[nextIndex];
+    const nextValue = nextButton.value();
+    if (nextValue !== undefined) this.selected.set(nextValue);
+    nextButton.focus();
   }
 
   writeValue(selected: string): void {
@@ -92,5 +142,13 @@ export class WattSegmentedButtonsComponent implements ControlValueAccessor {
 
   setDisabledState?(isDisabled: boolean): void {
     this.disabled.set(isDisabled);
+  }
+
+  private resolveFocusedIndex(
+    buttons: readonly WattSegmentedButtonComponent[],
+    selected: string
+  ): number {
+    const selectedIndex = buttons.findIndex((button) => button.value() === selected);
+    return selectedIndex === -1 ? 0 : selectedIndex;
   }
 }

--- a/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.ts
@@ -102,13 +102,16 @@ export class WattSegmentedButtonsComponent implements ControlValueAccessor {
 
       for (let i = 0; i < buttons.length; i++) {
         const button = buttons[i];
-        button.selected.set(button.value() === selected);
+        const isSelected = button.value() === selected;
+        button.selected.set(isSelected);
         button.disabled.set(disabled);
         button.tabIndex.set(!disabled && i === focusedIndex ? 0 : -1);
 
         const position = resolvePosition(i, buttons.length);
         const classList = button.elementRef.nativeElement.classList;
         for (const cls of POSITION_CLASSES) classList.toggle(cls, cls === position);
+        classList.toggle('selected', isSelected);
+        classList.toggle('disabled', disabled);
       }
     });
   }

--- a/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.ts
@@ -16,37 +16,23 @@
  * limitations under the License.
  */
 //#endregion
-import { NgTemplateOutlet } from '@angular/common';
-import { RouterLinkWithHref, RouterLinkActive } from '@angular/router';
-import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import {
   model,
   signal,
   inject,
+  effect,
   Component,
   ElementRef,
   forwardRef,
   contentChildren,
-  ViewEncapsulation,
   ChangeDetectionStrategy,
 } from '@angular/core';
 
-import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { WattSegmentedButtonComponent } from './watt-segmented-button.component';
 
-/**
- * Segmented buttons.
- */
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
-  encapsulation: ViewEncapsulation.None,
-  imports: [
-    MatButtonToggleModule,
-    FormsModule,
-    NgTemplateOutlet,
-    RouterLinkWithHref,
-    RouterLinkActive,
-  ],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -55,63 +41,42 @@ import { WattSegmentedButtonComponent } from './watt-segmented-button.component'
     },
   ],
   selector: 'watt-segmented-buttons',
+  host: {
+    '(segmentSelect)': 'onSegmentSelect($event)',
+  },
   styles: `
-    @use '@energinet/watt/utils' as watt;
-    @use '@angular/material' as mat;
-
-    :root {
-      @include mat.button-toggle-overrides(
-        (
-          selected-state-text-color: white,
-          selected-state-background-color: var(--watt-color-primary),
-          height: 2.5rem,
-        )
-      );
-
-      mat-button-toggle-group {
-        border-color: var(--watt-color-neutral-grey-700);
-
-        mat-button-toggle {
-          border-color: var(--watt-color-neutral-grey-700) !important;
-
-          button {
-            min-width: 6.5rem;
-
-            span {
-              font-size: 0.875rem;
-              font-weight: 600;
-            }
-          }
-        }
-      }
+    :host {
+      display: inline-flex;
     }
   `,
-  template: `
-    <mat-button-toggle-group
-      [(ngModel)]="selected"
-      [multiple]="false"
-      [hideSingleSelectionIndicator]="true"
-      [disabled]="disabled()"
-    >
-      @for (segmentedButton of segmentedButtonElements(); track segmentedButton) {
-        <mat-button-toggle
-          [routerLink]="segmentedButton.link()"
-          queryParamsHandling="merge"
-          routerLinkActive="mat-button-toggle-checked"
-          [disableRipple]="true"
-          [value]="segmentedButton.value()"
-        >
-          <ng-container *ngTemplateOutlet="segmentedButton.templateRef()" />
-        </mat-button-toggle>
-      }
-    </mat-button-toggle-group>
-  `,
+  template: `<ng-content />`,
 })
 export class WattSegmentedButtonsComponent implements ControlValueAccessor {
-  private element = inject(ElementRef);
-  segmentedButtonElements = contentChildren(WattSegmentedButtonComponent);
+  private readonly element = inject(ElementRef);
+  private readonly buttons = contentChildren(WattSegmentedButtonComponent);
   selected = model<string>('');
   disabled = signal(false);
+
+  constructor() {
+    effect(() => {
+      const buttons = this.buttons();
+      const selected = this.selected();
+      const disabled = this.disabled();
+      const last = buttons.length - 1;
+
+      for (let i = 0; i < buttons.length; i++) {
+        const button = buttons[i];
+        button.selected = button.value() === selected;
+        button.disabled = disabled;
+        button.position = i === 0 ? 'first' : i === last ? 'last' : 'middle';
+      }
+    });
+  }
+
+  onSegmentSelect(event: Event): void {
+    if (this.disabled()) return;
+    this.selected.set((event as CustomEvent<string>).detail);
+  }
 
   writeValue(selected: string): void {
     this.selected.set(selected);

--- a/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.ts
@@ -34,11 +34,35 @@ import {
   WattSegmentedButtonPosition,
 } from './watt-segmented-button.component';
 
+type ReadonlyButtons = readonly WattSegmentedButtonComponent[];
+
 function resolvePosition(index: number, total: number): WattSegmentedButtonPosition {
   if (total === 1) return 'standalone';
   if (index === 0) return 'first';
   if (index === total - 1) return 'last';
   return 'middle';
+}
+
+function findIndexByValue(buttons: ReadonlyButtons, value: string): number {
+  const index = buttons.findIndex((button) => button.value() === value);
+  return index === -1 ? 0 : index;
+}
+
+function nextKeyboardIndex(key: string, current: number, total: number): number | null {
+  switch (key) {
+    case 'ArrowRight':
+    case 'ArrowDown':
+      return (current + 1) % total;
+    case 'ArrowLeft':
+    case 'ArrowUp':
+      return (current - 1 + total) % total;
+    case 'Home':
+      return 0;
+    case 'End':
+      return total - 1;
+    default:
+      return null;
+  }
 }
 
 @Component({
@@ -74,7 +98,7 @@ export class WattSegmentedButtonsComponent implements ControlValueAccessor {
       const buttons = this.buttons();
       const selected = this.selected();
       const disabled = this.disabled();
-      const focusedIndex = this.resolveFocusedIndex(buttons, selected);
+      const focusedIndex = findIndexByValue(buttons, selected);
 
       for (let i = 0; i < buttons.length; i++) {
         const button = buttons[i];
@@ -96,28 +120,9 @@ export class WattSegmentedButtonsComponent implements ControlValueAccessor {
     const buttons = this.buttons();
     if (buttons.length === 0) return;
 
-    const currentIndex = buttons.findIndex((button) => button.value() === this.selected());
-    const activeIndex = currentIndex === -1 ? 0 : currentIndex;
-
-    let nextIndex: number | null = null;
-    switch (event.key) {
-      case 'ArrowRight':
-      case 'ArrowDown':
-        nextIndex = (activeIndex + 1) % buttons.length;
-        break;
-      case 'ArrowLeft':
-      case 'ArrowUp':
-        nextIndex = (activeIndex - 1 + buttons.length) % buttons.length;
-        break;
-      case 'Home':
-        nextIndex = 0;
-        break;
-      case 'End':
-        nextIndex = buttons.length - 1;
-        break;
-      default:
-        return;
-    }
+    const currentIndex = findIndexByValue(buttons, this.selected());
+    const nextIndex = nextKeyboardIndex(event.key, currentIndex, buttons.length);
+    if (nextIndex === null) return;
 
     event.preventDefault();
     const nextButton = buttons[nextIndex];
@@ -140,13 +145,5 @@ export class WattSegmentedButtonsComponent implements ControlValueAccessor {
 
   setDisabledState?(isDisabled: boolean): void {
     this.disabled.set(isDisabled);
-  }
-
-  private resolveFocusedIndex(
-    buttons: readonly WattSegmentedButtonComponent[],
-    selected: string
-  ): number {
-    const selectedIndex = buttons.findIndex((button) => button.value() === selected);
-    return selectedIndex === -1 ? 0 : selectedIndex;
   }
 }


### PR DESCRIPTION
## Summary

- Replace `MatButtonToggleModule` with a custom segmented buttons implementation that aligns 1:1 with the Figma design.
- Move styling directly onto the inner `<button>`/`<a>` element so state (selected, disabled, hover, focus) follows the actual interactive surface.
- Use `box-shadow` for the focus ring to avoid conflicts with the shared border between adjacent buttons.
- Rewrite Storybook entry with a Figma-aligned overview and a "Building blocks" view documenting enabled/hover/disabled × first/middle/last states.

<img width="646" height="901" alt="image" src="https://github.com/user-attachments/assets/5a96f80f-cb0d-4681-832f-c3a295a1b1df" />


Closes #5679