### PR TITLE
feat(dh/metering-point): add process step translations for BRS-005 and BRS-039

### DIFF
--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -1181,7 +1181,20 @@
         "BRS_036_REQUESTCHANGEPRODUCTIONOBLIGATION_V1_STEP_4": "Information om ændring af aftagepligt (RSM-022)",
         "BRS_041_V1_STEP_1": "Anmodning om ændring af elvarmestatus (RSM-027)",
         "BRS_041_V1_STEP_2": "Afvisning af ændring af elvarmestatus (RSM-027)",
-        "BRS_041_V1_STEP_3": "Godkendelse af ændring af elvarmestatus (RSM-027)"
+        "BRS_041_V1_STEP_3": "Godkendelse af ændring af elvarmestatus (RSM-027)",
+        "BRS_039_REJECTIONOFREQUESTFORSERVICE_V1_STEP_1": "Afvisning af anmodning om serviceydelse (RSM-020)",
+        "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_1": "Anmodning om annullering af serviceydelse (RSM-024)",
+        "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_2": "Godkendelse af annullering af serviceydelse (RSM-024)",
+        "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_3": "Afvisning af annullering af serviceydelse (RSM-024)",
+        "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_4": "Information om annullering af serviceydelse (RSM-025)",
+        "BRS_039_REQUESTFORSERVICE_V1_STEP_1": "Anmodning om serviceydelse (RSM-020)",
+        "BRS_039_REQUESTFORSERVICE_V1_STEP_3": "Anmodning om serviceydelse (RSM-020)",
+        "BRS_039_CONFIRMATIONOFREQUESTFORSERVICE_V1_STEP_1": "Godkendelse af anmodning om serviceydelse (RSM-020)",
+        "BRS_039_CONFIRMATIONOFREQUESTFORSERVICE_V1_STEP_2": "Godkendelse af anmodning om serviceydelse (RSM-020)",
+        "BRS_005_REQUESTFORMASTERDATA_V1_STEP_1": "Anmodning om stamdata (RSM-006)",
+        "BRS_005_REQUESTFORMASTERDATA_V1_STEP_2": "Afvisning af anmodning om stamdata (RSM-006)",
+        "BRS_005_REQUESTFORMASTERDATA_V1_STEP_3": "Information om målepunktsstamdata (RSM-022)",
+        "BRS_005_REQUESTFORMASTERDATA_V1_STEP_4": "Information om kundestamdata (RSM-028)"
       },
       "details": {
         "notFound": "Process ikke fundet",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -1181,7 +1181,20 @@
         "BRS_036_REQUESTCHANGEPRODUCTIONOBLIGATION_V1_STEP_4": "Notification of change of production obligation (RSM-022)",
         "BRS_041_V1_STEP_1": "Request for change of electrical heating status (RSM-027)",
         "BRS_041_V1_STEP_2": "Rejection of request for change of electrical heating status (RSM-027)",
-        "BRS_041_V1_STEP_3": "Confirmation of request for change of electrical heating status (RSM-027)"
+        "BRS_041_V1_STEP_3": "Confirmation of request for change of electrical heating status (RSM-027)",
+        "BRS_039_REJECTIONOFREQUESTFORSERVICE_V1_STEP_1": "Rejection of request for service (RSM-020)",
+        "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_1": "Request for cancellation for service (RSM-024)",
+        "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_2": "Confirmation of cancellation of service (RSM-024)",
+        "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_3": "Rejection of cancellation of service (RSM-024)",
+        "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_4": "Notification of cancellation of service (RSM-025)",
+        "BRS_039_REQUESTFORSERVICE_V1_STEP_1": "Request for service (RSM-020)",
+        "BRS_039_REQUESTFORSERVICE_V1_STEP_3": "Request for service (RSM-020)",
+        "BRS_039_CONFIRMATIONOFREQUESTFORSERVICE_V1_STEP_1": "Confirmation of request for service (RSM-020)",
+        "BRS_039_CONFIRMATIONOFREQUESTFORSERVICE_V1_STEP_2": "Confirmation of request for service (RSM-020)",
+        "BRS_005_REQUESTFORMASTERDATA_V1_STEP_1": "Request for metering point master data (RSM-006)",
+        "BRS_005_REQUESTFORMASTERDATA_V1_STEP_2": "Rejection of request for metering point master data (RSM-006)",
+        "BRS_005_REQUESTFORMASTERDATA_V1_STEP_3": "Notification of metering point master data (RSM-022)",
+        "BRS_005_REQUESTFORMASTERDATA_V1_STEP_4": "Notification of customer master data (RSM-028)"
       },
       "details": {
         "notFound": "Process not found",

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -1183,7 +1183,7 @@
         "BRS_041_V1_STEP_2": "Rejection of request for change of electrical heating status (RSM-027)",
         "BRS_041_V1_STEP_3": "Confirmation of request for change of electrical heating status (RSM-027)",
         "BRS_039_REJECTIONOFREQUESTFORSERVICE_V1_STEP_1": "Rejection of request for service (RSM-020)",
-        "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_1": "Request for cancellation for service (RSM-024)",
+        "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_1": "Request for cancellation of service (RSM-024)",
         "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_2": "Confirmation of cancellation of service (RSM-024)",
         "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_3": "Rejection of cancellation of service (RSM-024)",
         "BRS_039_REQUESTFORCANCELLATIONFORSERVICE_V1_STEP_4": "Notification of cancellation of service (RSM-025)",


### PR DESCRIPTION
## Summary

- Tilføjer danske og engelske oversættelser for 9 BRS-039 procestrin (serviceydelser: anmodning, annullering, godkendelse, afvisning)
- Tilføjer danske og engelske oversættelser for 4 BRS-005 procestrin (anmodning om stamdata, afvisning, notifikationer)

Ref: Energinet-DataHub/team-mosaic#1459