### PR TITLE
feat(dh/metering-point): rolle-konfiguration per procesaktion

### DIFF
--- a/libs/dh/metering-point/feature-process-overview/src/actions/customer-move-in/customer-move-in.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/actions/customer-move-in/customer-move-in.ts
@@ -19,14 +19,14 @@
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { WorkflowAction } from '@energinet-datahub/dh/shared/domain/graphql';
+import { EicFunction, WorkflowAction } from '@energinet-datahub/dh/shared/domain/graphql';
 import {
   BasePaths,
   getPath,
   MeteringPointSubPaths,
 } from '@energinet-datahub/dh/core/configuration-routing';
 
-import type { ActionHandlerMap } from '../registry';
+import { ResponsibleEnergySupplier, type ActionHandlerMap } from '../registry';
 
 @Injectable({ providedIn: 'root' })
 export class CustomerMoveInActions {
@@ -34,6 +34,7 @@ export class CustomerMoveInActions {
 
   readonly handlers: ActionHandlerMap = {
     [WorkflowAction.SendInformation]: {
+      roles: [ResponsibleEnergySupplier, EicFunction.GridAccessProvider],
       callback: (ctx) =>
         this.router.navigate([
           getPath<BasePaths>('metering-point'),

--- a/libs/dh/metering-point/feature-process-overview/src/actions/end-of-supply/end-of-supply.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/actions/end-of-supply/end-of-supply.ts
@@ -22,6 +22,7 @@ import { WattModalService } from '@energinet/watt/modal';
 
 import { mutation } from '@energinet-datahub/dh/shared/util-apollo';
 import {
+  EicFunction,
   ProcessManagerBusinessReason,
   CancelEndOfSupplyDocument,
   DisconnectMeteringPointDocument,
@@ -31,7 +32,7 @@ import {
   WorkflowAction,
 } from '@energinet-datahub/dh/shared/domain/graphql';
 
-import type { ActionHandlerMap } from '../registry';
+import { ResponsibleEnergySupplier, type ActionHandlerMap } from '../registry';
 import { cancelProcessAction } from '../shared/cancel-process-action';
 import { disconnectProcessAction } from '../shared/disconnect-process-action';
 import { rejectProcessAction } from '../shared/reject-process-action';
@@ -48,6 +49,7 @@ export class EndOfSupplyActions {
     [WorkflowAction.SendInformation]: {
       featureFlag: 'end-of-supply',
       permissions: ['metering-point:end-of-supply-request'],
+      roles: [ResponsibleEnergySupplier],
       callback: (ctx) => {
         this.modalService.open({
           component: DhRequestServiceModal,
@@ -64,6 +66,7 @@ export class EndOfSupplyActions {
     [WorkflowAction.ConfirmWorkflow]: {
       featureFlag: 'end-of-supply',
       permissions: ['metering-point:connection-state-manage'],
+      roles: [EicFunction.GridAccessProvider],
       callback: disconnectProcessAction((ctx, result, onCompleted, onError) => {
         this.disconnectMeteringPoint.mutate({
           refetchQueries: [
@@ -83,6 +86,7 @@ export class EndOfSupplyActions {
     [WorkflowAction.RejectRequest]: {
       featureFlag: 'end-of-supply',
       permissions: ['metering-point:end-of-supply-respond'],
+      roles: [ResponsibleEnergySupplier],
       callback: rejectProcessAction(({ ctx, result, onCompleted, onError }) => {
         this.rejectEndOfSupply.mutate({
           refetchQueries: [
@@ -104,6 +108,7 @@ export class EndOfSupplyActions {
     [WorkflowAction.CancelWorkflow]: {
       featureFlag: 'end-of-supply',
       permissions: ['metering-point:end-of-supply-request', 'metering-point:end-of-supply-respond'],
+      roles: [ResponsibleEnergySupplier, EicFunction.GridAccessProvider],
       callback: cancelProcessAction(
         `meteringPoint.processOverview.processTypeName.${ProcessManagerBusinessReason.EndOfSupply}`,
         (ctx, onCompleted, onError) => {

--- a/libs/dh/metering-point/feature-process-overview/src/actions/registry.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/actions/registry.ts
@@ -23,6 +23,7 @@ import { DhFeatureFlagsService } from '@energinet-datahub/dh/shared/feature-flag
 import { PermissionService } from '@energinet-datahub/dh/shared/feature-authorization';
 import { Permission } from '@energinet-datahub/dh/shared/domain';
 import {
+  EicFunction,
   ProcessManagerBusinessReason,
   WorkflowAction,
 } from '@energinet-datahub/dh/shared/domain/graphql';
@@ -31,9 +32,13 @@ import { ProcessActionContext } from './context';
 import { EndOfSupplyActions } from './end-of-supply/end-of-supply';
 import { CustomerMoveInActions } from './customer-move-in/customer-move-in';
 
+export const ResponsibleEnergySupplier = 'ResponsibleEnergySupplier' as const;
+export type ActionRole = EicFunction | typeof ResponsibleEnergySupplier;
+
 export interface ActionHandler {
   featureFlag?: Parameters<DhFeatureFlagsService['isEnabled']>[0];
   permissions?: Permission[];
+  roles?: ActionRole[];
   callback: (context: ProcessActionContext) => void;
 }
 

--- a/libs/dh/metering-point/feature-process-overview/src/actions/registry.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/actions/registry.ts
@@ -20,7 +20,10 @@ import { inject, Injectable, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 
 import { DhFeatureFlagsService } from '@energinet-datahub/dh/shared/feature-flags';
-import { PermissionService } from '@energinet-datahub/dh/shared/feature-authorization';
+import {
+  DhActorStorage,
+  PermissionService,
+} from '@energinet-datahub/dh/shared/feature-authorization';
 import { Permission } from '@energinet-datahub/dh/shared/domain';
 import {
   EicFunction,
@@ -60,6 +63,7 @@ function collectPermissions(
 export class DhActionsRegistry {
   private readonly featureFlags = inject(DhFeatureFlagsService);
   private readonly permissionService = inject(PermissionService);
+  private readonly actor = inject(DhActorStorage).getSelectedActor();
 
   private readonly isFas = toSignal(this.permissionService.isFas(), { initialValue: false });
 
@@ -82,33 +86,42 @@ export class DhActionsRegistry {
     );
   }
 
+  private matchesRoles(handler: ActionHandler, isResponsible: boolean): boolean {
+    if (!handler.roles?.length) return true;
+    return handler.roles.some((role) =>
+      role === ResponsibleEnergySupplier
+        ? this.actor.marketRole === EicFunction.EnergySupplier && isResponsible
+        : this.actor.marketRole === role
+    );
+  }
+
   getSupportedActions(
     availableActions: WorkflowAction[],
-    businessReason: ProcessManagerBusinessReason
+    businessReason: ProcessManagerBusinessReason,
+    isEnergySupplierResponsible: boolean
   ): WorkflowAction[] {
     return availableActions.filter((action) => {
       const handler = this.registry[businessReason]?.[action];
       if (!handler || !this.featureFlags.isEnabled(handler.featureFlag)) return false;
-      // FAS users see all supported actions for informational purposes,
-      // but cannot execute them (gated by canPerformActions in the template
-      // and hasRequiredPermission in execute).
       if (this.isFas()) return true;
-      return this.hasRequiredPermission(handler);
+      if (!this.hasRequiredPermission(handler)) return false;
+      return this.matchesRoles(handler, isEnergySupplierResponsible);
     });
   }
 
   execute(
     action: WorkflowAction,
     businessReason: ProcessManagerBusinessReason,
-    context: ProcessActionContext
+    context: ProcessActionContext,
+    isEnergySupplierResponsible: boolean
   ): void {
-    const handler = this.registry[businessReason]?.[action];
-    if (
-      handler &&
-      this.featureFlags.isEnabled(handler.featureFlag) &&
-      this.hasRequiredPermission(handler)
-    ) {
-      handler.callback(context);
-    }
+    if (this.isFas()) return;
+    const supported = this.getSupportedActions(
+      [action],
+      businessReason,
+      isEnergySupplierResponsible
+    );
+    if (!supported.includes(action)) return;
+    this.registry[businessReason]?.[action]?.callback(context);
   }
 }

--- a/libs/dh/metering-point/feature-process-overview/src/actions/registry.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/actions/registry.ts
@@ -102,6 +102,8 @@ export class DhActionsRegistry {
     return availableActions.filter((action) => {
       const handler = this.registry[businessReason]?.[action];
       if (!handler || !this.featureFlags.isEnabled(handler.featureFlag)) return false;
+      // FAS users see every supported action (info row in the table, disabled
+      // button in the drawer). Execution is blocked separately in execute().
       if (this.isFas()) return true;
       if (!this.hasRequiredPermission(handler)) return false;
       return this.matchesRoles(handler, isEnergySupplierResponsible);

--- a/libs/dh/metering-point/feature-process-overview/src/actions/registry.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/actions/registry.ts
@@ -90,9 +90,7 @@ export class DhActionsRegistry {
     if (!handler.roles?.length) return true;
     const marketRole = this.actorStorage.getSelectedActor().marketRole;
     return handler.roles.some((role) =>
-      role === ResponsibleEnergySupplier
-        ? marketRole === EicFunction.EnergySupplier && isResponsible
-        : marketRole === role
+      role === ResponsibleEnergySupplier ? isResponsible : marketRole === role
     );
   }
 

--- a/libs/dh/metering-point/feature-process-overview/src/actions/registry.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/actions/registry.ts
@@ -63,7 +63,7 @@ function collectPermissions(
 export class DhActionsRegistry {
   private readonly featureFlags = inject(DhFeatureFlagsService);
   private readonly permissionService = inject(PermissionService);
-  private readonly actor = inject(DhActorStorage).getSelectedActor();
+  private readonly actorStorage = inject(DhActorStorage);
 
   private readonly isFas = toSignal(this.permissionService.isFas(), { initialValue: false });
 
@@ -88,10 +88,11 @@ export class DhActionsRegistry {
 
   private matchesRoles(handler: ActionHandler, isResponsible: boolean): boolean {
     if (!handler.roles?.length) return true;
+    const marketRole = this.actorStorage.getSelectedActor().marketRole;
     return handler.roles.some((role) =>
       role === ResponsibleEnergySupplier
-        ? this.actor.marketRole === EicFunction.EnergySupplier && isResponsible
-        : this.actor.marketRole === role
+        ? marketRole === EicFunction.EnergySupplier && isResponsible
+        : marketRole === role
     );
   }
 

--- a/libs/dh/metering-point/feature-process-overview/src/actions/supported-actions.pipe.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/actions/supported-actions.pipe.ts
@@ -31,9 +31,14 @@ export class SupportedActionsPipe implements PipeTransform {
 
   transform(
     availableActions: WorkflowAction[] | null | undefined,
-    businessReason?: ProcessManagerBusinessReason
+    businessReason?: ProcessManagerBusinessReason,
+    isEnergySupplierResponsible?: boolean
   ): WorkflowAction[] {
     if (!availableActions || !businessReason) return [];
-    return this.registry.getSupportedActions(availableActions, businessReason);
+    return this.registry.getSupportedActions(
+      availableActions,
+      businessReason,
+      isEnergySupplierResponsible ?? false
+    );
   }
 }

--- a/libs/dh/metering-point/feature-process-overview/src/components/details/details.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/components/details/details.ts
@@ -118,7 +118,7 @@ import { SupportedActionsPipe } from '../../actions/supported-actions.pipe';
         @if (canShowActions()) {
           @for (
             action of process.data()?.meteringPointProcessById?.availableActions
-              | supportedActions: businessReason();
+              | supportedActions: businessReason() : isEnergySupplierResponsible();
             track action
           ) {
             <watt-button variant="secondary" [disabled]="isFas()" (click)="executeAction(action)">
@@ -194,12 +194,17 @@ export class DhMeteringPointProcessOverviewDetails {
     if (!reason) return;
     if (!this.canPerformActions()) return;
 
-    this.actionService.execute(action, reason, {
-      meteringPointId: this.meteringPointId(),
-      internalMeteringPointId: this.internalMeteringPointId(),
-      processId: this.id(),
-      cutoffDate: this.cutoffDate(),
-      onSuccess: () => this.navigation.navigate('list'),
-    });
+    this.actionService.execute(
+      action,
+      reason,
+      {
+        meteringPointId: this.meteringPointId(),
+        internalMeteringPointId: this.internalMeteringPointId(),
+        processId: this.id(),
+        cutoffDate: this.cutoffDate(),
+        onSuccess: () => this.navigation.navigate('list'),
+      },
+      this.isEnergySupplierResponsible()
+    );
   }
 }

--- a/libs/dh/metering-point/feature-process-overview/src/components/details/details.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/components/details/details.ts
@@ -33,13 +33,9 @@ import { WattDatePipe } from '@energinet/watt/date';
 import { WattButtonComponent } from '@energinet/watt/button';
 
 import { DhStateBadge, DhEmDashFallbackPipe } from '@energinet-datahub/dh/shared/ui-util';
-import {
-  DhActorStorage,
-  PermissionService,
-} from '@energinet-datahub/dh/shared/feature-authorization';
+import { PermissionService } from '@energinet-datahub/dh/shared/feature-authorization';
 import { query } from '@energinet-datahub/dh/shared/util-apollo';
 import {
-  EicFunction,
   GetMeteringPointProcessByIdDocument,
   WorkflowAction,
 } from '@energinet-datahub/dh/shared/domain/graphql';
@@ -115,16 +111,14 @@ import { SupportedActionsPipe } from '../../actions/supported-actions.pipe';
         </watt-description-list>
       </watt-drawer-heading>
       <watt-drawer-actions *transloco="let t; prefix: 'meteringPoint.processOverview'">
-        @if (canShowActions()) {
-          @for (
-            action of process.data()?.meteringPointProcessById?.availableActions
-              | supportedActions: businessReason() : isEnergySupplierResponsible();
-            track action
-          ) {
-            <watt-button variant="secondary" [disabled]="isFas()" (click)="executeAction(action)">
-              {{ t('actions.' + businessReason() + '.' + action) }}
-            </watt-button>
-          }
+        @for (
+          action of process.data()?.meteringPointProcessById?.availableActions
+            | supportedActions: businessReason() : isEnergySupplierResponsible();
+          track action
+        ) {
+          <watt-button variant="secondary" [disabled]="isFas()" (click)="executeAction(action)">
+            {{ t('actions.' + businessReason() + '.' + action) }}
+          </watt-button>
         }
       </watt-drawer-actions>
       <watt-drawer-content>
@@ -146,24 +140,8 @@ export class DhMeteringPointProcessOverviewDetails {
   protected navigation = inject(DhNavigationService);
   private readonly actionService = inject(DhActionsRegistry);
   private readonly permissionService = inject(PermissionService);
-  private readonly actor = inject(DhActorStorage).getSelectedActor();
 
   protected isFas = toSignal(this.permissionService.isFas(), { initialValue: false });
-  // Market role comes from the currently selected actor, not from token claims,
-  // so it is known synchronously at component creation. This avoids a brief
-  // flicker where a non-responsible supplier would see action buttons before
-  // the token-based role signal resolves.
-  private readonly hasGridAccessProviderRole =
-    this.actor.marketRole === EicFunction.GridAccessProvider;
-
-  private readonly hasMeteringPointAccess = computed(
-    () => this.hasGridAccessProviderRole || this.isEnergySupplierResponsible()
-  );
-
-  // FAS admins render the buttons but cannot click them (see `[disabled]`).
-  protected readonly canShowActions = computed(() => this.hasMeteringPointAccess() || this.isFas());
-
-  private readonly canPerformActions = computed(() => this.canShowActions() && !this.isFas());
 
   process = query(GetMeteringPointProcessByIdDocument, () => ({
     fetchPolicy: 'cache-and-network',
@@ -192,7 +170,6 @@ export class DhMeteringPointProcessOverviewDetails {
   executeAction(action: WorkflowAction) {
     const reason = this.businessReason();
     if (!reason) return;
-    if (!this.canPerformActions()) return;
 
     this.actionService.execute(
       action,

--- a/libs/dh/metering-point/feature-process-overview/src/components/overview.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/components/overview.ts
@@ -19,7 +19,6 @@
 import { Component, computed, inject, input } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { filter } from 'rxjs';
-
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TranslocoDirective, translate } from '@jsverse/transloco';
 

--- a/libs/dh/metering-point/feature-process-overview/src/components/overview.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/components/overview.ts
@@ -19,6 +19,7 @@
 import { Component, computed, inject, input } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { filter } from 'rxjs';
+
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TranslocoDirective, translate } from '@jsverse/transloco';
 
@@ -38,12 +39,8 @@ import {
   dhMakeFormControl,
 } from '@energinet-datahub/dh/shared/ui-util';
 import { RouterOutlet } from '@angular/router';
+import { PermissionService } from '@energinet-datahub/dh/shared/feature-authorization';
 import {
-  DhActorStorage,
-  PermissionService,
-} from '@energinet-datahub/dh/shared/feature-authorization';
-import {
-  EicFunction,
   GetMeteringPointProcessOverviewDocument,
   WorkflowAction,
 } from '@energinet-datahub/dh/shared/domain/graphql';
@@ -136,34 +133,32 @@ import { SupportedActionsPipe } from '../actions/supported-actions.pipe';
           {{ process.initiator?.displayName | dhEmDashFallback }}
         </ng-container>
         <ng-container *wattTableCell="columns.actions; let process">
-          @if (canShowActions()) {
-            <vater-stack
-              direction="row"
-              gap="s"
-              *transloco="let t; prefix: 'meteringPoint.processOverview.actions'"
-            >
-              @for (
-                action of process.availableActions
-                  | supportedActions: process.businessReason : isEnergySupplierResponsible();
-                track action
-              ) {
-                @if (canPerformActions()) {
-                  <watt-button
-                    variant="secondary"
-                    (click)="onActionClick($event, process, action)"
-                    size="small"
-                  >
-                    {{ t(process.businessReason + '.' + action) }}
-                  </watt-button>
-                } @else if (isFas()) {
-                  <vater-stack direction="row" gap="xs">
-                    <watt-icon name="warning" size="s" />
-                    <span>{{ t(process.businessReason + '.FAS_' + action) }}</span>
-                  </vater-stack>
-                }
+          <vater-stack
+            direction="row"
+            gap="s"
+            *transloco="let t; prefix: 'meteringPoint.processOverview.actions'"
+          >
+            @for (
+              action of process.availableActions
+                | supportedActions: process.businessReason : isEnergySupplierResponsible();
+              track action
+            ) {
+              @if (isFas()) {
+                <vater-stack direction="row" gap="xs">
+                  <watt-icon name="warning" size="s" />
+                  <span>{{ t(process.businessReason + '.FAS_' + action) }}</span>
+                </vater-stack>
+              } @else {
+                <watt-button
+                  variant="secondary"
+                  (click)="onActionClick($event, process, action)"
+                  size="small"
+                >
+                  {{ t(process.businessReason + '.' + action) }}
+                </watt-button>
               }
-            </vater-stack>
-          }
+            }
+          </vater-stack>
         </ng-container>
       </watt-table>
     </watt-data-table>
@@ -174,7 +169,6 @@ export class DhMeteringPointProcessOverviewTable {
   protected readonly navigation = inject(DhNavigationService);
   private readonly actionService = inject(DhActionsRegistry);
   private readonly permissionService = inject(PermissionService);
-  private readonly actor = inject(DhActorStorage).getSelectedActor();
 
   readonly meteringPointId = input.required<string>();
   readonly internalMeteringPointId = input.required<string>();
@@ -182,20 +176,6 @@ export class DhMeteringPointProcessOverviewTable {
   readonly id = input<string>();
 
   protected isFas = toSignal(this.permissionService.isFas(), { initialValue: false });
-  // Market role comes from the currently selected actor, not from token claims,
-  // so it is known synchronously at component creation. This avoids a brief
-  // flicker where a non-responsible supplier would see action buttons before
-  // the token-based role signal resolves.
-  private readonly hasGridAccessProviderRole =
-    this.actor.marketRole === EicFunction.GridAccessProvider;
-
-  private readonly hasMeteringPointAccess = computed(
-    () => this.hasGridAccessProviderRole || this.isEnergySupplierResponsible()
-  );
-
-  protected readonly canPerformActions = this.hasMeteringPointAccess;
-
-  protected readonly canShowActions = computed(() => this.hasMeteringPointAccess() || this.isFas());
 
   initialDateRange = {
     start: dayjs().subtract(3, 'months').startOf('day').toDate(),
@@ -232,7 +212,6 @@ export class DhMeteringPointProcessOverviewTable {
 
   onActionClick(event: Event, process: MeteringPointProcess, action: WorkflowAction) {
     event.stopPropagation();
-    if (!this.canPerformActions()) return;
     this.actionService.execute(
       action,
       process.businessReason,

--- a/libs/dh/metering-point/feature-process-overview/src/components/overview.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/components/overview.ts
@@ -143,7 +143,8 @@ import { SupportedActionsPipe } from '../actions/supported-actions.pipe';
               *transloco="let t; prefix: 'meteringPoint.processOverview.actions'"
             >
               @for (
-                action of process.availableActions | supportedActions: process.businessReason;
+                action of process.availableActions
+                  | supportedActions: process.businessReason : isEnergySupplierResponsible();
                 track action
               ) {
                 @if (canPerformActions()) {
@@ -232,11 +233,16 @@ export class DhMeteringPointProcessOverviewTable {
   onActionClick(event: Event, process: MeteringPointProcess, action: WorkflowAction) {
     event.stopPropagation();
     if (!this.canPerformActions()) return;
-    this.actionService.execute(action, process.businessReason, {
-      meteringPointId: this.meteringPointId(),
-      internalMeteringPointId: this.internalMeteringPointId(),
-      processId: process.id,
-      cutoffDate: process.cutoffDate,
-    });
+    this.actionService.execute(
+      action,
+      process.businessReason,
+      {
+        meteringPointId: this.meteringPointId(),
+        internalMeteringPointId: this.internalMeteringPointId(),
+        processId: process.id,
+        cutoffDate: process.cutoffDate,
+      },
+      this.isEnergySupplierResponsible()
+    );
   }
 }

--- a/libs/dh/metering-point/feature-process-overview/src/components/overview.ts
+++ b/libs/dh/metering-point/feature-process-overview/src/components/overview.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 //#endregion
-import { Component, computed, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { filter } from 'rxjs';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -50,6 +50,7 @@ import { SupportedActionsPipe } from '../actions/supported-actions.pipe';
 
 @Component({
   selector: 'dh-metering-point-process-overview-table',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ReactiveFormsModule,
     RouterOutlet,

--- a/libs/dh/metering-point/feature-process-overview/tests/actions-registry.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/actions-registry.spec.ts
@@ -599,22 +599,33 @@ describe('DhActionsRegistry', () => {
       expect(callback).not.toHaveBeenCalled();
     });
 
-    it('should not call handler for FAS users even when action is supported', () => {
+    it('should not call handler for FAS users even when action would otherwise be supported', () => {
       const callback = vi.fn();
-      const registry = setupRegistry({
-        isFas: true,
-        endOfSupplyHandlers: {
-          [WorkflowAction.CancelWorkflow]: { callback },
-        },
-      });
+      const baseSetup = {
+        endOfSupplyHandlers: { [WorkflowAction.CancelWorkflow]: { callback } },
+      };
 
-      registry.execute(
+      // Sanity: without FAS, the same setup DOES invoke the handler.
+      // This proves the trigger is wired up before we assert the FAS-block.
+      const nonFas = setupRegistry(baseSetup);
+      nonFas.execute(
         WorkflowAction.CancelWorkflow,
         ProcessManagerBusinessReason.EndOfSupply,
         mockContext,
         false
       );
+      expect(callback).toHaveBeenCalledTimes(1);
+      callback.mockClear();
 
+      // With FAS, the same trigger does NOT invoke the handler.
+      TestBed.resetTestingModule();
+      const fas = setupRegistry({ ...baseSetup, isFas: true });
+      fas.execute(
+        WorkflowAction.CancelWorkflow,
+        ProcessManagerBusinessReason.EndOfSupply,
+        mockContext,
+        false
+      );
       expect(callback).not.toHaveBeenCalled();
     });
 

--- a/libs/dh/metering-point/feature-process-overview/tests/actions-registry.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/actions-registry.spec.ts
@@ -20,14 +20,22 @@ import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 
 import {
+  EicFunction,
   ProcessManagerBusinessReason,
   WorkflowAction,
 } from '@energinet-datahub/dh/shared/domain/graphql';
 import { Permission } from '@energinet-datahub/dh/shared/domain';
 import { DhFeatureFlagsService } from '@energinet-datahub/dh/shared/feature-flags';
-import { PermissionService } from '@energinet-datahub/dh/shared/feature-authorization';
+import {
+  DhActorStorage,
+  PermissionService,
+} from '@energinet-datahub/dh/shared/feature-authorization';
 
-import { DhActionsRegistry, ActionHandlerMap } from '../src/actions/registry';
+import {
+  DhActionsRegistry,
+  ActionHandlerMap,
+  ResponsibleEnergySupplier,
+} from '../src/actions/registry';
 import { EndOfSupplyActions } from '../src/actions/end-of-supply/end-of-supply';
 import { CustomerMoveInActions } from '../src/actions/customer-move-in/customer-move-in';
 import { ProcessActionContext } from '../src/actions/context';
@@ -55,6 +63,7 @@ describe('DhActionsRegistry', () => {
       hasEndOfSupplyRespondPermission?: boolean;
       hasEndOfSupplyRequestPermission?: boolean;
       isFas?: boolean;
+      actorMarketRole?: EicFunction;
       endOfSupplyHandlers?: ActionHandlerMap;
       customerMoveInHandlers?: ActionHandlerMap;
     } = {}
@@ -64,6 +73,7 @@ describe('DhActionsRegistry', () => {
       hasEndOfSupplyRespondPermission = true,
       hasEndOfSupplyRequestPermission = false,
       isFas = false,
+      actorMarketRole = EicFunction.GridAccessProvider,
       endOfSupplyHandlers = {
         [WorkflowAction.CancelWorkflow]: {
           featureFlag: 'end-of-supply',
@@ -97,6 +107,19 @@ describe('DhActionsRegistry', () => {
           },
         },
         {
+          provide: DhActorStorage,
+          useValue: {
+            getSelectedActor: () => ({
+              id: 'actor-1',
+              gln: '1234567890123',
+              marketRole: actorMarketRole,
+              actorName: 'Test Actor',
+              organizationName: 'Test Org',
+              displayName: 'Test Actor Display',
+            }),
+          },
+        },
+        {
           provide: EndOfSupplyActions,
           useValue: createMockHandlers(endOfSupplyHandlers),
         },
@@ -116,7 +139,8 @@ describe('DhActionsRegistry', () => {
 
       const result = registry.getSupportedActions(
         [WorkflowAction.CancelWorkflow],
-        ProcessManagerBusinessReason.EndOfSupply
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
       );
 
       expect(result).toEqual([WorkflowAction.CancelWorkflow]);
@@ -127,7 +151,8 @@ describe('DhActionsRegistry', () => {
 
       const result = registry.getSupportedActions(
         [WorkflowAction.SendInformation],
-        ProcessManagerBusinessReason.CustomerMoveIn
+        ProcessManagerBusinessReason.CustomerMoveIn,
+        false
       );
 
       expect(result).toEqual([WorkflowAction.SendInformation]);
@@ -138,7 +163,8 @@ describe('DhActionsRegistry', () => {
 
       const result = registry.getSupportedActions(
         [WorkflowAction.CancelWorkflow, WorkflowAction.SendInformation],
-        ProcessManagerBusinessReason.EndOfSupply
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
       );
 
       expect(result).toEqual([WorkflowAction.CancelWorkflow]);
@@ -149,7 +175,8 @@ describe('DhActionsRegistry', () => {
 
       const result = registry.getSupportedActions(
         [WorkflowAction.CancelWorkflow],
-        ProcessManagerBusinessReason.EndOfSupply
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
       );
 
       expect(result).toEqual([]);
@@ -160,7 +187,8 @@ describe('DhActionsRegistry', () => {
 
       const result = registry.getSupportedActions(
         [WorkflowAction.CancelWorkflow],
-        ProcessManagerBusinessReason.NewMeteringPoint
+        ProcessManagerBusinessReason.NewMeteringPoint,
+        false
       );
 
       expect(result).toEqual([]);
@@ -169,7 +197,11 @@ describe('DhActionsRegistry', () => {
     it('should return empty array when no available actions', () => {
       const registry = setupRegistry();
 
-      const result = registry.getSupportedActions([], ProcessManagerBusinessReason.EndOfSupply);
+      const result = registry.getSupportedActions(
+        [],
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
+      );
 
       expect(result).toEqual([]);
     });
@@ -188,7 +220,8 @@ describe('DhActionsRegistry', () => {
 
       const result = registry.getSupportedActions(
         [WorkflowAction.RejectRequest],
-        ProcessManagerBusinessReason.EndOfSupply
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
       );
 
       expect(result).toEqual([WorkflowAction.RejectRequest]);
@@ -208,7 +241,8 @@ describe('DhActionsRegistry', () => {
 
       const result = registry.getSupportedActions(
         [WorkflowAction.RejectRequest],
-        ProcessManagerBusinessReason.EndOfSupply
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
       );
 
       expect(result).toEqual([]);
@@ -221,7 +255,8 @@ describe('DhActionsRegistry', () => {
 
       const result = registry.getSupportedActions(
         [WorkflowAction.CancelWorkflow],
-        ProcessManagerBusinessReason.EndOfSupply
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
       );
 
       expect(result).toEqual([WorkflowAction.CancelWorkflow]);
@@ -245,7 +280,8 @@ describe('DhActionsRegistry', () => {
 
       const result = registry.getSupportedActions(
         [WorkflowAction.SendInformation],
-        ProcessManagerBusinessReason.EndOfSupply
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
       );
 
       expect(result).toEqual([WorkflowAction.SendInformation]);
@@ -269,7 +305,8 @@ describe('DhActionsRegistry', () => {
 
       const result = registry.getSupportedActions(
         [WorkflowAction.SendInformation],
-        ProcessManagerBusinessReason.EndOfSupply
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
       );
 
       expect(result).toEqual([WorkflowAction.SendInformation]);
@@ -293,10 +330,159 @@ describe('DhActionsRegistry', () => {
 
       const result = registry.getSupportedActions(
         [WorkflowAction.SendInformation],
-        ProcessManagerBusinessReason.EndOfSupply
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
       );
 
       expect(result).toEqual([]);
+    });
+
+    it('should include action for actor whose role matches handler.roles', () => {
+      const registry = setupRegistry({
+        actorMarketRole: EicFunction.GridAccessProvider,
+        endOfSupplyHandlers: {
+          [WorkflowAction.ConfirmWorkflow]: {
+            featureFlag: 'end-of-supply',
+            roles: [EicFunction.GridAccessProvider],
+            callback: vi.fn(),
+          },
+        },
+      });
+
+      const result = registry.getSupportedActions(
+        [WorkflowAction.ConfirmWorkflow],
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
+      );
+
+      expect(result).toEqual([WorkflowAction.ConfirmWorkflow]);
+    });
+
+    it('should exclude action when actor role is not in handler.roles', () => {
+      const registry = setupRegistry({
+        actorMarketRole: EicFunction.EnergySupplier,
+        endOfSupplyHandlers: {
+          [WorkflowAction.ConfirmWorkflow]: {
+            featureFlag: 'end-of-supply',
+            roles: [EicFunction.GridAccessProvider],
+            callback: vi.fn(),
+          },
+        },
+      });
+
+      const result = registry.getSupportedActions(
+        [WorkflowAction.ConfirmWorkflow],
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should include action for ResponsibleEnergySupplier when actor is responsible', () => {
+      const registry = setupRegistry({
+        actorMarketRole: EicFunction.EnergySupplier,
+        endOfSupplyHandlers: {
+          [WorkflowAction.SendInformation]: {
+            featureFlag: 'end-of-supply',
+            roles: [ResponsibleEnergySupplier],
+            callback: vi.fn(),
+          },
+        },
+      });
+
+      const result = registry.getSupportedActions(
+        [WorkflowAction.SendInformation],
+        ProcessManagerBusinessReason.EndOfSupply,
+        true
+      );
+
+      expect(result).toEqual([WorkflowAction.SendInformation]);
+    });
+
+    it('should exclude action for ResponsibleEnergySupplier when actor is supplier but not responsible', () => {
+      const registry = setupRegistry({
+        actorMarketRole: EicFunction.EnergySupplier,
+        endOfSupplyHandlers: {
+          [WorkflowAction.SendInformation]: {
+            featureFlag: 'end-of-supply',
+            roles: [ResponsibleEnergySupplier],
+            callback: vi.fn(),
+          },
+        },
+      });
+
+      const result = registry.getSupportedActions(
+        [WorkflowAction.SendInformation],
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should exclude action for ResponsibleEnergySupplier when actor is not a supplier even if flag is true', () => {
+      const registry = setupRegistry({
+        actorMarketRole: EicFunction.GridAccessProvider,
+        endOfSupplyHandlers: {
+          [WorkflowAction.SendInformation]: {
+            featureFlag: 'end-of-supply',
+            roles: [ResponsibleEnergySupplier],
+            callback: vi.fn(),
+          },
+        },
+      });
+
+      const result = registry.getSupportedActions(
+        [WorkflowAction.SendInformation],
+        ProcessManagerBusinessReason.EndOfSupply,
+        true
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should include action when any role in a mixed roles array matches', () => {
+      const registry = setupRegistry({
+        actorMarketRole: EicFunction.GridAccessProvider,
+        endOfSupplyHandlers: {
+          [WorkflowAction.CancelWorkflow]: {
+            featureFlag: 'end-of-supply',
+            roles: [ResponsibleEnergySupplier, EicFunction.GridAccessProvider],
+            callback: vi.fn(),
+          },
+        },
+      });
+
+      const result = registry.getSupportedActions(
+        [WorkflowAction.CancelWorkflow],
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
+      );
+
+      expect(result).toEqual([WorkflowAction.CancelWorkflow]);
+    });
+
+    it('should include all actions for FAS regardless of roles', () => {
+      const registry = setupRegistry({
+        isFas: true,
+        actorMarketRole: EicFunction.DataHubAdministrator,
+        endOfSupplyHandlers: {
+          [WorkflowAction.SendInformation]: {
+            featureFlag: 'end-of-supply',
+            roles: [ResponsibleEnergySupplier],
+            callback: vi.fn(),
+          },
+        },
+      });
+
+      const result = registry.getSupportedActions(
+        [WorkflowAction.SendInformation],
+        ProcessManagerBusinessReason.EndOfSupply,
+        false
+      );
+
+      expect(result).toEqual([WorkflowAction.SendInformation]);
     });
   });
 
@@ -312,7 +498,8 @@ describe('DhActionsRegistry', () => {
       registry.execute(
         WorkflowAction.CancelWorkflow,
         ProcessManagerBusinessReason.EndOfSupply,
-        mockContext
+        mockContext,
+        false
       );
 
       expect(callback).toHaveBeenCalledWith(mockContext);
@@ -325,7 +512,8 @@ describe('DhActionsRegistry', () => {
         registry.execute(
           WorkflowAction.CancelWorkflow,
           ProcessManagerBusinessReason.NewMeteringPoint,
-          mockContext
+          mockContext,
+          false
         )
       ).not.toThrow();
     });
@@ -337,7 +525,8 @@ describe('DhActionsRegistry', () => {
         registry.execute(
           WorkflowAction.SendInformation,
           ProcessManagerBusinessReason.EndOfSupply,
-          mockContext
+          mockContext,
+          false
         )
       ).not.toThrow();
     });
@@ -358,7 +547,8 @@ describe('DhActionsRegistry', () => {
       registry.execute(
         WorkflowAction.RejectRequest,
         ProcessManagerBusinessReason.EndOfSupply,
-        mockContext
+        mockContext,
+        false
       );
 
       expect(callback).not.toHaveBeenCalled();
@@ -373,12 +563,82 @@ describe('DhActionsRegistry', () => {
         },
       });
 
-      registry.execute(WorkflowAction.CancelWorkflow, ProcessManagerBusinessReason.EndOfSupply, {
-        ...mockContext,
-        onSuccess,
-      });
+      registry.execute(
+        WorkflowAction.CancelWorkflow,
+        ProcessManagerBusinessReason.EndOfSupply,
+        {
+          ...mockContext,
+          onSuccess,
+        },
+        false
+      );
 
       expect(callback).toHaveBeenCalledWith(expect.objectContaining({ onSuccess }));
+    });
+
+    it('should not call handler when actor role is not allowed', () => {
+      const callback = vi.fn();
+      const registry = setupRegistry({
+        actorMarketRole: EicFunction.EnergySupplier,
+        endOfSupplyHandlers: {
+          [WorkflowAction.ConfirmWorkflow]: {
+            featureFlag: 'end-of-supply',
+            roles: [EicFunction.GridAccessProvider],
+            callback,
+          },
+        },
+      });
+
+      registry.execute(
+        WorkflowAction.ConfirmWorkflow,
+        ProcessManagerBusinessReason.EndOfSupply,
+        mockContext,
+        false
+      );
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should not call handler for FAS users even when action is supported', () => {
+      const callback = vi.fn();
+      const registry = setupRegistry({
+        isFas: true,
+        endOfSupplyHandlers: {
+          [WorkflowAction.CancelWorkflow]: { callback },
+        },
+      });
+
+      registry.execute(
+        WorkflowAction.CancelWorkflow,
+        ProcessManagerBusinessReason.EndOfSupply,
+        mockContext,
+        false
+      );
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should call handler when ResponsibleEnergySupplier role matches', () => {
+      const callback = vi.fn();
+      const registry = setupRegistry({
+        actorMarketRole: EicFunction.EnergySupplier,
+        endOfSupplyHandlers: {
+          [WorkflowAction.RejectRequest]: {
+            featureFlag: 'end-of-supply',
+            roles: [ResponsibleEnergySupplier],
+            callback,
+          },
+        },
+      });
+
+      registry.execute(
+        WorkflowAction.RejectRequest,
+        ProcessManagerBusinessReason.EndOfSupply,
+        mockContext,
+        true
+      );
+
+      expect(callback).toHaveBeenCalledWith(mockContext);
     });
   });
 });

--- a/libs/dh/metering-point/feature-process-overview/tests/actions-registry.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/actions-registry.spec.ts
@@ -421,27 +421,6 @@ describe('DhActionsRegistry', () => {
       expect(result).toEqual([]);
     });
 
-    it('should exclude action for ResponsibleEnergySupplier when actor is not a supplier even if flag is true', () => {
-      const registry = setupRegistry({
-        actorMarketRole: EicFunction.GridAccessProvider,
-        endOfSupplyHandlers: {
-          [WorkflowAction.SendInformation]: {
-            featureFlag: 'end-of-supply',
-            roles: [ResponsibleEnergySupplier],
-            callback: vi.fn(),
-          },
-        },
-      });
-
-      const result = registry.getSupportedActions(
-        [WorkflowAction.SendInformation],
-        ProcessManagerBusinessReason.EndOfSupply,
-        true
-      );
-
-      expect(result).toEqual([]);
-    });
-
     it('should include action when any role in a mixed roles array matches', () => {
       const registry = setupRegistry({
         actorMarketRole: EicFunction.GridAccessProvider,

--- a/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
@@ -241,6 +241,17 @@ describe('Process overview details', () => {
     expect(screen.queryAllByRole('button', { name: /Request disconnection/i })).toHaveLength(0);
   });
 
+  it('should show CustomerMoveIn.SendInformation for non-responsible EnergySupplier (no role gate)', async () => {
+    await setup('process-cmi-info', {
+      actorMarketRole: EicFunction.EnergySupplier,
+      isEnergySupplierResponsible: false,
+    });
+
+    await waitForAsync(() =>
+      expect(screen.getAllByRole('button', { name: /Send information/i }).length).toBeGreaterThan(0)
+    );
+  });
+
   it('should show action buttons for responsible EnergySupplier', async () => {
     await setup('process-eos-cancel', {
       actorMarketRole: EicFunction.EnergySupplier,

--- a/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
@@ -120,8 +120,11 @@ describe('Process overview details', () => {
     );
   });
 
-  it('should show reject request button for EndOfSupply process', async () => {
-    await setup('process-eos-cancel');
+  it('should show reject request button for responsible EnergySupplier on EndOfSupply process', async () => {
+    await setup('process-eos-cancel', {
+      actorMarketRole: EicFunction.EnergySupplier,
+      isEnergySupplierResponsible: true,
+    });
     await waitForAsync(() =>
       expect(screen.getAllByRole('button', { name: /Reject request/i }).length).toBeGreaterThan(0)
     );

--- a/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
@@ -244,15 +244,25 @@ describe('Process overview details', () => {
     expect(screen.queryAllByRole('button', { name: /Request disconnection/i })).toHaveLength(0);
   });
 
-  it('should show CustomerMoveIn.SendInformation for non-responsible EnergySupplier (no role gate)', async () => {
+  it('should show CustomerMoveIn.SendInformation for responsible EnergySupplier', async () => {
     await setup('process-cmi-info', {
       actorMarketRole: EicFunction.EnergySupplier,
-      isEnergySupplierResponsible: false,
+      isEnergySupplierResponsible: true,
     });
 
     await waitForAsync(() =>
       expect(screen.getAllByRole('button', { name: /Send information/i }).length).toBeGreaterThan(0)
     );
+  });
+
+  it('should hide CustomerMoveIn.SendInformation for non-responsible EnergySupplier', async () => {
+    await setup('process-cmi-info', {
+      actorMarketRole: EicFunction.EnergySupplier,
+      isEnergySupplierResponsible: false,
+    });
+
+    expect(document.querySelector('watt-description-list')).not.toBeNull();
+    expect(screen.queryAllByRole('button', { name: /Send information/i })).toHaveLength(0);
   });
 
   it('should show action buttons for responsible EnergySupplier', async () => {

--- a/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/details.spec.ts
@@ -236,6 +236,9 @@ describe('Process overview details', () => {
       actorMarketRole: EicFunction.EnergySupplier,
       isEnergySupplierResponsible: false,
     });
+
+    expect(document.querySelector('watt-description-list')).not.toBeNull();
+
     expect(screen.queryAllByRole('button', { name: /Cancel/i })).toHaveLength(0);
     expect(screen.queryAllByRole('button', { name: /Reject request/i })).toHaveLength(0);
     expect(screen.queryAllByRole('button', { name: /Request disconnection/i })).toHaveLength(0);

--- a/libs/dh/metering-point/feature-process-overview/tests/overview.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/overview.spec.ts
@@ -149,10 +149,12 @@ describe('Process overview', () => {
     );
   });
 
-  it('should not show action buttons when user has no relevant market role', async () => {
+  it('should hide EndOfSupply actions for unrelated market roles but still show CustomerMoveIn (no role gate)', async () => {
     await setup({ actorMarketRole: EicFunction.DataHubAdministrator });
     expect(screen.queryAllByRole('button', { name: /Cancel/i })).toHaveLength(0);
-    expect(screen.queryAllByRole('button', { name: /Send information/i })).toHaveLength(0);
+    await waitForAsync(() =>
+      expect(screen.getAllByRole('button', { name: /Send information/i }).length).toBeGreaterThan(0)
+    );
   });
 
   it('should show warning text instead of buttons for FAS users', async () => {
@@ -173,14 +175,20 @@ describe('Process overview', () => {
     );
   });
 
-  it('should hide all actions for non-responsible EnergySupplier', async () => {
-    await setup({
+  it('should hide EndOfSupply actions for non-responsible EnergySupplier and show CustomerMoveIn', async () => {
+    const fixture = await setup({
       actorMarketRole: EicFunction.EnergySupplier,
       isEnergySupplierResponsible: false,
     });
+    const router = fixture.debugElement.injector.get(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
     expect(screen.queryAllByRole('button', { name: /Cancel/i })).toHaveLength(0);
-    expect(screen.queryAllByRole('button', { name: /Send information/i })).toHaveLength(0);
     expect(screen.queryAllByText(/can cancel workflow/i)).toHaveLength(0);
+
+    await waitForAsync(() =>
+      expect(screen.getAllByRole('button', { name: /Send information/i }).length).toBeGreaterThan(0)
+    );
   });
 
   it('should still show action buttons for GridAccessProvider regardless of responsibility', async () => {

--- a/libs/dh/metering-point/feature-process-overview/tests/overview.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/overview.spec.ts
@@ -176,12 +176,10 @@ describe('Process overview', () => {
   });
 
   it('should hide EndOfSupply actions for non-responsible EnergySupplier and show CustomerMoveIn', async () => {
-    const fixture = await setup({
+    await setup({
       actorMarketRole: EicFunction.EnergySupplier,
       isEnergySupplierResponsible: false,
     });
-    const router = fixture.debugElement.injector.get(Router);
-    vi.spyOn(router, 'navigate').mockResolvedValue(true);
 
     expect(screen.queryAllByRole('button', { name: /Cancel/i })).toHaveLength(0);
     expect(screen.queryAllByText(/can cancel workflow/i)).toHaveLength(0);

--- a/libs/dh/metering-point/feature-process-overview/tests/overview.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/overview.spec.ts
@@ -149,12 +149,10 @@ describe('Process overview', () => {
     );
   });
 
-  it('should hide EndOfSupply actions for unrelated market roles but still show CustomerMoveIn (no role gate)', async () => {
+  it('should hide all action buttons for unrelated market roles', async () => {
     await setup({ actorMarketRole: EicFunction.DataHubAdministrator });
     expect(screen.queryAllByRole('button', { name: /Cancel/i })).toHaveLength(0);
-    await waitForAsync(() =>
-      expect(screen.getAllByRole('button', { name: /Send information/i }).length).toBeGreaterThan(0)
-    );
+    expect(screen.queryAllByRole('button', { name: /Send information/i })).toHaveLength(0);
   });
 
   it('should show warning text instead of buttons for FAS users', async () => {
@@ -175,18 +173,15 @@ describe('Process overview', () => {
     );
   });
 
-  it('should hide EndOfSupply actions for non-responsible EnergySupplier and show CustomerMoveIn', async () => {
+  it('should hide all actions for non-responsible EnergySupplier', async () => {
     await setup({
       actorMarketRole: EicFunction.EnergySupplier,
       isEnergySupplierResponsible: false,
     });
 
     expect(screen.queryAllByRole('button', { name: /Cancel/i })).toHaveLength(0);
+    expect(screen.queryAllByRole('button', { name: /Send information/i })).toHaveLength(0);
     expect(screen.queryAllByText(/can cancel workflow/i)).toHaveLength(0);
-
-    await waitForAsync(() =>
-      expect(screen.getAllByRole('button', { name: /Send information/i }).length).toBeGreaterThan(0)
-    );
   });
 
   it('should still show action buttons for GridAccessProvider regardless of responsibility', async () => {

--- a/libs/dh/metering-point/feature-process-overview/tests/supported-actions.pipe.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/supported-actions.pipe.spec.ts
@@ -52,8 +52,7 @@ async function setup(overrides: Partial<TestHost> = {}) {
         useValue: {
           getSupportedActions: (
             actions: WorkflowAction[],
-            reason: ProcessManagerBusinessReason,
-            _isEnergySupplierResponsible?: boolean
+            reason: ProcessManagerBusinessReason
           ) => {
             const registered: Partial<Record<ProcessManagerBusinessReason, WorkflowAction[]>> = {
               [ProcessManagerBusinessReason.EndOfSupply]: [WorkflowAction.CancelWorkflow],

--- a/libs/dh/metering-point/feature-process-overview/tests/supported-actions.pipe.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/supported-actions.pipe.spec.ts
@@ -52,7 +52,8 @@ async function setup(overrides: Partial<TestHost> = {}) {
         useValue: {
           getSupportedActions: (
             actions: WorkflowAction[],
-            reason: ProcessManagerBusinessReason
+            reason: ProcessManagerBusinessReason,
+            _isEnergySupplierResponsible?: boolean
           ) => {
             const registered: Partial<Record<ProcessManagerBusinessReason, WorkflowAction[]>> = {
               [ProcessManagerBusinessReason.EndOfSupply]: [WorkflowAction.CancelWorkflow],

--- a/libs/dh/metering-point/feature-process-overview/tests/supported-actions.pipe.spec.ts
+++ b/libs/dh/metering-point/feature-process-overview/tests/supported-actions.pipe.spec.ts
@@ -32,7 +32,10 @@ import { SupportedActionsPipe } from '../src/actions/supported-actions.pipe';
 @Component({
   imports: [SupportedActionsPipe],
   template: `
-    @for (action of actions | supportedActions: businessReason; track action) {
+    @for (
+      action of actions | supportedActions: businessReason : isEnergySupplierResponsible;
+      track action
+    ) {
       <span>{{ action }}</span>
     } @empty {
       <span>No actions</span>
@@ -42,31 +45,33 @@ import { SupportedActionsPipe } from '../src/actions/supported-actions.pipe';
 class TestHost {
   actions: WorkflowAction[] | null = null;
   businessReason?: ProcessManagerBusinessReason;
+  isEnergySupplierResponsible?: boolean;
 }
 
 async function setup(overrides: Partial<TestHost> = {}) {
+  const getSupportedActions = vi.fn(
+    (actions: WorkflowAction[], reason: ProcessManagerBusinessReason) => {
+      const registered: Partial<Record<ProcessManagerBusinessReason, WorkflowAction[]>> = {
+        [ProcessManagerBusinessReason.EndOfSupply]: [WorkflowAction.CancelWorkflow],
+        [ProcessManagerBusinessReason.CustomerMoveIn]: [WorkflowAction.SendInformation],
+      };
+      const supported = registered[reason] ?? [];
+      return actions.filter((a) => supported.includes(a));
+    }
+  );
+
   await render(TestHost, {
     providers: [
       {
         provide: DhActionsRegistry,
-        useValue: {
-          getSupportedActions: (
-            actions: WorkflowAction[],
-            reason: ProcessManagerBusinessReason
-          ) => {
-            const registered: Partial<Record<ProcessManagerBusinessReason, WorkflowAction[]>> = {
-              [ProcessManagerBusinessReason.EndOfSupply]: [WorkflowAction.CancelWorkflow],
-              [ProcessManagerBusinessReason.CustomerMoveIn]: [WorkflowAction.SendInformation],
-            };
-            const supported = registered[reason] ?? [];
-            return actions.filter((a) => supported.includes(a));
-          },
-        },
+        useValue: { getSupportedActions },
       },
     ],
     imports: [getTranslocoTestingModule()],
     componentProperties: overrides,
   });
+
+  return { getSupportedActions };
 }
 
 describe('SupportedActionsPipe', () => {
@@ -123,5 +128,32 @@ describe('SupportedActionsPipe', () => {
     });
 
     expect(screen.getByText('No actions')).toBeInTheDocument();
+  });
+
+  it('should forward isEnergySupplierResponsible to the registry', async () => {
+    const { getSupportedActions } = await setup({
+      actions: [WorkflowAction.CancelWorkflow],
+      businessReason: ProcessManagerBusinessReason.EndOfSupply,
+      isEnergySupplierResponsible: true,
+    });
+
+    expect(getSupportedActions).toHaveBeenCalledWith(
+      [WorkflowAction.CancelWorkflow],
+      ProcessManagerBusinessReason.EndOfSupply,
+      true
+    );
+  });
+
+  it('should default isEnergySupplierResponsible to false when not bound', async () => {
+    const { getSupportedActions } = await setup({
+      actions: [WorkflowAction.CancelWorkflow],
+      businessReason: ProcessManagerBusinessReason.EndOfSupply,
+    });
+
+    expect(getSupportedActions).toHaveBeenCalledWith(
+      [WorkflowAction.CancelWorkflow],
+      ProcessManagerBusinessReason.EndOfSupply,
+      false
+    );
   });
 });


### PR DESCRIPTION
## Opsummering

- Erstatter den hårde komponent-gate fra #5746 med deklarativ `roles[]`-konfiguration på hver `ActionHandler`. Hver action specificerer selv hvilke roller der må udføre den, på samme måde som `permissions[]` allerede fungerer.
- Tilføjer en syntetisk `ResponsibleEnergySupplier`-rolle (frontend-only union på `EicFunction`) der kombinerer `EnergySupplier`-aktørrollen med per-målepunkt ansvarligheds-flaget. Det fjerner behovet for et separat `requiresResponsibility`-felt og gør alle kombinationer i `roles[]` meningsfulde.
- `DhActionsRegistry` er eneste autorisations-kilde. Komponenterne (`overview.ts`, `details.ts`) er reduceret til ren rendering: de itererer over den registry-filtrerede liste og vælger info-spor (FAS) eller knap.
- `EndOfSupply`-handlers konfigureret som dokumenteret: `SendInformation` og `RejectRequest` kun ansvarlig elleverandør; `ConfirmWorkflow` kun netadgangsleverandør; `CancelWorkflow` begge.
- `CustomerMoveIn.SendInformation` bevarer den oprindelige adfærd fra #5746 (ansvarlig elleverandør eller netadgangsleverandør) som eksplicit `roles[]`-konfiguration på handler'en. Tidligere lå reglen i komponentens fælles gate; nu er den per-action.
- Bagudkompatibel på datamodel-niveau: handlers uden `roles` virker uændret.

Ref: #1471