### PR TITLE
chore: ignore root-level terminalOutput file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ libs/dh/shared/domain/src/generated/graphql
 # nested node_modules
 node_modules
 
+# Nx Cloud may drop task terminal output at the workspace root; keep it out of "QA fixes" auto-commits
+/terminalOutput
+
 # Cypress
 cypress.env.json
 


### PR DESCRIPTION
## Summary

Nx Cloud started dropping a `terminalOutput` file at the workspace root during CI runs (content matches `graphql-codegen` output from `dh-shared-domain:generate`). The `Commit CI QA fixes` step in `pr.yml` uses `git add -A`, so the stray file was committed on every PR run (five `QA fixes` commits today).

The root-anchored `/terminalOutput` pattern suppresses only the misplaced file at repo root; `.nx/cache/<hash>/terminalOutput` files remain covered by the existing `.nx/cache` rule, and any legitimate file of the same name deeper in the tree is unaffected.

No issue associated.