### PR TITLE
fix: replace github-create-release action with gh CLI to fix null PR number on push to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ permissions:
   attestations: write
   contents: write
   id-token: write
+  pull-requests: read
 on:
   push:
     branches:
@@ -115,13 +116,20 @@ jobs:
           sbom-path: ${{ github.workspace }}/sbom.spdx.json
 
       - name: Create pre-release
-        uses: Energinet-Datahub/.github/.github/actions/github-create-release@actions/v1
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: ${{ steps.get_releaseversion_strings.outputs.release_version }}
-          prerelease: true
-          title: ${{ steps.get_releaseversion_strings.outputs.release_version }}
-          files: ${{ github.workspace }}/${{ steps.get_releaseversion_strings.outputs.release_version }}/${{ steps.get_releaseversion_strings.outputs.release_zip_filename }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TAG="${{ steps.get_releaseversion_strings.outputs.release_version }}"
+          RELEASE_FILE="${{ github.workspace }}/${{ steps.get_releaseversion_strings.outputs.release_version }}/${{ steps.get_releaseversion_strings.outputs.release_zip_filename }}"
+
+          gh release delete "$RELEASE_TAG" --yes --cleanup-tag 2>/dev/null || true
+
+          gh release create "$RELEASE_TAG" \
+            --title "$RELEASE_TAG" \
+            --prerelease \
+            --target "${{ github.sha }}" \
+            --generate-notes \
+            "$RELEASE_FILE"
 
   frontend_promote_prerelease:
     needs: [frontend_ci_build]


### PR DESCRIPTION
## Problem

`github-create-release@actions/v1` reads the PR number exclusively from `GH_CONTEXT` (`github.event.number` or `ref_name` matching `queue/main/pr-(\d+)`). Neither is populated for a `push` to `main` — `event.number` is null and `ref_name` is `main`. This causes `Invoke-GithubPrCommitHistory` to call `/pulls//commits`, which returns an error JSON instead of an array. `$_.sha.Substring()` then throws "You cannot call a method on a null-valued expression."

## Fix

- Replace the external `github-create-release` action with direct `gh release create` CLI commands, which correctly use the already-resolved `release_version` and `sha` from context
- Use `--generate-notes` for release notes (GitHub's native PR/commit association, works correctly in push context)
- Delete the pre-existing pre-release before creating a new one, mirroring the action's original behaviour (`|| true` makes 404 non-fatal)
- Add `pull-requests: read` permission so `--generate-notes` can associate PRs with the release