### PR TITLE
chore(deps): bump @testing-library/user-event from 13.5.0 to 14.6.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -97,7 +97,7 @@
         "@swc/helpers": "0.5.19",
         "@testing-library/angular": "18.1.1",
         "@testing-library/jest-dom": "6.6.3",
-        "@testing-library/user-event": "13.5.0",
+        "@testing-library/user-event": "14.6.1",
         "@types/crypto-js": "4.2.2",
         "@types/encoding-japanese": "2.2.1",
         "@types/express": "4.17.14",
@@ -1415,7 +1415,7 @@
 
     "@testing-library/jest-dom": ["@testing-library/jest-dom@6.6.3", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "chalk": "^3.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "lodash": "^4.17.21", "redent": "^3.0.0" } }, "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA=="],
 
-    "@testing-library/user-event": ["@testing-library/user-event@13.5.0", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg=="],
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@theguild/federation-composition": ["@theguild/federation-composition@0.21.3", "", { "dependencies": { "constant-case": "^3.0.4", "debug": "4.4.3", "json5": "^2.2.3", "lodash.sortby": "^4.7.0" }, "peerDependencies": { "graphql": "^16.0.0" } }, "sha512-+LlHTa4UbRpZBog3ggAxjYIFvdfH3UMvvBUptur19TMWkqU4+n3GmN+mDjejU+dyBXIG27c25RsiQP1HyvM99g=="],
 
@@ -4777,8 +4777,6 @@
 
     "@testing-library/jest-dom/chalk": ["chalk@3.0.0", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg=="],
 
-    "@testing-library/user-event/@babel/runtime": ["@babel/runtime@7.28.3", "", {}, "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA=="],
-
     "@ts-morph/common/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@ts-morph/common/mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
@@ -5416,8 +5414,6 @@
     "ssri/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
-
-    "storybook/@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "storybook/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 

--- a/libs/dh/admin/feature-user-roles/tests/user-roles.component.spec.ts
+++ b/libs/dh/admin/feature-user-roles/tests/user-roles.component.spec.ts
@@ -120,9 +120,10 @@ describe(DhUserRolesComponent, () => {
     ];
 
     await setup({ mockData: localMockData });
+    const user = userEvent.setup();
 
     const [selectAllCheckbox] = screen.getAllByRole('checkbox');
-    userEvent.click(selectAllCheckbox);
+    await user.click(selectAllCheckbox);
 
     expect(screen.getByText('Select at least one user role')).toBeInTheDocument();
   });
@@ -144,10 +145,11 @@ describe(DhUserRolesComponent, () => {
     const { updateUserRolesOutput } = await setup({
       mockData: localMockData,
     });
+    const user = userEvent.setup();
 
     const [, secondCheckbox, thirdCheckbox] = screen.getAllByRole('checkbox');
     // Select a previously unselected role
-    userEvent.click(thirdCheckbox);
+    await user.click(thirdCheckbox);
 
     let expectedOutput: UpdateUserRoles = {
       actors: [
@@ -172,7 +174,7 @@ describe(DhUserRolesComponent, () => {
     expect(updateUserRolesOutput).toHaveBeenCalledWith(expectedOutput);
 
     // Unselect a previously selected role
-    userEvent.click(secondCheckbox);
+    await user.click(secondCheckbox);
 
     expectedOutput = {
       actors: [

--- a/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
@@ -138,6 +138,7 @@ describe('Process overview details', () => {
 
   it('should open disconnect modal when request disconnection is clicked', async () => {
     await setup('process-eos-cancel');
+    const user = userEvent.setup();
     await waitForAsync(() =>
       expect(
         screen.getAllByRole('button', { name: /Request disconnection/i }).length
@@ -147,7 +148,7 @@ describe('Process overview details', () => {
       name: /Request disconnection/i,
     });
 
-    userEvent.click(disconnectButton);
+    await user.click(disconnectButton);
 
     await waitForAsync(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
     const dialog = screen.getByRole('dialog');
@@ -156,6 +157,7 @@ describe('Process overview details', () => {
 
   it('should close disconnect modal after submitting', async () => {
     await setup('process-eos-cancel');
+    const user = userEvent.setup();
     await waitForAsync(() =>
       expect(
         screen.getAllByRole('button', { name: /Request disconnection/i }).length
@@ -164,14 +166,14 @@ describe('Process overview details', () => {
     const [disconnectButton] = screen.getAllByRole('button', {
       name: /Request disconnection/i,
     });
-    userEvent.click(disconnectButton);
+    await user.click(disconnectButton);
     await waitForAsync(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
 
     const dialog = screen.getByRole('dialog');
     const confirmButton = within(dialog).getByRole('button', {
       name: /Request disconnection/i,
     });
-    userEvent.click(confirmButton);
+    await user.click(confirmButton);
 
     await waitForAsync(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
@@ -185,6 +187,7 @@ describe('Process overview details', () => {
 
   it('should navigate with internalMeteringPointId when Send information is clicked', async () => {
     const fixture = await setup('process-cmi-info');
+    const user = userEvent.setup();
     const router = fixture.debugElement.injector.get(Router);
     vi.spyOn(router, 'navigate').mockResolvedValue(true);
 
@@ -193,7 +196,7 @@ describe('Process overview details', () => {
     );
     const sendInfoButtons = screen.getAllByRole('button', { name: /Send information/i });
 
-    userEvent.click(sendInfoButtons[0]);
+    await user.click(sendInfoButtons[0]);
 
     await waitForAsync(() =>
       expect(router.navigate).toHaveBeenCalledWith([

--- a/libs/dh/metering-point/feature-process-overview/tests/overview.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/overview.spec.ts
@@ -108,13 +108,14 @@ describe('Process overview', () => {
 
   it('should show cancel button and open modal when clicked', async () => {
     await setup();
+    const user = userEvent.setup();
 
     await waitForAsync(() =>
       expect(screen.getAllByRole('button', { name: /Cancel/i }).length).toBeGreaterThan(0)
     );
     const cancelButtons = screen.getAllByRole('button', { name: /Cancel/i });
 
-    userEvent.click(cancelButtons[0]);
+    await user.click(cancelButtons[0]);
 
     await waitForAsync(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -127,6 +128,7 @@ describe('Process overview', () => {
 
   it('should show send information button and navigate when clicked', async () => {
     const fixture = await setup();
+    const user = userEvent.setup();
     const router = fixture.debugElement.injector.get(Router);
     vi.spyOn(router, 'navigate').mockResolvedValue(true);
 
@@ -135,7 +137,7 @@ describe('Process overview', () => {
     );
     const sendInfoButtons = screen.getAllByRole('button', { name: /Send information/i });
 
-    userEvent.click(sendInfoButtons[0]);
+    await user.click(sendInfoButtons[0]);
 
     await waitForAsync(() =>
       expect(router.navigate).toHaveBeenCalledWith([

--- a/libs/watt/package/breadcrumbs/watt-breadcrumbs.component.spec.ts
+++ b/libs/watt/package/breadcrumbs/watt-breadcrumbs.component.spec.ts
@@ -125,13 +125,14 @@ describe(WattBreadcrumbsComponent.name, () => {
 
   it('should navigate on click, when routerLink is added', async () => {
     await setup();
+    const user = userEvent.setup();
 
     // Initially should show overview route
     await waitForAsync(() => {
       expect(screen.getByText(`${ROUTE_PREFIX}Overview`)).toBeInTheDocument();
     });
 
-    userEvent.click(getBreadcrumbWithRouterLink() as HTMLElement);
+    await user.click(getBreadcrumbWithRouterLink() as HTMLElement);
 
     // Should navigate to breadcrumbs route
     await waitForAsync(() => {
@@ -145,8 +146,9 @@ describe(WattBreadcrumbsComponent.name, () => {
   it('should trigger click callback, when (click) is added', async () => {
     const mockFn = vi.fn();
     await setup(mockFn);
+    const user = userEvent.setup();
 
-    userEvent.click(getBreadcrumbWithClick() as HTMLElement);
+    await user.click(getBreadcrumbWithClick() as HTMLElement);
 
     expect(mockFn).toHaveBeenCalled();
   });

--- a/libs/watt/package/button/watt-button.component.spec.ts
+++ b/libs/watt/package/button/watt-button.component.spec.ts
@@ -109,6 +109,7 @@ describe(WattButtonComponent, () => {
     const renderResult = await renderComponent({
       disabled: true,
     });
+    const user = userEvent.setup();
 
     const wattButton = renderResult.container;
 
@@ -118,7 +119,7 @@ describe(WattButtonComponent, () => {
     });
 
     if (wattButton) {
-      expect(() => userEvent.click(wattButton)).toThrow();
+      await expect(user.click(wattButton)).rejects.toThrow();
     }
   });
 

--- a/libs/watt/package/checkbox/watt-checkbox.module.spec.ts
+++ b/libs/watt/package/checkbox/watt-checkbox.module.spec.ts
@@ -88,9 +88,10 @@ describe(WattCheckboxComponent, () => {
     it('prevents clicking on disabled checkbox', async () => {
       const initialState = { value: true, disabled: true };
       const { fixture, checkboxLabel } = await setup(initialState);
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
 
       if (checkboxLabel) {
-        userEvent.click(checkboxLabel);
+        await user.click(checkboxLabel);
         await fixture.whenStable();
       }
 
@@ -102,9 +103,10 @@ describe(WattCheckboxComponent, () => {
     it.skip('can click on checkbox after enabling it', async () => {
       const initialState = { value: true, disabled: true };
       const { fixture, checkboxLabel } = await setup(initialState);
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
 
       if (checkboxLabel) {
-        userEvent.click(checkboxLabel);
+        await user.click(checkboxLabel);
         await fixture.whenStable();
       }
 
@@ -114,7 +116,7 @@ describe(WattCheckboxComponent, () => {
       fixture.componentInstance.checkboxControl.enable();
 
       if (checkboxLabel) {
-        userEvent.click(checkboxLabel);
+        await user.click(checkboxLabel);
         await fixture.whenStable();
       }
 

--- a/libs/watt/package/chip/watt-date-range-chip.component.spec.ts
+++ b/libs/watt/package/chip/watt-date-range-chip.component.spec.ts
@@ -126,9 +126,10 @@ describe(WattDateRangeChipComponent.name, () => {
 
   it('should open date picker when clicked', async () => {
     await setup();
+    const user = userEvent.setup();
 
     const chip = screen.getByRole('button', { pressed: false });
-    userEvent.click(chip);
+    await user.click(chip);
 
     await waitForAsync(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -198,9 +199,10 @@ describe(WattDateRangeChipComponent.name, () => {
 
   it('should show clear and select buttons when showActions is true', async () => {
     await setup({ showActions: true });
+    const user = userEvent.setup();
 
     const chip = screen.getByRole('button');
-    userEvent.click(chip);
+    await user.click(chip);
 
     await waitForAsync(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -220,9 +222,10 @@ describe(WattDateRangeChipComponent.name, () => {
       formControl: new FormControl(dateRange),
       showActions: true,
     });
+    const user = userEvent.setup();
 
     const chip = screen.getByRole('button');
-    userEvent.click(chip);
+    await user.click(chip);
 
     await waitForAsync(() => {
       const clearButton = screen.getByRole('button', { name: /clear/i });
@@ -230,7 +233,7 @@ describe(WattDateRangeChipComponent.name, () => {
     });
 
     const clearButton = screen.getByRole('button', { name: /clear/i });
-    userEvent.click(clearButton);
+    await user.click(clearButton);
 
     expect(selectionChangeSpy).toHaveBeenCalledWith(null);
   });

--- a/libs/watt/package/clipboard/watt-copy-to-clipboard.directive.spec.ts
+++ b/libs/watt/package/clipboard/watt-copy-to-clipboard.directive.spec.ts
@@ -26,8 +26,9 @@ describe(WattCopyToClipboardDirective, () => {
     await render(`<span wattCopyToClipboard>Text</span>`, {
       imports: [WattCopyToClipboardDirective],
     });
+    const user = userEvent.setup();
 
-    userEvent.click(screen.getByText('Text'));
+    await user.click(screen.getByText('Text'));
 
     // Clipboard only works in an actual browser
     expect(screen.getByText('Failed to copy')).toBeInTheDocument();

--- a/libs/watt/package/drawer/watt-drawer.component.spec.ts
+++ b/libs/watt/package/drawer/watt-drawer.component.spec.ts
@@ -285,10 +285,18 @@ describe(WattDrawerComponent, () => {
   });
 
   it('does not call "closed" on Escape when drawer is closed', async () => {
-    await setup(defaultTemplate);
-    const user = userEvent.setup();
+    const { container } = await setup(defaultTemplate);
 
-    await user.keyboard('{Escape}');
+    // Dispatch keydown directly on the drawer host so the (keydown.escape)
+    // listener actually receives it. user.keyboard sends the event to the
+    // focused element (typically body), and the event would bubble upward
+    // away from the drawer rather than into it, so the listener would never
+    // fire and the assertion would pass for the wrong reason.
+    const drawer = container.querySelector(DRAWER_SELECTOR);
+    if (drawer) {
+      const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+      drawer.dispatchEvent(event);
+    }
 
     expect(closedOutput).not.toHaveBeenCalled();
   });

--- a/libs/watt/package/drawer/watt-drawer.component.spec.ts
+++ b/libs/watt/package/drawer/watt-drawer.component.spec.ts
@@ -111,10 +111,11 @@ describe(WattDrawerComponent, () => {
 
   it('should open drawer', async () => {
     await setup(defaultTemplate);
+    const user = userEvent.setup();
 
     expect(getDrawerContent()).not.toBeInTheDocument();
 
-    userEvent.click(getOpenDrawerButton());
+    await user.click(getOpenDrawerButton());
 
     expect(getDrawerTopBarContent()).toBeInTheDocument();
     expect(getDrawerActions()).toBeInTheDocument();
@@ -123,9 +124,10 @@ describe(WattDrawerComponent, () => {
 
   it('should not add content more than once, when "open" is called multiple times', async () => {
     await setup(defaultTemplate);
+    const user = userEvent.setup();
 
-    userEvent.click(getOpenDrawerButton());
-    userEvent.click(getOpenDrawerButton());
+    await user.click(getOpenDrawerButton());
+    await user.click(getOpenDrawerButton());
 
     expect(getDrawerTopBarContent()).toBeInTheDocument();
     expect(getDrawerActions()).toBeInTheDocument();
@@ -134,8 +136,9 @@ describe(WattDrawerComponent, () => {
 
   it('should not load content, before the drawer is opened', async () => {
     await setup(defaultTemplate);
+    const user = userEvent.setup();
 
-    userEvent.click(getOpenDrawerButton());
+    await user.click(getOpenDrawerButton());
 
     await waitForAsync(() => {
       expect(getInitialTimer()).toBeInTheDocument();
@@ -144,18 +147,20 @@ describe(WattDrawerComponent, () => {
 
   it('should close drawer, triggered externally outside of the drawer', async () => {
     await setup(defaultTemplate);
+    const user = userEvent.setup();
 
-    userEvent.click(getOpenDrawerButton());
-    userEvent.click(getExternalCloseDrawerButton());
+    await user.click(getOpenDrawerButton());
+    await user.click(getExternalCloseDrawerButton());
 
     expect(getDrawerContent()).not.toBeInTheDocument();
   });
 
   it('should close drawer, triggered internally inside of the drawer', async () => {
     await setup(defaultTemplate);
+    const user = userEvent.setup();
 
-    userEvent.click(getOpenDrawerButton());
-    userEvent.click(getInternalCloseDrawerButton());
+    await user.click(getOpenDrawerButton());
+    await user.click(getInternalCloseDrawerButton());
 
     expect(getDrawerContent()).not.toBeInTheDocument();
   });
@@ -168,16 +173,17 @@ describe(WattDrawerComponent, () => {
   it.skip('should destroy content when closing', async () => {
     vi.useFakeTimers();
     await setup(defaultTemplate);
+    const user = userEvent.setup();
 
-    userEvent.click(getOpenDrawerButton());
+    await user.click(getOpenDrawerButton());
     await waitForAsync(
       () => {
         expect(getStartedTimer()).toBeInTheDocument();
       },
       { timeout: 2000 }
     );
-    userEvent.click(getInternalCloseDrawerButton());
-    userEvent.click(getOpenDrawerButton());
+    await user.click(getInternalCloseDrawerButton());
+    await user.click(getOpenDrawerButton());
 
     await waitForAsync(() => {
       expect(getStartedTimer()).not.toBeInTheDocument();
@@ -188,30 +194,33 @@ describe(WattDrawerComponent, () => {
 
   it('should output `closed` when drawer is closed', async () => {
     await setup(defaultTemplate);
+    const user = userEvent.setup();
 
-    userEvent.click(getOpenDrawerButton());
+    await user.click(getOpenDrawerButton());
     await waitForAsync(() => expect(getDrawerContent()).toBeInTheDocument());
 
-    userEvent.click(getInternalCloseDrawerButton());
+    await user.click(getInternalCloseDrawerButton());
 
     await waitForAsync(() => expect(closedOutput).toHaveBeenCalled());
   });
 
   it('should output `closed` when drawer is closed, from outside the drawer', async () => {
     await setup(defaultTemplate);
+    const user = userEvent.setup();
 
-    userEvent.click(getOpenDrawerButton());
+    await user.click(getOpenDrawerButton());
     await waitForAsync(() => expect(getDrawerContent()).toBeInTheDocument());
 
-    userEvent.click(getExternalCloseDrawerButton());
+    await user.click(getExternalCloseDrawerButton());
 
     await waitForAsync(() => expect(closedOutput).toHaveBeenCalled());
   });
 
   it('closes on global Escape', async () => {
     const { container } = await setup(defaultTemplate);
+    const user = userEvent.setup();
 
-    userEvent.click(getOpenDrawerButton());
+    await user.click(getOpenDrawerButton());
     await waitForAsync(() => expect(getDrawerContent()).toBeInTheDocument());
 
     // Find the drawer element and dispatch escape key event on it
@@ -226,8 +235,9 @@ describe(WattDrawerComponent, () => {
 
   it('closes on Escape when focus is in the drawer', async () => {
     const { container } = await setup(defaultTemplate);
+    const user = userEvent.setup();
 
-    userEvent.click(getOpenDrawerButton());
+    await user.click(getOpenDrawerButton());
     await waitForAsync(() => expect(getDrawerContent()).toBeInTheDocument());
 
     // Focus on drawer content and dispatch escape key
@@ -243,8 +253,9 @@ describe(WattDrawerComponent, () => {
 
   it.skip('calls "closed" only once when Escape is pressed multiple times', async () => {
     const { container } = await setup(defaultTemplate);
+    const user = userEvent.setup();
 
-    userEvent.click(getOpenDrawerButton());
+    await user.click(getOpenDrawerButton());
     await waitForAsync(() => expect(getDrawerContent()).toBeInTheDocument());
 
     // Reset the spy
@@ -275,8 +286,9 @@ describe(WattDrawerComponent, () => {
 
   it('does not call "closed" on Escape when drawer is closed', async () => {
     await setup(defaultTemplate);
+    const user = userEvent.setup();
 
-    userEvent.keyboard('{Escape}');
+    await user.keyboard('{Escape}');
 
     expect(closedOutput).not.toHaveBeenCalled();
   });
@@ -304,13 +316,14 @@ describe(WattDrawerComponent, () => {
 
   it('closes drawer when another drawer is opened', async () => {
     await setup(multipleTemplate);
+    const user = userEvent.setup();
     const firstButton = screen.getByRole('button', { name: /^open first/i });
     const secondButton = screen.getByRole('button', { name: /^open second/i });
 
-    userEvent.click(firstButton);
+    await user.click(firstButton);
     await waitForAsync(() => expect(screen.queryByText(/first drawer/i)).toBeInTheDocument());
 
-    userEvent.click(secondButton);
+    await user.click(secondButton);
 
     await waitForAsync(() => {
       expect(closedOutput).toHaveBeenCalled();
@@ -321,8 +334,9 @@ describe(WattDrawerComponent, () => {
 
   it('shows loading state', async () => {
     await setup(defaultTemplate, { loading: true });
+    const user = userEvent.setup();
 
-    userEvent.click(getOpenDrawerButton());
+    await user.click(getOpenDrawerButton());
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
@@ -331,15 +345,16 @@ describe(WattDrawerComponent, () => {
   // It passes when executed individually but fails as part of the complete test suite.
   it.skip('closes drawer when clicking outside', async () => {
     await setup(multipleTemplate);
+    const user = userEvent.setup();
 
-    userEvent.click(screen.getByRole('button', { name: /^open first/i }));
+    await user.click(screen.getByRole('button', { name: /^open first/i }));
 
     // This is an implementation detail, but it is the only way to test
     // this behavior - otherwise the second click is happening in
     // the same event loop as the button click (synchronous).
     await new Promise((res) => setTimeout(res, 0));
 
-    userEvent.click(document.body);
+    await user.click(document.body);
 
     expect(closedOutput).toHaveBeenCalled();
     expect(getDrawerTopBarContent()).not.toBeInTheDocument();
@@ -347,9 +362,10 @@ describe(WattDrawerComponent, () => {
 
   it('does not call "closed" when click outside triggers an open', async () => {
     await setup(multipleTemplate);
+    const user = userEvent.setup();
 
-    userEvent.click(screen.getByRole('button', { name: /^open first/i }));
-    userEvent.click(screen.getByRole('button', { name: /^open second/i }));
+    await user.click(screen.getByRole('button', { name: /^open first/i }));
+    await user.click(screen.getByRole('button', { name: /^open second/i }));
 
     expect(closedOutput).not.toHaveBeenCalled();
     await waitForAsync(() => expect(screen.queryByText(/second drawer/i)).toBeInTheDocument());

--- a/libs/watt/package/dropdown/watt-dropdown.component.spec.ts
+++ b/libs/watt/package/dropdown/watt-dropdown.component.spec.ts
@@ -70,17 +70,18 @@ describe(WattDropdownComponent, () => {
     }
 
     const { fixture } = await render(TestComponent, { providers: [FormGroupDirective] });
-    userEvent.click(screen.getByRole('combobox')); // open dropdown before each test
-    return fixture.componentInstance;
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('combobox')); // open dropdown before each test
+    return { component: fixture.componentInstance, user };
   }
 
   it('can select an option from the dropdown', async () => {
-    const component = await setup();
+    const { component, user } = await setup();
 
     const [firstOption] = dropdownOptions;
     const option = screen.getByRole('option', { name: firstOption.displayValue });
 
-    userEvent.click(option);
+    await user.click(option);
 
     expect(component.control.value).toBe(firstOption.value);
   });
@@ -102,33 +103,33 @@ describe(WattDropdownComponent, () => {
 
     it('can reset the dropdown', async () => {
       const [firstOption] = dropdownOptions;
-      const component = await setup({ initialState: firstOption.value });
+      const { component, user } = await setup({ initialState: firstOption.value });
 
       const resetOption = screen.getByRole('option', { name: '—' });
-      userEvent.click(resetOption);
+      await user.click(resetOption);
 
       expect(component.control.value).toBeNull();
     });
 
     it('cannot reset the dropdown if showResetOption is false', async () => {
       const [firstOption] = dropdownOptions;
-      const component = await setup({
+      const { component, user } = await setup({
         initialState: firstOption.value,
         showResetOption: false,
       });
 
       // for each option, click the option and verify selected is not null
       for (const option of screen.getAllByRole('option')) {
-        userEvent.click(option);
+        await user.click(option);
         expect(component.control.value).not.toBe(null);
       }
     });
 
     it('can filter the available options', async () => {
-      await setup();
+      const { user } = await setup();
 
       const filterInput = screen.getByRole('textbox', { name: 'dropdown search' });
-      userEvent.type(filterInput, 'Bat');
+      await user.type(filterInput, 'Bat');
 
       const options = screen.getAllByRole('option').map((option) => option.textContent?.trim());
       expect(options).toContain('Batman');
@@ -139,37 +140,39 @@ describe(WattDropdownComponent, () => {
   describe('multi selection', () => {
     it('can reset the dropdown', async () => {
       const [firstOption, secondOption] = dropdownOptions;
-      const component = await setup({
+      const { component, user } = await setup({
         initialState: [firstOption.value, secondOption.value],
         multiple: true,
       });
 
       expect(component.control.value).toEqual([firstOption.value, secondOption.value]);
 
-      screen.getAllByRole('option', { selected: true }).forEach((o) => userEvent.click(o));
+      for (const o of screen.getAllByRole('option', { selected: true })) {
+        await user.click(o);
+      }
       expect(component.control.value).toBeNull();
     });
 
     it('can select/unselect all options via a toggle all checkbox', async () => {
-      const component = await setup({ multiple: true });
+      const { component, user } = await setup({ multiple: true });
 
       expect(component.control.value).toBeNull();
 
       const checkbox = screen.getByRole('checkbox');
 
-      userEvent.click(checkbox);
+      await user.click(checkbox);
       expect(component.control.value).toStrictEqual(dropdownOptions.map((o) => o.value));
 
-      userEvent.click(checkbox);
+      await user.click(checkbox);
       expect(component.control.value).toBeNull();
     });
 
     it('shows a label when no options can be found after filtering', async () => {
       const noOptionsFoundLabel = 'No options found.';
-      await setup({ multiple: true, noOptionsFoundLabel });
+      const { user } = await setup({ multiple: true, noOptionsFoundLabel });
 
       const filterInput = screen.getByRole('textbox', { name: 'dropdown search' });
-      userEvent.type(filterInput, 'non-existent option');
+      await user.type(filterInput, 'non-existent option');
 
       const options = screen.queryAllByRole('option');
       expect(options).toHaveLength(0);
@@ -180,7 +183,7 @@ describe(WattDropdownComponent, () => {
 
     it('emits a value after filter + selection', async () => {
       const [firstOption, secondOption] = dropdownOptions;
-      const component = await setup({
+      const { component, user } = await setup({
         multiple: true,
         initialState: [secondOption.value],
       });
@@ -191,10 +194,10 @@ describe(WattDropdownComponent, () => {
       );
 
       const filterInput = screen.getByRole('textbox', { name: 'dropdown search' });
-      userEvent.type(filterInput, 'outlaws');
+      await user.type(filterInput, 'outlaws');
 
       const options = screen.getAllByRole('option');
-      userEvent.click(options[0]);
+      await user.click(options[0]);
 
       expect(observer).toHaveBeenNthCalledWith(1, [firstOption.value]);
       expect(observer).toHaveBeenNthCalledWith(2, [firstOption.value, secondOption.value]);

--- a/libs/watt/package/modal/watt-modal.component.spec.ts
+++ b/libs/watt/package/modal/watt-modal.component.spec.ts
@@ -65,12 +65,13 @@ describe(WattModalComponent, () => {
         /* noop */
       },
     });
-    userEvent.click(screen.getByRole('button'));
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button'));
     await waitForAsync(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
     // Close before teardown to avoid NG0953 (closed OutputRef emit after destroy)
-    userEvent.click(screen.getByLabelText('Close'));
+    await user.click(screen.getByLabelText('Close'));
     await waitForAsync(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
@@ -79,8 +80,9 @@ describe(WattModalComponent, () => {
   it('closes when rejected', async () => {
     const closed = vi.fn();
     await setup({ closed });
-    userEvent.click(screen.getByRole('button'));
-    userEvent.click(screen.getByText('No'));
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByText('No'));
     await waitForAsync(() => expect(closed).toBeCalledWith(false));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
@@ -88,8 +90,9 @@ describe(WattModalComponent, () => {
   it('closes when accepted', async () => {
     const closed = vi.fn();
     await setup({ closed });
-    userEvent.click(screen.getByRole('button'));
-    userEvent.click(screen.getByText('Yes'));
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByText('Yes'));
     await waitForAsync(() => expect(closed).toBeCalledWith(true));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
@@ -97,8 +100,20 @@ describe(WattModalComponent, () => {
   it('closes on ESC', async () => {
     const closed = vi.fn();
     await setup({ closed });
-    userEvent.click(screen.getByRole('button'));
-    userEvent.keyboard('[Escape]');
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button'));
+    const dialog = await screen.findByRole('dialog');
+    // Dispatch keydown on the dialog so it bubbles up to body where the CDK
+    // OverlayKeyboardDispatcher listener is attached. MatDialog filters Escape
+    // by `keyCode === 27`, which the KeyboardEvent constructor does not set
+    // automatically, so set it explicitly here.
+    const escEvent = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      code: 'Escape',
+      bubbles: true,
+    });
+    Object.defineProperty(escEvent, 'keyCode', { get: () => 27 });
+    dialog.dispatchEvent(escEvent);
     await waitForAsync(() => expect(closed).toBeCalledWith(false));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
@@ -106,12 +121,13 @@ describe(WattModalComponent, () => {
   it('closes on close button click', async () => {
     const closed = vi.fn();
     await setup({ closed });
-    userEvent.click(screen.getByRole('button'));
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button'));
     await waitForAsync(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
-    userEvent.click(screen.getByLabelText('Close'));
+    await user.click(screen.getByLabelText('Close'));
     await waitForAsync(() => expect(closed).toBeCalledWith(false));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
@@ -119,10 +135,11 @@ describe(WattModalComponent, () => {
   it('disables close button', async () => {
     const closed = vi.fn();
     await setup({ closed, disableClose: true });
-    userEvent.click(screen.getByRole('button'));
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button'));
     expect(screen.queryByLabelText('Close')).not.toBeInTheDocument();
     // Close via service to avoid NG0953 (closed OutputRef emit after destroy)
-    userEvent.click(screen.getByText('No'));
+    await user.click(screen.getByText('No'));
     await waitForAsync(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
@@ -131,12 +148,13 @@ describe(WattModalComponent, () => {
   it('disables ESC', async () => {
     const closed = vi.fn();
     await setup({ closed, disableClose: true });
-    userEvent.click(screen.getByRole('button'));
-    userEvent.keyboard('[Escape]');
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button'));
+    await user.keyboard('[Escape]');
     await waitForAsync(() => expect(closed).not.toBeCalled());
     expect(screen.queryByRole('dialog')).toBeInTheDocument();
     // Close before teardown to avoid NG0953 (closed OutputRef emit after destroy)
-    userEvent.click(screen.getByText('No'));
+    await user.click(screen.getByText('No'));
     await waitForAsync(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
@@ -148,13 +166,14 @@ describe(WattModalComponent, () => {
         /* noop */
       },
     });
-    userEvent.click(screen.getByRole('button'));
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button'));
     await waitForAsync(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
     expect(screen.getByRole('heading')).toHaveTextContent('Test Modal');
     // Close before teardown to avoid NG0953 (closed OutputRef emit after destroy)
-    userEvent.click(screen.getByLabelText('Close'));
+    await user.click(screen.getByLabelText('Close'));
     await waitForAsync(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });

--- a/libs/watt/package/modal/watt-modal.component.spec.ts
+++ b/libs/watt/package/modal/watt-modal.component.spec.ts
@@ -53,6 +53,19 @@ function setup(componentProperties?: Properties) {
   });
 }
 
+// MatDialog filters Escape by the deprecated `keyCode === 27`, which neither
+// the KeyboardEvent constructor nor user-event v14 populates. Dispatch a
+// synthetic event with `keyCode` defined explicitly so the filter triggers.
+function dispatchEscape(target: Element) {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Escape',
+    code: 'Escape',
+    bubbles: true,
+  });
+  Object.defineProperty(event, 'keyCode', { get: () => 27 });
+  target.dispatchEvent(event);
+}
+
 describe(WattModalComponent, () => {
   it('starts closed', async () => {
     await setup();
@@ -102,18 +115,7 @@ describe(WattModalComponent, () => {
     await setup({ closed });
     const user = userEvent.setup();
     await user.click(screen.getByRole('button'));
-    const dialog = await screen.findByRole('dialog');
-    // Dispatch keydown on the dialog so it bubbles up to body where the CDK
-    // OverlayKeyboardDispatcher listener is attached. MatDialog filters Escape
-    // by `keyCode === 27`, which the KeyboardEvent constructor does not set
-    // automatically, so set it explicitly here.
-    const escEvent = new KeyboardEvent('keydown', {
-      key: 'Escape',
-      code: 'Escape',
-      bubbles: true,
-    });
-    Object.defineProperty(escEvent, 'keyCode', { get: () => 27 });
-    dialog.dispatchEvent(escEvent);
+    dispatchEscape(await screen.findByRole('dialog'));
     await waitForAsync(() => expect(closed).toBeCalledWith(false));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
@@ -150,7 +152,7 @@ describe(WattModalComponent, () => {
     await setup({ closed, disableClose: true });
     const user = userEvent.setup();
     await user.click(screen.getByRole('button'));
-    await user.keyboard('[Escape]');
+    dispatchEscape(await screen.findByRole('dialog'));
     await waitForAsync(() => expect(closed).not.toBeCalled());
     expect(screen.queryByRole('dialog')).toBeInTheDocument();
     // Close before teardown to avoid NG0953 (closed OutputRef emit after destroy)

--- a/libs/watt/package/package.json
+++ b/libs/watt/package/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@energinet/watt",
-  "version": "4.4.3",
+  "version": "4.4.4",
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/libs/watt/package/picker/datepicker/watt-datepicker.spec.ts
+++ b/libs/watt/package/picker/datepicker/watt-datepicker.spec.ts
@@ -171,10 +171,11 @@ describe(WattDatepickerComponent, () => {
         template,
         initialState: initialDate.toISOString(),
       });
+      const user = userEvent.setup();
 
-      // Do NOT clear first — clearing triggers inputChanged('') which sets value to null.
+      // Do NOT clear first - clearing triggers inputChanged('') which sets value to null.
       // Typing an incomplete date into an already-populated input should leave the value unchanged.
-      userEvent.type(actualInput, '2509');
+      await user.type(actualInput, '2509');
 
       fixture.detectChanges();
       await fixture.whenStable();
@@ -190,9 +191,10 @@ describe(WattDatepickerComponent, () => {
         template,
         min: minDate,
       });
+      const user = userEvent.setup();
 
-      userEvent.clear(actualInput);
-      userEvent.type(actualInput, '19092023'); // Before min date
+      await user.clear(actualInput);
+      await user.type(actualInput, '19092023'); // Before min date
 
       fixture.detectChanges();
       await fixture.whenStable();
@@ -214,9 +216,10 @@ describe(WattDatepickerComponent, () => {
         template,
         max: maxDate,
       });
+      const user = userEvent.setup();
 
-      userEvent.clear(actualInput);
-      userEvent.type(actualInput, '21092023'); // After max date
+      await user.clear(actualInput);
+      await user.type(actualInput, '21092023'); // After max date
 
       fixture.detectChanges();
       await fixture.whenStable();

--- a/libs/watt/package/picker/timepicker/watt-timepicker.component.spec.ts
+++ b/libs/watt/package/picker/timepicker/watt-timepicker.component.spec.ts
@@ -78,12 +78,13 @@ describe(WattTimepickerComponent, () => {
       const { fixture, timepickerInput } = await setup({
         template,
       });
+      const user = userEvent.setup();
 
       const startTime = '0123';
       const endTime = '1234';
 
-      userEvent.clear(timepickerInput);
-      userEvent.type(timepickerInput, `${startTime}${endTime}`);
+      await user.clear(timepickerInput);
+      await user.type(timepickerInput, `${startTime}${endTime}`);
 
       const actualTimeRange = fixture.componentInstance.timeRangeControl.value;
       const expectedTimeRange: WattDateRange = { start: '01:23', end: '12:34' };
@@ -98,9 +99,10 @@ describe(WattTimepickerComponent, () => {
         template,
         initialState: timeRange,
       });
+      const user = userEvent.setup();
 
       // Delete one character from the end
-      userEvent.type(timepickerInput, backspace);
+      await user.type(timepickerInput, backspace);
 
       let actualTimeRange = fixture.componentInstance.timeRangeControl.value;
       let expectedTimeRange: WattDateRange = { start: '01:23', end: '' };
@@ -109,7 +111,7 @@ describe(WattTimepickerComponent, () => {
 
       // Current state: `01:23 - 12:3`
       // Delete eight (`3 - 12:3`) characters from the end
-      userEvent.type(timepickerInput, Array(8).fill(backspace).join(''));
+      await user.type(timepickerInput, Array(8).fill(backspace).join(''));
 
       actualTimeRange = fixture.componentInstance.timeRangeControl.value;
       expectedTimeRange = { start: '', end: '' };
@@ -125,33 +127,34 @@ describe(WattTimepickerComponent, () => {
 
     it('shows slider on button click', async () => {
       await setup({ template });
+      const user = userEvent.setup();
 
       const sliderToggle = screen.queryByRole('button') as HTMLButtonElement;
 
-      userEvent.click(sliderToggle);
+      await user.click(sliderToggle);
 
       expect(screen.queryByRole('dialog')).not.toBeEmptyDOMElement();
     });
 
     it('hides slider on second button click', async () => {
       await setup({ template });
+      const user = userEvent.setup();
 
       const sliderToggle = screen.queryByRole('button') as HTMLButtonElement;
 
-      userEvent.click(sliderToggle);
-      userEvent.click(sliderToggle);
+      await user.click(sliderToggle);
+      await user.click(sliderToggle);
 
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
     it('disables slider button', async () => {
       await setup({ template, disabled: true });
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
 
       const sliderToggle = screen.queryByRole('button') as HTMLButtonElement;
 
-      userEvent.click(sliderToggle, undefined, {
-        skipPointerEventsCheck: true,
-      });
+      await user.click(sliderToggle);
 
       expect(sliderToggle).toBeDisabled();
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -159,9 +162,10 @@ describe(WattTimepickerComponent, () => {
 
     it('hides slider on blur', async () => {
       const { fixture } = await setup({ template });
+      const user = userEvent.setup();
       const sliderToggle = screen.queryByRole('button') as HTMLButtonElement;
 
-      userEvent.click(sliderToggle);
+      await user.click(sliderToggle);
 
       // Simulate focus moving outside the component by calling onFocusOut with a relatedTarget outside
       const timepickerComponent = fixture.debugElement.children[0].componentInstance;
@@ -181,9 +185,10 @@ describe(WattTimepickerComponent, () => {
 
     it('shows slider with default values if input is empty', async () => {
       await setup({ template });
+      const user = userEvent.setup();
 
       const sliderToggle = screen.queryByRole('button') as HTMLButtonElement;
-      userEvent.click(sliderToggle);
+      await user.click(sliderToggle);
 
       const [leftHandle, rightHandle] = screen.queryAllByRole('slider');
 
@@ -196,9 +201,10 @@ describe(WattTimepickerComponent, () => {
 
     it('shows slider with initial values from state', async () => {
       await setup({ template, initialState: { start: '00:10', end: '23:20' } });
+      const user = userEvent.setup();
 
       const sliderToggle = screen.queryByRole('button') as HTMLButtonElement;
-      userEvent.click(sliderToggle);
+      await user.click(sliderToggle);
 
       const [leftHandle, rightHandle] = screen.queryAllByRole('slider');
 
@@ -214,9 +220,10 @@ describe(WattTimepickerComponent, () => {
         template,
         initialState: { start: '00:00', end: '23:59' },
       });
+      const user = userEvent.setup();
 
       const sliderToggle = screen.queryByRole('button') as HTMLButtonElement;
-      userEvent.click(sliderToggle);
+      await user.click(sliderToggle);
 
       const [leftHandle, rightHandle] = screen.queryAllByRole('slider');
 
@@ -230,15 +237,16 @@ describe(WattTimepickerComponent, () => {
 
     it('adjusts slider values when input changes', async () => {
       const { timepickerInput } = await setup({ template });
+      const user = userEvent.setup();
 
       const startTime = '0123';
       const endTime = '2345';
 
       const sliderToggle = screen.queryByRole('button') as HTMLButtonElement;
-      userEvent.click(sliderToggle);
+      await user.click(sliderToggle);
 
-      userEvent.clear(timepickerInput);
-      userEvent.type(timepickerInput, `${startTime}${endTime}`);
+      await user.clear(timepickerInput);
+      await user.type(timepickerInput, `${startTime}${endTime}`);
 
       const [leftHandle, rightHandle] = screen.queryAllByRole('slider');
 
@@ -251,10 +259,11 @@ describe(WattTimepickerComponent, () => {
 
     it('displays slider label with value from input', async () => {
       await setup({ template });
+      const user = userEvent.setup();
 
       const sliderToggle = screen.queryByRole('button') as HTMLButtonElement;
 
-      userEvent.click(sliderToggle);
+      await user.click(sliderToggle);
 
       expect(screen.queryByText('Adjust time range')).toBeInTheDocument();
     });

--- a/libs/watt/package/search/watt-search.component.spec.ts
+++ b/libs/watt/package/search/watt-search.component.spec.ts
@@ -24,22 +24,24 @@ import { WattSearchComponent } from './watt-search.component';
 describe(WattSearchComponent, () => {
   it('clear input (using button)', async () => {
     await render(WattSearchComponent);
+    const user = userEvent.setup();
 
     const search = screen.getByRole('searchbox');
     const button = screen.getByRole('button');
 
-    userEvent.type(search, 'test');
+    await user.type(search, 'test');
     expect(search).toHaveValue('test');
 
-    userEvent.click(button);
+    await user.click(button);
     expect(search).toHaveValue('');
   });
 
   it('clear input (using component API)', async () => {
     const { fixture } = await render(WattSearchComponent);
+    const user = userEvent.setup();
 
     const search = screen.getByRole('searchbox');
-    userEvent.type(search, 'test');
+    await user.type(search, 'test');
 
     fixture.componentInstance.clear();
 

--- a/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.spec.ts
+++ b/libs/watt/package/segmented-buttons/watt-segmented-buttons.component.spec.ts
@@ -109,8 +109,9 @@ describe(WattSegmentedButtonsComponent, () => {
 
     it('updates the form control when clicking a button', async () => {
       const { host } = await setup('day');
+      const user = userEvent.setup();
 
-      await userEvent.click(screen.getByRole('radio', { name: 'Year' }));
+      await user.click(screen.getByRole('radio', { name: 'Year' }));
 
       expect(host.control.value).toBe('year');
       expect(screen.getByRole('radio', { name: 'Year' })).toHaveAttribute('aria-checked', 'true');
@@ -131,8 +132,9 @@ describe(WattSegmentedButtonsComponent, () => {
       }
 
       const { fixture } = await render(TestHostComponent);
+      const user = userEvent.setup();
 
-      await userEvent.click(screen.getByRole('radio', { name: 'No value' }));
+      await user.click(screen.getByRole('radio', { name: 'No value' }));
 
       expect(fixture.componentInstance.control.value).toBe('keep');
     });
@@ -174,8 +176,9 @@ describe(WattSegmentedButtonsComponent, () => {
       }
 
       const { fixture } = await render(TestHostComponent);
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
 
-      await userEvent.click(screen.getByRole('radio', { name: 'Month' }));
+      await user.click(screen.getByRole('radio', { name: 'Month' }));
 
       expect(fixture.componentInstance.control.value).toBe('day');
     });
@@ -263,54 +266,60 @@ describe(WattSegmentedButtonsComponent, () => {
 
     it('moves selection right with ArrowRight', async () => {
       const { host } = await setup('day');
+      const user = userEvent.setup();
       screen.getByRole('radio', { name: 'Day' }).focus();
 
-      await userEvent.keyboard('{ArrowRight}');
+      await user.keyboard('{ArrowRight}');
 
       expect(host.control.value).toBe('month');
     });
 
     it('moves selection left with ArrowLeft', async () => {
       const { host } = await setup('month');
+      const user = userEvent.setup();
       screen.getByRole('radio', { name: 'Month' }).focus();
 
-      await userEvent.keyboard('{ArrowLeft}');
+      await user.keyboard('{ArrowLeft}');
 
       expect(host.control.value).toBe('day');
     });
 
     it('wraps from last to first on ArrowRight', async () => {
       const { host } = await setup('year');
+      const user = userEvent.setup();
       screen.getByRole('radio', { name: 'Year' }).focus();
 
-      await userEvent.keyboard('{ArrowRight}');
+      await user.keyboard('{ArrowRight}');
 
       expect(host.control.value).toBe('day');
     });
 
     it('wraps from first to last on ArrowLeft', async () => {
       const { host } = await setup('day');
+      const user = userEvent.setup();
       screen.getByRole('radio', { name: 'Day' }).focus();
 
-      await userEvent.keyboard('{ArrowLeft}');
+      await user.keyboard('{ArrowLeft}');
 
       expect(host.control.value).toBe('year');
     });
 
     it('jumps to first with Home', async () => {
       const { host } = await setup('year');
+      const user = userEvent.setup();
       screen.getByRole('radio', { name: 'Year' }).focus();
 
-      await userEvent.keyboard('{Home}');
+      await user.keyboard('{Home}');
 
       expect(host.control.value).toBe('day');
     });
 
     it('jumps to last with End', async () => {
       const { host } = await setup('day');
+      const user = userEvent.setup();
       screen.getByRole('radio', { name: 'Day' }).focus();
 
-      await userEvent.keyboard('{End}');
+      await user.keyboard('{End}');
 
       expect(host.control.value).toBe('year');
     });

--- a/libs/watt/package/table/watt-table.component.spec.ts
+++ b/libs/watt/package/table/watt-table.component.spec.ts
@@ -206,9 +206,10 @@ describe(WattTableComponent, () => {
     };
 
     await setup({ dataSource, columns, sortChange });
+    const user = userEvent.setup();
 
     const position = screen.getByRole('columnheader', { name: 'position' });
-    userEvent.click(position.children[0]);
+    await user.click(position.children[0]);
 
     expect(sortChange).toHaveBeenCalledWith({
       active: 'position',
@@ -225,9 +226,10 @@ describe(WattTableComponent, () => {
     };
 
     await setup({ dataSource, columns, rowClick });
+    const user = userEvent.setup();
 
     const [firstCell] = screen.getAllByRole('gridcell');
-    userEvent.click(firstCell);
+    await user.click(firstCell);
 
     expect(rowClick).toHaveBeenCalledWith(data[0]);
   });
@@ -241,10 +243,11 @@ describe(WattTableComponent, () => {
     };
 
     const result = await setup({ dataSource, columns, rowClick });
+    const user = userEvent.setup();
 
     const [, secondRow] = result.getAllByRole('row');
     const [firstCell] = result.getAllByRole('gridcell');
-    userEvent.click(firstCell);
+    await user.click(firstCell);
 
     const lastCall = rowClick.mock.lastCall;
 
@@ -482,9 +485,10 @@ describe(WattTableComponent, () => {
     });
 
     let [, firstCheckbox] = screen.getAllByRole('checkbox');
+    const user = userEvent.setup();
 
     await waitForAsync(() => expect(firstCheckbox).toBeChecked());
-    userEvent.click(firstCheckbox);
+    await user.click(firstCheckbox);
 
     result.rerender({
       componentProperties: {

--- a/libs/watt/package/tooltip/watt-tooltip.directive.spec.ts
+++ b/libs/watt/package/tooltip/watt-tooltip.directive.spec.ts
@@ -41,36 +41,40 @@ describe(WattTooltipDirective.name, () => {
 
   it('displays tooltip on hover', async () => {
     await setup();
+    const user = userEvent.setup();
     expect(isTooltipVisible()).toBe(false);
 
-    userEvent.hover(getTooltipTarget());
+    await user.hover(getTooltipTarget());
     expect(isTooltipVisible()).toBe(true);
   });
 
   it('hides tooltip on unhover', async () => {
     await setup();
-    userEvent.hover(getTooltipTarget());
+    const user = userEvent.setup();
+    await user.hover(getTooltipTarget());
     expect(isTooltipVisible()).toBe(true);
 
-    userEvent.unhover(getTooltipTarget());
+    await user.unhover(getTooltipTarget());
     expect(isTooltipVisible()).toBe(false);
   });
 
   it('displays tooltip on focus', async () => {
     await setup();
+    const user = userEvent.setup();
     expect(isTooltipVisible()).toBe(false);
 
-    userEvent.tab();
+    await user.tab();
 
     expect(isTooltipVisible()).toBe(true);
   });
 
   it('hides tooltip on blur', async () => {
     await setup();
-    userEvent.tab();
+    const user = userEvent.setup();
+    await user.tab();
     expect(isTooltipVisible()).toBe(true);
 
-    userEvent.tab();
+    await user.tab();
 
     expect(isTooltipVisible()).toBe(false);
   });

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "@swc/helpers": "0.5.19",
     "@testing-library/angular": "18.1.1",
     "@testing-library/jest-dom": "6.6.3",
-    "@testing-library/user-event": "13.5.0",
+    "@testing-library/user-event": "14.6.1",
     "@types/crypto-js": "4.2.2",
     "@types/encoding-japanese": "2.2.1",
     "@types/express": "4.17.14",


### PR DESCRIPTION
## Summary

- Bump `@testing-library/user-event` from `13.5.0` to `14.6.1` (last major version, also consolidates with the version Storybook already required transitively).
- Migrate 17 spec files from the v13 sync API to the v14 async pattern: each test now calls `userEvent.setup()` and awaits every interaction.
- Convert the disabled-button assertion in `watt-button.component.spec.ts` from `expect(() => userEvent.click(...)).toThrow()` to `await expect(user.click(...)).rejects.toThrow()` so it still verifies the click is rejected.
- Replace the deprecated per-call `skipPointerEventsCheck: true` with the global `pointerEventsCheck: 0` option in the few specs that need to click disabled elements (timepicker, checkbox, segmented-buttons).
- Work around a happy-dom + Material edge case in the modal `closes on ESC` spec: user-event v14 no longer populates the deprecated `keyCode` property, but `MatDialog` filters Escape by `keyCode === 27`. The test now dispatches a synthetic `KeyboardEvent` with `keyCode` defined explicitly. The companion `disables ESC` test is unaffected because it asserts the modal stays open regardless of the event source.

Ref: #2481