### PR TITLE
fix(dh/metering-point): disable process drawer actions for FAS users

### DIFF
--- a/libs/dh/metering-point/feature-process-overview/src/components/details/details.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/components/details/details.ts
@@ -17,6 +17,7 @@
  */
 //#endregion
 import { Component, computed, inject, input } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { TranslocoDirective } from '@jsverse/transloco';
 
 import { WATT_DESCRIPTION_LIST } from '@energinet/watt/description-list';
@@ -25,6 +26,7 @@ import { WattDatePipe } from '@energinet/watt/date';
 import { WattButtonComponent } from '@energinet/watt/button';
 
 import { DhStateBadge, DhEmDashFallbackPipe } from '@energinet-datahub/dh/shared/ui-util';
+import { PermissionService } from '@energinet-datahub/dh/shared/feature-authorization';
 import { query } from '@energinet-datahub/dh/shared/util-apollo';
 import {
   GetMeteringPointProcessByIdDocument,
@@ -99,7 +101,11 @@ import { SupportedActionsPipe } from '../../actions/supported-actions.pipe';
             | supportedActions: businessReason();
           track action
         ) {
-          <watt-button variant="secondary" (click)="executeAction(action)">
+          <watt-button
+            variant="secondary"
+            [disabled]="isFas()"
+            (click)="executeAction(action)"
+          >
             {{ t('actions.' + businessReason() + '.' + action) }}
           </watt-button>
         }
@@ -120,6 +126,9 @@ export class DhMeteringPointProcessOverviewDetails {
   readonly meteringPointId = input.required<string>();
   protected navigation = inject(DhNavigationService);
   private readonly actionService = inject(DhActionsRegistry);
+  private readonly permissionService = inject(PermissionService);
+
+  protected isFas = toSignal(this.permissionService.isFas(), { initialValue: false });
 
   process = query(GetMeteringPointProcessByIdDocument, () => ({
     fetchPolicy: 'cache-and-network',

--- a/libs/dh/metering-point/feature-process-overview/src/components/details/details.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/components/details/details.ts
@@ -101,11 +101,7 @@ import { SupportedActionsPipe } from '../../actions/supported-actions.pipe';
             | supportedActions: businessReason();
           track action
         ) {
-          <watt-button
-            variant="secondary"
-            [disabled]="isFas()"
-            (click)="executeAction(action)"
-          >
+          <watt-button variant="secondary" [disabled]="isFas()" (click)="executeAction(action)">
             {{ t('actions.' + businessReason() + '.' + action) }}
           </watt-button>
         }

--- a/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
@@ -35,7 +35,10 @@ import { PermissionService } from '@energinet-datahub/dh/shared/feature-authoriz
 
 import { DhMeteringPointProcessOverviewDetails } from '../src/components/details/details';
 
-async function setup(processId = 'process-eos-cancel', permissionOverrides: { isFas?: boolean } = {}) {
+async function setup(
+  processId = 'process-eos-cancel',
+  permissionOverrides: { isFas?: boolean } = {}
+) {
   const { isFas = false } = permissionOverrides;
   const { fixture } = await render(DhMeteringPointProcessOverviewDetails, {
     providers: [

--- a/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
@@ -109,14 +109,17 @@ describe('Process overview details', () => {
     expect(terms.some((term) => /Initiating participant/i.test(term.textContent || ''))).toBe(true);
   });
 
-  it('should disable action buttons for FAS users', async () => {
-    await setup('process-eos-cancel', { isFas: true });
+  it.each([
+    ['process-eos-cancel', /Cancel|Reject request/i],
+    ['process-eos-request-service', /Request service/i],
+  ])('should disable action buttons for FAS users (%s)', async (processId, buttonPattern) => {
+    await setup(processId, { isFas: true });
     await waitForAsync(() =>
-      expect(screen.getAllByRole('button', { name: /Cancel/i }).length).toBeGreaterThan(0)
+      expect(screen.getAllByRole('button', { name: buttonPattern }).length).toBeGreaterThan(0)
     );
-    const actionButtons = screen.getAllByRole('button', { name: /Cancel|Reject request/i });
+    const actionButtons = screen.getAllByRole('button', { name: buttonPattern });
     actionButtons.forEach((button) => {
-      expect(button).toBeDisabled();
+      expect((button as HTMLButtonElement).disabled).toBe(true);
     });
   });
 });

--- a/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
@@ -35,7 +35,8 @@ import { PermissionService } from '@energinet-datahub/dh/shared/feature-authoriz
 
 import { DhMeteringPointProcessOverviewDetails } from '../src/components/details/details';
 
-async function setup(processId = 'process-eos-cancel') {
+async function setup(processId = 'process-eos-cancel', permissionOverrides: { isFas?: boolean } = {}) {
+  const { isFas = false } = permissionOverrides;
   const { fixture } = await render(DhMeteringPointProcessOverviewDetails, {
     providers: [
       provideHttpClient(withInterceptorsFromDi()),
@@ -47,7 +48,7 @@ async function setup(processId = 'process-eos-cancel') {
       {
         provide: PermissionService,
         useValue: {
-          isFas: () => of(false),
+          isFas: () => of(isFas),
           hasMarketRole: () => of(true),
           hasPermission: () => of(true),
         },
@@ -106,5 +107,16 @@ describe('Process overview details', () => {
     await setup();
     const terms = screen.getAllByRole('term');
     expect(terms.some((term) => /Initiating participant/i.test(term.textContent || ''))).toBe(true);
+  });
+
+  it('should disable action buttons for FAS users', async () => {
+    await setup('process-eos-cancel', { isFas: true });
+    await waitForAsync(() =>
+      expect(screen.getAllByRole('button', { name: /Cancel/i }).length).toBeGreaterThan(0)
+    );
+    const actionButtons = screen.getAllByRole('button', { name: /Cancel|Reject request/i });
+    actionButtons.forEach((button) => {
+      expect(button).toBeDisabled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- FAS (sysadmin) users see all supported actions in the process overview drawer for informational purposes, but cannot execute them. The table already hides action buttons behind a warning pill for FAS; the drawer previously rendered them as fully clickable.
- Disables the drawer action buttons when the current user is FAS so the permission rules stay consistent between the table and the drawer. Defense in depth: the registry's `execute()` already rejects FAS callers via `hasRequiredMarketRole`, so this is purely a UX/affordance fix.
- Extends the details spec to cover both EndOfSupply action groups — cancel/reject (`process-eos-cancel`) and request service (`process-eos-request-service`) — via `it.each`, replacing the untyped `toBeDisabled()` matcher with a typed `HTMLButtonElement.disabled` check the IDE can resolve.