### PR TITLE
fix(e2e): bump auth setup timeout and split MSAL hash wait

### DIFF
--- a/apps/dh/e2e-dh/src/e2e/auth.setup.ts
+++ b/apps/dh/e2e-dh/src/e2e/auth.setup.ts
@@ -81,8 +81,7 @@ setup('authenticate', async ({ page, context, baseURL }) => {
       const hashParams = new URLSearchParams(
         url.hash.startsWith('#') ? url.hash.slice(1) : url.hash
       );
-      const hasAuthParamsInSearch =
-        url.searchParams.has('code') || url.searchParams.has('state');
+      const hasAuthParamsInSearch = url.searchParams.has('code') || url.searchParams.has('state');
       const hasAuthParamsInHash = hashParams.has('code') || hashParams.has('state');
       return url.hostname === appHost && !hasAuthParamsInSearch && !hasAuthParamsInHash;
     },

--- a/apps/dh/e2e-dh/src/e2e/auth.setup.ts
+++ b/apps/dh/e2e-dh/src/e2e/auth.setup.ts
@@ -39,15 +39,17 @@ setup('authenticate', async ({ page, context, baseURL }) => {
     );
   }
 
-  // Decline cookie banner ahead of navigation so it does not intercept clicks. Derive the
-  // domain from baseURL so the cookie applies whether tests run against localhost (mocked
-  // dev server) or a deployed env (acceptance tests against dev_xxx / preprod).
-  const cookieDomain = baseURL ? new URL(baseURL).hostname : 'localhost';
+  // Hostname of the app under test, used both as the cookie domain for the cookie-consent
+  // pre-decline below and as the post-login URL gate further down. Derived from baseURL so
+  // it works against localhost (mocked dev server) and any deployed env.
+  const appHost = baseURL ? new URL(baseURL).hostname : 'localhost';
+
+  // Decline cookie banner ahead of navigation so it does not intercept clicks.
   await context.addCookies([
     {
       name: 'CookieInformationConsent',
       value: encodeURIComponent('{"consents_approved":[]}'),
-      domain: cookieDomain,
+      domain: appHost,
       path: '/',
       sameSite: 'Lax',
       secure: true,
@@ -75,7 +77,6 @@ setup('authenticate', async ({ page, context, baseURL }) => {
   // resolve immediately) AND that the auth params have been cleared. This means a stuck MSAL
   // surfaces here with a clear "URL still contains auth params" failure instead of a
   // downstream "profileMenu not visible".
-  const appHost = baseURL ? new URL(baseURL).hostname : 'localhost';
   await page.waitForURL(
     (url) => {
       const hashParams = new URLSearchParams(

--- a/apps/dh/e2e-dh/src/e2e/auth.setup.ts
+++ b/apps/dh/e2e-dh/src/e2e/auth.setup.ts
@@ -63,12 +63,25 @@ setup('authenticate', async ({ page, context, baseURL }) => {
   await page.getByRole('textbox', { name: /password|adgangskode/i }).fill(password);
   await page.getByRole('button', { name: /log på|sign in/i }).click();
 
-  // Wait for MSAL to consume the auth code from the redirect URL. B2C sends the user back to
-  // the app with `#state=...&code=...` in the hash; MSAL parses it, exchanges the code for
-  // tokens, then strips the hash via history.replaceState. Splitting the wait this way means
-  // an MSAL hang surfaces here with a clear "URL still contains #state=" failure rather than
-  // a downstream "profileMenu not visible".
-  await page.waitForURL((url) => !url.hash.includes('state='), { timeout: 60_000 });
+  // Wait for MSAL to consume the auth response after B2C redirects back to the app. MSAL is
+  // configured with the default `fragment` response mode (see dh-b2c-config.ts), so B2C sends
+  // the user back to the app with `#state=...&code=...` in the hash; MSAL parses it, exchanges
+  // the code for tokens, then strips the hash via history.replaceState. We also defensively
+  // check `?code=` in case the response mode is ever flipped to `query`.
+  //
+  // The predicate must require BOTH that we are back on the app's host (not still on B2C's
+  // *.b2clogin.com confirm page, where the hash is empty and the predicate would otherwise
+  // resolve immediately) AND that the auth params have been cleared. This means a stuck MSAL
+  // surfaces here with a clear "URL still contains #state=" failure instead of a downstream
+  // "profileMenu not visible".
+  const appHost = baseURL ? new URL(baseURL).hostname : 'localhost';
+  await page.waitForURL(
+    (url) =>
+      url.hostname === appHost &&
+      !url.hash.includes('state=') &&
+      !url.search.includes('code='),
+    { timeout: 60_000 }
+  );
 
   // Login is complete when the authenticated shell renders. The profile menu only exists
   // on authenticated pages, so this works regardless of the user's default landing route.

--- a/apps/dh/e2e-dh/src/e2e/auth.setup.ts
+++ b/apps/dh/e2e-dh/src/e2e/auth.setup.ts
@@ -66,18 +66,26 @@ setup('authenticate', async ({ page, context, baseURL }) => {
   // Wait for MSAL to consume the auth response after B2C redirects back to the app. MSAL is
   // configured with the default `fragment` response mode (see dh-b2c-config.ts), so B2C sends
   // the user back to the app with `#state=...&code=...` in the hash; MSAL parses it, exchanges
-  // the code for tokens, then strips the hash via history.replaceState. We also defensively
-  // check `?code=` in case the response mode is ever flipped to `query`.
+  // the code for tokens, then strips the hash via history.replaceState. We assert that both
+  // `code` and `state` are absent from both the query string and the hash so the predicate
+  // stays correct if response mode is ever flipped to `query`.
   //
   // The predicate must require BOTH that we are back on the app's host (not still on B2C's
   // *.b2clogin.com confirm page, where the hash is empty and the predicate would otherwise
   // resolve immediately) AND that the auth params have been cleared. This means a stuck MSAL
-  // surfaces here with a clear "URL still contains #state=" failure instead of a downstream
-  // "profileMenu not visible".
+  // surfaces here with a clear "URL still contains auth params" failure instead of a
+  // downstream "profileMenu not visible".
   const appHost = baseURL ? new URL(baseURL).hostname : 'localhost';
   await page.waitForURL(
-    (url) =>
-      url.hostname === appHost && !url.hash.includes('state=') && !url.search.includes('code='),
+    (url) => {
+      const hashParams = new URLSearchParams(
+        url.hash.startsWith('#') ? url.hash.slice(1) : url.hash
+      );
+      const hasAuthParamsInSearch =
+        url.searchParams.has('code') || url.searchParams.has('state');
+      const hasAuthParamsInHash = hashParams.has('code') || hashParams.has('state');
+      return url.hostname === appHost && !hasAuthParamsInSearch && !hasAuthParamsInHash;
+    },
     { timeout: 60_000 }
   );
 

--- a/apps/dh/e2e-dh/src/e2e/auth.setup.ts
+++ b/apps/dh/e2e-dh/src/e2e/auth.setup.ts
@@ -24,6 +24,12 @@ const STORAGE_STATE = path.resolve(__dirname, '..', '..', '.auth', 'user.json');
 const SESSION_STORAGE_STATE = path.resolve(__dirname, '..', '..', '.auth', 'session.json');
 
 setup('authenticate', async ({ page, context, baseURL }) => {
+  // Acceptance runs hit a real B2C tenant: redirect chain, token exchange, and the initial
+  // GraphQL roundtrip after sign-in regularly consume 20-40s on slower dev envs. The default
+  // 30s test budget leaves no headroom for the post-login profileMenu wait, so we extend the
+  // whole setup. Login itself is the slow step; subsequent specs reuse the saved storage state.
+  setup.setTimeout(120_000);
+
   const email = process.env['DH_E2E_USERNAME'] ?? '';
   const password = process.env['DH_E2E_PASSWORD'] ?? '';
 
@@ -56,6 +62,13 @@ setup('authenticate', async ({ page, context, baseURL }) => {
   await page.getByRole('textbox', { name: /email address|mailadresse/i }).fill(email);
   await page.getByRole('textbox', { name: /password|adgangskode/i }).fill(password);
   await page.getByRole('button', { name: /log på|sign in/i }).click();
+
+  // Wait for MSAL to consume the auth code from the redirect URL. B2C sends the user back to
+  // the app with `#state=...&code=...` in the hash; MSAL parses it, exchanges the code for
+  // tokens, then strips the hash via history.replaceState. Splitting the wait this way means
+  // an MSAL hang surfaces here with a clear "URL still contains #state=" failure rather than
+  // a downstream "profileMenu not visible".
+  await page.waitForURL((url) => !url.hash.includes('state='), { timeout: 60_000 });
 
   // Login is complete when the authenticated shell renders. The profile menu only exists
   // on authenticated pages, so this works regardless of the user's default landing route.

--- a/apps/dh/e2e-dh/src/e2e/auth.setup.ts
+++ b/apps/dh/e2e-dh/src/e2e/auth.setup.ts
@@ -77,9 +77,7 @@ setup('authenticate', async ({ page, context, baseURL }) => {
   const appHost = baseURL ? new URL(baseURL).hostname : 'localhost';
   await page.waitForURL(
     (url) =>
-      url.hostname === appHost &&
-      !url.hash.includes('state=') &&
-      !url.search.includes('code='),
+      url.hostname === appHost && !url.hash.includes('state=') && !url.search.includes('code='),
     { timeout: 60_000 }
   );
 


### PR DESCRIPTION
Acceptance runs on dev_001 fail intermittently because the default 30s test budget is consumed by the real B2C redirect chain and token exchange before the post-login profileMenu wait gets a chance. Bump the setup test timeout to 120s and add an explicit waitForURL that completes when MSAL has cleared the #state hash, which improves failure observability when MSAL itself is the bottleneck.

Refs #5729

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/greenforce-frontend) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

- #0000


