### PR TITLE
fix(watt): position date chip overlay below the chip

### DIFF
--- a/libs/watt/package/chip/watt-date-chip.component.ts
+++ b/libs/watt/package/chip/watt-date-chip.component.ts
@@ -32,7 +32,7 @@ import { WattMenuChipComponent } from './watt-menu-chip.component';
   styles: [
     `
       watt-date-chip {
-        input {
+        input.cdk-visually-hidden {
           top: 0;
           bottom: 0;
           height: auto;
@@ -46,7 +46,7 @@ import { WattMenuChipComponent } from './watt-menu-chip.component';
     `,
   ],
   template: `
-    <mat-datepicker #picker />
+    <mat-datepicker #picker panelClass="watt-date-chip__panel" />
     <watt-field [control]="formControl()" [chipMode]="true">
       <watt-menu-chip
         hasPopup="dialog"

--- a/libs/watt/package/chip/watt-date-range-chip.component.ts
+++ b/libs/watt/package/chip/watt-date-range-chip.component.ts
@@ -92,7 +92,7 @@ export class WattDateRangeSelectionStrategy extends DefaultMatCalendarRangeStrat
   styles: [
     `
       watt-date-range-chip {
-        mat-date-range-input {
+        mat-date-range-input.cdk-visually-hidden {
           top: 0;
           bottom: 0;
           height: auto;
@@ -107,10 +107,15 @@ export class WattDateRangeSelectionStrategy extends DefaultMatCalendarRangeStrat
           background-color: transparent;
         }
       }
+
+      .cdk-overlay-pane:has(.watt-date-chip__panel),
+      .cdk-overlay-pane:has(.watt-date-range-chip__panel) {
+        margin-top: var(--watt-space-xs);
+      }
     `,
   ],
   template: `
-    <mat-date-range-picker #picker>
+    <mat-date-range-picker #picker panelClass="watt-date-range-chip__panel">
       @if (showActions()) {
         <mat-date-range-picker-actions>
           <watt-button variant="text" (click)="clearInput()" icon="remove">{{

--- a/libs/watt/package/chip/watt-date-range-chip.component.ts
+++ b/libs/watt/package/chip/watt-date-range-chip.component.ts
@@ -107,11 +107,6 @@ export class WattDateRangeSelectionStrategy extends DefaultMatCalendarRangeStrat
           background-color: transparent;
         }
       }
-
-      .cdk-overlay-pane:has(.watt-date-chip__panel),
-      .cdk-overlay-pane:has(.watt-date-range-chip__panel) {
-        margin-top: var(--watt-space-xs);
-      }
     `,
   ],
   template: `

--- a/libs/watt/package/core/styles/@energinet/watt/theme/material-overwrites/datepicker.scss
+++ b/libs/watt/package/core/styles/@energinet/watt/theme/material-overwrites/datepicker.scss
@@ -73,3 +73,9 @@
   border-bottom: 1px solid var(--watt-color-secondary);
   border-top: 1px solid var(--watt-color-secondary);
 }
+
+// Visual gap between the chip trigger and the datepicker overlay it opens
+.cdk-overlay-pane:has(.watt-date-chip__panel),
+.cdk-overlay-pane:has(.watt-date-range-chip__panel) {
+  margin-top: var(--watt-space-xs);
+}

--- a/libs/watt/package/package.json
+++ b/libs/watt/package/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@energinet/watt",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "license": "Apache-2.0",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

- Bumper specificiteten på input-overrides i `watt-date-chip` og `watt-date-range-chip` så `cdk-visually-hidden` ikke længere overskriver `height: auto`. Det skjulte input strækker sig nu over hele chip-wrapperen, så Materials datepicker-overlay forankres ved chippets bund i stedet for at lægge sig oven på chippet.
- Tilføjer en `panelClass` på begge pickere og en `margin-top: var(--watt-space-xs)` på `.cdk-overlay-pane` via `:has()`, så kalenderen får et lille visuelt mellemrum til chippet.

<img width="344" height="417" alt="image" src="https://github.com/user-attachments/assets/e440d06a-dcac-44fd-af31-41cc56ffecf4" />


Ref: #2588