### PR TITLE
feat: Add projections status operation tool JSON view

### DIFF
--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/OperationTools/MeteringPoint/OperationToolsMeteringPointRevisionLogTests.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Integration/GraphQL/OperationTools/MeteringPoint/OperationToolsMeteringPointRevisionLogTests.cs
@@ -21,6 +21,7 @@ using Energinet.DataHub.ElectricityMarket.Abstractions.Framework;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.ClearMigrationEventsDeadLetterQueue.V1;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.DeleteAllEventSourcingData.V1;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.GetMeteringPointMigratedCount.V1;
+using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.GetProjectionsStatus.V1;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.RebuildProjections.V1;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.ReplayMigrationEventsDeadLetterQueue.V1;
 using Energinet.DataHub.WebApi.Clients.ElectricityMarket.v1;
@@ -232,6 +233,32 @@ public class OperationToolsMeteringPointRevisionLogTests
         server.ElectricityMarketClientV1Mock.Setup(
                 c => c.MeteringPointCountAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MeteringPointCountDto { TotalCount = 1000, QuarantinedCount = 5 });
+
+        await RevisionLogTestHelper.ExecuteAndAssertAsync(server, operation, []);
+    }
+
+    [Fact]
+    [RevisionLogTest("OperationToolsMeteringPointNode.GetProjectionsStatusAsync")]
+    public async Task GetProjectionsStatus()
+    {
+        var operation =
+            """
+                query {
+                  projectionsStatus {
+                    projections {
+                      name
+                    }
+                  }
+                }
+            """;
+
+        var server = new GraphQLTestService();
+        var result = Result<GetProjectionsStatusResultDtoV1>.Success(
+            new GetProjectionsStatusResultDtoV1(100, 50, 10, 5, []));
+
+        server.ElectricityMarketClientMock.Setup(
+                c => c.SendAsync(It.IsAny<GetProjectionsStatusQueryV1>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
 
         await RevisionLogTestHelper.ExecuteAndAssertAsync(server, operation, []);
     }

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/OperationToolsMeteringPointRevisionLogTests.projectionsStatus.verified.json
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/OperationToolsMeteringPointRevisionLogTests.projectionsStatus.verified.json
@@ -1,0 +1,9 @@
+﻿{
+  "activity": "projectionsStatus",
+  "payload": {
+    "query": "{ projectionsStatus { projections { name } } }",
+    "variables": {}
+  },
+  "affectedEntityType": "OperationToolsMeteringPoint",
+  "affectedEntityKey": null
+}

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
@@ -1437,6 +1437,7 @@ type Query {
   meteringPointCount: MeteringPointCountDto! @authorize(roles: [ "operation-tools:view" ])
   meteringPointMigratedCount: Long! @authorize(roles: [ "operation-tools:view" ])
   operationToolsMeteringPoint(id: String!): GetMeteringPointDebugResultDtoV1 @authorize(roles: [ "operation-tools:view" ])
+  projectionsStatus: String! @authorize(roles: [ "operation-tools:view" ])
   balanceResponsible(skip: Int take: Int order: BalanceResponsibleSortInput): BalanceResponsibleCollectionSegment
   balanceResponsibleById(documentId: String!): BalanceResponsible!
   esettServiceStatus: [ReadinessStatusDto!]!

--- a/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
+++ b/apps/dh/api-dh/source/DataHub.WebApi.Tests/Snapshots/SchemaTests.ChangeTest.verified.graphql
@@ -831,6 +831,14 @@ type GetMeteringPointDebugResultDtoV1 {
   events: [ElectricityMarketV2EventDto!]!
 }
 
+type GetProjectionsStatusResultDtoV1 {
+  daemonHighWaterMark: Long!
+  eventCount: Long!
+  eventSequenceNumber: Long!
+  streamCount: Long!
+  projections: [ProjectionStatus!]!
+}
+
 type GridAreaAuditedChangeAuditLogDto {
   auditedBy: String
   currentOwner: String
@@ -1409,6 +1417,18 @@ type ProcessesEdge {
   node: OrchestrationInstance!
 }
 
+type ProjectionStatus {
+  name: String!
+  assignedNodeNumber: Int!
+  action: String!
+  exception: String
+  previousGoodMark: Long!
+  mode: String!
+  rebuildThreshold: Long!
+  sequence: Long!
+  timestamp: DateTime!
+}
+
 type Query {
   conversation(conversationId: UUID!): Conversation! @authorize(roles: [ "metering-point:actor-conversation" ])
   conversationsForMeteringPoint(meteringPointIdentification: String searchTerm: String ownConversations: Boolean unread: Boolean opened: Boolean closed: Boolean subjects: [ConversationSubject!]): Conversations! @authorize(roles: [ "metering-point:actor-conversation" ])
@@ -1437,7 +1457,7 @@ type Query {
   meteringPointCount: MeteringPointCountDto! @authorize(roles: [ "operation-tools:view" ])
   meteringPointMigratedCount: Long! @authorize(roles: [ "operation-tools:view" ])
   operationToolsMeteringPoint(id: String!): GetMeteringPointDebugResultDtoV1 @authorize(roles: [ "operation-tools:view" ])
-  projectionsStatus: String! @authorize(roles: [ "operation-tools:view" ])
+  projectionsStatus: GetProjectionsStatusResultDtoV1! @authorize(roles: [ "operation-tools:view" ])
   balanceResponsible(skip: Int take: Int order: BalanceResponsibleSortInput): BalanceResponsibleCollectionSegment
   balanceResponsibleById(documentId: String!): BalanceResponsible!
   esettServiceStatus: [ReadinessStatusDto!]!

--- a/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
+++ b/apps/dh/api-dh/source/DataHub.WebApi/DataHub.WebApi.csproj
@@ -57,7 +57,7 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="16.0.0" />
     <PackageReference Include="Energinet.DataHub.Core.App.WebApp" Version="16.0.0" />
     <PackageReference Include="Energinet.DataHub.EDI.B2CClient" Version="2.5.3" />
-    <PackageReference Include="Energinet.DataHub.ElectricityMarket.Client" Version="1.91.0" />
+    <PackageReference Include="Energinet.DataHub.ElectricityMarket.Client" Version="1.109.0" />
     <PackageReference Include="Energinet.DataHub.MarketParticipant.Authorization" Version="3.0.7" />
     <PackageReference Include="Energinet.DataHub.Measurements.Client" Version="11.3.1" />
     <PackageReference Include="Energinet.DataHub.MessageArchive.Client" Version="2.0.8" />

--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/OperationToolsMeteringPointNode.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/OperationToolsMeteringPointNode.cs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Text.Json;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Features.MeteringPoint.GetMeteringPointDebug.V1;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.ClearMigrationEventsDeadLetterQueue.V1;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.DeleteAllEventSourcingData.V1;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.GetMeteringPointMigratedCount.V1;
+using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.GetProjectionsStatus.V1;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.RebuildProjections.V1;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.ReplayMigrationEventsDeadLetterQueue.V1;
 using Energinet.DataHub.ElectricityMarket.Client;
@@ -96,16 +98,15 @@ public static class OperationToolsMeteringPointNode
     [Query]
     [Authorize(Roles = ["operation-tools:view"])]
     [UseRevisionLog]
-    public static Task<string> GetProjectionsStatusAsync(CancellationToken ct)
+    public static async Task<string> GetProjectionsStatusAsync(
+        IElectricityMarketClient electricityMarketClient,
+        CancellationToken ct)
     {
-        // TODO: Replace with actual IElectricityMarketClient call once the operation is available
-        var dummyStatus = """
-            {
-              "status": "not_implemented",
-              "message": "GetProjectionsStatus is not yet available in the electricity market client."
-            }
-            """;
-        return Task.FromResult(dummyStatus);
+        var result = await electricityMarketClient.SendAsync(new GetProjectionsStatusQueryV1(), ct);
+
+        return !result.IsSuccess
+            ? throw new InvalidOperationException($"Failed to get projections status: {result.DiagnosticMessage}.")
+            : JsonSerializer.Serialize(result.Data, new JsonSerializerOptions() { WriteIndented = true });
     }
 
     [Mutation]

--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/OperationToolsMeteringPointNode.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/OperationToolsMeteringPointNode.cs
@@ -31,8 +31,6 @@ namespace Energinet.DataHub.WebApi.Modules.ElectricityMarket.MeteringPoint;
 
 public static class OperationToolsMeteringPointNode
 {
-    private static readonly JsonSerializerOptions IndentedOptions = new() { WriteIndented = true };
-
     [Query]
     [Authorize(Roles = ["operation-tools:view"])]
     public static async Task<string> GetDebugViewAsync(

--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/OperationToolsMeteringPointNode.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/OperationToolsMeteringPointNode.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Text.Json;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Features.MeteringPoint.GetMeteringPointDebug.V1;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.ClearMigrationEventsDeadLetterQueue.V1;
 using Energinet.DataHub.ElectricityMarket.Abstractions.Operations.DeleteAllEventSourcingData.V1;

--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/OperationToolsMeteringPointNode.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/OperationToolsMeteringPointNode.cs
@@ -31,6 +31,8 @@ namespace Energinet.DataHub.WebApi.Modules.ElectricityMarket.MeteringPoint;
 
 public static class OperationToolsMeteringPointNode
 {
+    private static readonly JsonSerializerOptions IndentedOptions = new() { WriteIndented = true };
+
     [Query]
     [Authorize(Roles = ["operation-tools:view"])]
     public static async Task<string> GetDebugViewAsync(
@@ -98,15 +100,15 @@ public static class OperationToolsMeteringPointNode
     [Query]
     [Authorize(Roles = ["operation-tools:view"])]
     [UseRevisionLog]
-    public static async Task<string> GetProjectionsStatusAsync(
+    public static async Task<GetProjectionsStatusResultDtoV1> GetProjectionsStatusAsync(
         IElectricityMarketClient electricityMarketClient,
         CancellationToken ct)
     {
         var result = await electricityMarketClient.SendAsync(new GetProjectionsStatusQueryV1(), ct);
 
-        return !result.IsSuccess
+        return !result.IsSuccess || !result.HasData
             ? throw new InvalidOperationException($"Failed to get projections status: {result.DiagnosticMessage}.")
-            : JsonSerializer.Serialize(result.Data, new JsonSerializerOptions() { WriteIndented = true });
+            : result.Data;
     }
 
     [Mutation]

--- a/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/OperationToolsMeteringPointNode.cs
+++ b/apps/dh/api-dh/source/DataHub.WebApi/Modules/ElectricityMarket/MeteringPoint/OperationToolsMeteringPointNode.cs
@@ -93,6 +93,21 @@ public static class OperationToolsMeteringPointNode
             : result.Data;
     }
 
+    [Query]
+    [Authorize(Roles = ["operation-tools:view"])]
+    [UseRevisionLog]
+    public static Task<string> GetProjectionsStatusAsync(CancellationToken ct)
+    {
+        // TODO: Replace with actual IElectricityMarketClient call once the operation is available
+        var dummyStatus = """
+            {
+              "status": "not_implemented",
+              "message": "GetProjectionsStatus is not yet available in the electricity market client."
+            }
+            """;
+        return Task.FromResult(dummyStatus);
+    }
+
     [Mutation]
     [Authorize(Roles = ["operation-tools:manage"])]
     [UseRevisionLog]

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/da.json
@@ -3601,6 +3601,10 @@
           "message": "Er du sikker på, at du vil genopbygge projektionen?"
         }
       },
+      "projectionsStatus": {
+        "title": "Projektionsstatus",
+        "button": "Hent projektionsstatus"
+      },
       "dangerZone": {
         "title": "Farezone"
       },

--- a/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
+++ b/libs/dh/globalization/assets-localization/src/assets/i18n/en.json
@@ -3601,6 +3601,10 @@
           "message": "Are you sure you want to rebuild the projection?"
         }
       },
+      "projectionsStatus": {
+        "title": "Projections Status",
+        "button": "Get projections status"
+      },
       "dangerZone": {
         "title": "Danger Zone"
       },

--- a/libs/dh/metering-point/feature-debug/src/debug-metering-point-actions/metering-point-actions.component.ts
+++ b/libs/dh/metering-point/feature-debug/src/debug-metering-point-actions/metering-point-actions.component.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 //#endregion
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { TranslocoDirective } from '@jsverse/transloco';
@@ -132,8 +132,8 @@ import {
               {{ t('projectionsStatus.button') }}
             </watt-button>
 
-            @if (projectionsStatusQuery.data(); as data) {
-              <pre class="result-box">{{ prettifyJson(data.projectionsStatus) }}</pre>
+            @if (projectionsStatusJson()) {
+              <pre class="result-box">{{ projectionsStatusJson() }}</pre>
             }
 
             @if (projectionsStatusQuery.error(); as error) {
@@ -170,6 +170,11 @@ export class DhMeteringPointActionsComponent {
   timeoutControl = dhMakeFormControl('30');
   projectionTypeOptions = dhEnumToWattDropdownOptions(ProjectionType);
   projectionsStatusQuery = lazyQuery(GetProjectionsStatusDocument);
+  projectionsStatusJson = computed(() => {
+    const data = this.projectionsStatusQuery.data()?.projectionsStatus;
+    if (!data) return null;
+    return JSON.stringify(data, (key, value) => (key === '__typename' ? undefined : value), 2);
+  });
 
   onConfirmRebuild(confirmed: boolean): void {
     if (!confirmed) return;
@@ -181,13 +186,5 @@ export class DhMeteringPointActionsComponent {
 
   getProjectionsStatus(): void {
     this.projectionsStatusQuery.query({ fetchPolicy: 'network-only' });
-  }
-
-  prettifyJson(json: string): string {
-    try {
-      return JSON.stringify(JSON.parse(json), null, 2);
-    } catch {
-      return json;
-    }
   }
 }

--- a/libs/dh/metering-point/feature-debug/src/debug-metering-point-actions/metering-point-actions.component.ts
+++ b/libs/dh/metering-point/feature-debug/src/debug-metering-point-actions/metering-point-actions.component.ts
@@ -29,10 +29,11 @@ import { WattHeadingComponent } from '@energinet/watt/heading';
 import { WattTextFieldComponent } from '@energinet/watt/text-field';
 import { WATT_MODAL } from '@energinet/watt/modal';
 
-import { mutation } from '@energinet-datahub/dh/shared/util-apollo';
+import { mutation, lazyQuery } from '@energinet-datahub/dh/shared/util-apollo';
 import {
   RebuildProjectionsDocument,
   ProjectionType,
+  GetProjectionsStatusDocument,
 } from '@energinet-datahub/dh/shared/domain/graphql';
 import { assertIsDefined } from '@energinet-datahub/dh/shared/util-assert';
 import {
@@ -118,6 +119,30 @@ import {
             </vater-flex>
           </vater-flex>
         </watt-card>
+
+        <watt-card style="grid-column: 1 / -1">
+          <vater-flex direction="column" gap="m">
+            <h3 watt-heading>{{ t('projectionsStatus.title') }}</h3>
+
+            <watt-button
+              variant="secondary"
+              [loading]="projectionsStatusQuery.loading()"
+              (click)="getProjectionsStatus()"
+            >
+              {{ t('projectionsStatus.button') }}
+            </watt-button>
+
+            @if (projectionsStatusQuery.data(); as data) {
+              <pre class="result-box">{{ prettifyJson(data.projectionsStatus) }}</pre>
+            }
+
+            @if (projectionsStatusQuery.error(); as error) {
+              <div class="result-box">
+                <strong>{{ t('error') }}</strong> {{ error.message }}
+              </div>
+            }
+          </vater-flex>
+        </watt-card>
       </vater-grid>
 
       <watt-modal
@@ -144,6 +169,7 @@ export class DhMeteringPointActionsComponent {
   projectionTypeControl = dhMakeFormControl<ProjectionType>();
   timeoutControl = dhMakeFormControl('30');
   projectionTypeOptions = dhEnumToWattDropdownOptions(ProjectionType);
+  projectionsStatusQuery = lazyQuery(GetProjectionsStatusDocument);
 
   onConfirmRebuild(confirmed: boolean): void {
     if (!confirmed) return;
@@ -151,5 +177,17 @@ export class DhMeteringPointActionsComponent {
     const timeout = parseInt(this.timeoutControl.value || '5');
     assertIsDefined(projection);
     this.rebuildProjections.mutate({ variables: { input: { projection, timeout } } });
+  }
+
+  getProjectionsStatus(): void {
+    this.projectionsStatusQuery.query({ fetchPolicy: 'network-only' });
+  }
+
+  prettifyJson(json: string): string {
+    try {
+      return JSON.stringify(JSON.parse(json), null, 2);
+    } catch {
+      return json;
+    }
   }
 }

--- a/libs/dh/metering-point/feature-debug/src/graphql/get-projections-status.graphql
+++ b/libs/dh/metering-point/feature-debug/src/graphql/get-projections-status.graphql
@@ -1,3 +1,19 @@
 query GetProjectionsStatus {
-  projectionsStatus
+  projectionsStatus {
+    daemonHighWaterMark
+    eventCount
+    eventSequenceNumber
+    streamCount
+    projections {
+      name
+      assignedNodeNumber
+      action
+      exception
+      previousGoodMark
+      mode
+      rebuildThreshold
+      sequence
+      timestamp
+    }
+  }
 }

--- a/libs/dh/metering-point/feature-debug/src/graphql/get-projections-status.graphql
+++ b/libs/dh/metering-point/feature-debug/src/graphql/get-projections-status.graphql
@@ -1,0 +1,3 @@
+query GetProjectionsStatus {
+  projectionsStatus
+}

--- a/libs/dh/shared/data-access-graphql/schema.graphql
+++ b/libs/dh/shared/data-access-graphql/schema.graphql
@@ -1437,6 +1437,7 @@ type Query {
   meteringPointCount: MeteringPointCountDto! @authorize(roles: [ "operation-tools:view" ])
   meteringPointMigratedCount: Long! @authorize(roles: [ "operation-tools:view" ])
   operationToolsMeteringPoint(id: String!): GetMeteringPointDebugResultDtoV1 @authorize(roles: [ "operation-tools:view" ])
+  projectionsStatus: String! @authorize(roles: [ "operation-tools:view" ])
   balanceResponsible(skip: Int take: Int order: BalanceResponsibleSortInput): BalanceResponsibleCollectionSegment
   balanceResponsibleById(documentId: String!): BalanceResponsible!
   esettServiceStatus: [ReadinessStatusDto!]!

--- a/libs/dh/shared/data-access-graphql/schema.graphql
+++ b/libs/dh/shared/data-access-graphql/schema.graphql
@@ -831,6 +831,14 @@ type GetMeteringPointDebugResultDtoV1 {
   events: [ElectricityMarketV2EventDto!]!
 }
 
+type GetProjectionsStatusResultDtoV1 {
+  daemonHighWaterMark: Long!
+  eventCount: Long!
+  eventSequenceNumber: Long!
+  streamCount: Long!
+  projections: [ProjectionStatus!]!
+}
+
 type GridAreaAuditedChangeAuditLogDto {
   auditedBy: String
   currentOwner: String
@@ -1409,6 +1417,18 @@ type ProcessesEdge {
   node: OrchestrationInstance!
 }
 
+type ProjectionStatus {
+  name: String!
+  assignedNodeNumber: Int!
+  action: String!
+  exception: String
+  previousGoodMark: Long!
+  mode: String!
+  rebuildThreshold: Long!
+  sequence: Long!
+  timestamp: DateTime!
+}
+
 type Query {
   conversation(conversationId: UUID!): Conversation! @authorize(roles: [ "metering-point:actor-conversation" ])
   conversationsForMeteringPoint(meteringPointIdentification: String searchTerm: String ownConversations: Boolean unread: Boolean opened: Boolean closed: Boolean subjects: [ConversationSubject!]): Conversations! @authorize(roles: [ "metering-point:actor-conversation" ])
@@ -1437,7 +1457,7 @@ type Query {
   meteringPointCount: MeteringPointCountDto! @authorize(roles: [ "operation-tools:view" ])
   meteringPointMigratedCount: Long! @authorize(roles: [ "operation-tools:view" ])
   operationToolsMeteringPoint(id: String!): GetMeteringPointDebugResultDtoV1 @authorize(roles: [ "operation-tools:view" ])
-  projectionsStatus: String! @authorize(roles: [ "operation-tools:view" ])
+  projectionsStatus: GetProjectionsStatusResultDtoV1! @authorize(roles: [ "operation-tools:view" ])
   balanceResponsible(skip: Int take: Int order: BalanceResponsibleSortInput): BalanceResponsibleCollectionSegment
   balanceResponsibleById(documentId: String!): BalanceResponsible!
   esettServiceStatus: [ReadinessStatusDto!]!

--- a/libs/dh/shared/test-util-mocks/src/metering-point.mocks.ts
+++ b/libs/dh/shared/test-util-mocks/src/metering-point.mocks.ts
@@ -38,6 +38,7 @@ import {
   mockGetMeteringPointNewConversationInfoQuery,
   mockGetMeteringPointsByGridAreaQuery,
   mockGetOperationToolsMeteringPointQuery,
+  mockGetProjectionsStatusQuery,
   mockGetRelatedMeteringPointsByIdQuery,
   mockMarkConversationReadMutation,
   mockMarkConversationUnReadMutation,
@@ -79,6 +80,7 @@ export function meteringPointMocks(apiBase: string) {
     getAggreatedMeasurementsForAllYears(),
     getRelatedMeteringPoints(),
     getOperationToolsMeteringPoint(),
+    getProjectionsStatus(),
     requestConnectionStateChange(),
     changeProductionObligation(),
     requestEndOfSupply(),
@@ -622,6 +624,22 @@ function getMeteringPointsByGridArea() {
       data: {
         __typename: 'Query',
         meteringPointsByGridAreaCode,
+      },
+    });
+  });
+}
+
+function getProjectionsStatus() {
+  return mockGetProjectionsStatusQuery(async () => {
+    await delay(mswConfig.delay);
+
+    return HttpResponse.json({
+      data: {
+        __typename: 'Query',
+        projectionsStatus: JSON.stringify({
+          status: 'ok',
+          projections: [],
+        }),
       },
     });
   });

--- a/libs/dh/shared/test-util-mocks/src/metering-point.mocks.ts
+++ b/libs/dh/shared/test-util-mocks/src/metering-point.mocks.ts
@@ -636,10 +636,39 @@ function getProjectionsStatus() {
     return HttpResponse.json({
       data: {
         __typename: 'Query',
-        projectionsStatus: JSON.stringify({
-          status: 'ok',
-          projections: [],
-        }),
+        projectionsStatus: {
+          __typename: 'GetProjectionsStatusResultDtoV1',
+          daemonHighWaterMark: '9854',
+          eventCount: '2359',
+          eventSequenceNumber: '9854',
+          streamCount: '1109',
+          projections: [
+            {
+              __typename: 'ProjectionStatus',
+              name: 'MeteringPointWithRelations:All',
+              assignedNodeNumber: 0,
+              action: 'Updated',
+              exception: null,
+              previousGoodMark: '0',
+              mode: 'continuous',
+              rebuildThreshold: '0',
+              sequence: '8659',
+              timestamp: new Date('2026-04-17T13:00:00.210217+00:00'),
+            },
+            {
+              __typename: 'ProjectionStatus',
+              name: 'HighWaterMark',
+              assignedNodeNumber: 0,
+              action: 'Updated',
+              exception: null,
+              previousGoodMark: '0',
+              mode: 'continuous',
+              rebuildThreshold: '0',
+              sequence: '9854',
+              timestamp: new Date('2026-04-17T13:00:00.2102256+00:00'),
+            },
+          ],
+        },
       },
     });
   });


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

Add a simple JSON view of the data returned from Electricity Market's `GetProjectionsStatusQuery`. This just shows all information and will probably be updated once we've tried using it.

Mocked data:
<img width="1585" height="1454" alt="image" src="https://github.com/user-attachments/assets/90193797-f9ea-4bcd-83f6-512a01eb55fe" />


